### PR TITLE
update pairing failed msg in pubkeycompendium

### DIFF
--- a/src/BLSPublicKeyCompendium.sol
+++ b/src/BLSPublicKeyCompendium.sol
@@ -63,7 +63,7 @@ contract BLSPublicKeyCompendium is IBLSPublicKeyCompendium {
             BN254.negGeneratorG2(),
             messageHash.plus(BN254.generatorG1().scalar_mul(gamma)),
             pubkeyG2
-        ), "BLSPublicKeyCompendium.registerBLSPublicKey: either the G1 signature is wrong (make sure the right msg is being signed), or G1 and G2 private key do not match");
+        ), "BLSPublicKeyCompendium.registerBLSPublicKey: either the G1 signature is wrong, or G1 and G2 private key do not match");
 
         operatorToPubkeyHash[msg.sender] = pubkeyHash;
         pubkeyHashToOperator[pubkeyHash] = msg.sender;

--- a/test/unit/BLSPublicKeyCompendiumUnit.t.sol
+++ b/test/unit/BLSPublicKeyCompendiumUnit.t.sol
@@ -43,7 +43,7 @@ contract BLSPublicKeyCompendiumUnitTests is Test {
         BN254.G1Point memory badPubKeyG1 = BN254.generatorG1().scalar_mul(420); // mismatch public keys
 
         vm.prank(alice);
-        vm.expectRevert(bytes("BLSPublicKeyCompendium.registerBLSPublicKey: G1 and G2 private key do not match"));
+        vm.expectRevert(bytes("BLSPublicKeyCompendium.registerBLSPublicKey: either the G1 signature is wrong, or G1 and G2 private key do not match"));
         compendium.registerBLSPublicKey(signedMessageHash, badPubKeyG1, pubKeyG2);
     }
 
@@ -51,7 +51,7 @@ contract BLSPublicKeyCompendiumUnitTests is Test {
         signedMessageHash = _signMessage(bob); // sign with wrong private key
 
         vm.prank(alice); 
-        vm.expectRevert(bytes("BLSPublicKeyCompendium.registerBLSPublicKey: G1 and G2 private key do not match"));
+        vm.expectRevert(bytes("BLSPublicKeyCompendium.registerBLSPublicKey: either the G1 signature is wrong, or G1 and G2 private key do not match"));
         compendium.registerBLSPublicKey(signedMessageHash, pubKeyG1, pubKeyG2);
     }
 


### PR DESCRIPTION
Registration was failing because we hadn't update the eigensdk to also add the compendium's address in the msg being signed, but we were still getting a "G1 and G2 private key do not match", which was confusing.

This PR fixes the error msg.