### PR TITLE
BUGFIX: make it possible for operators to reregister

### DIFF
--- a/src/BLSRegistryCoordinatorWithIndices.sol
+++ b/src/BLSRegistryCoordinatorWithIndices.sol
@@ -399,10 +399,12 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
 
         /**
          * If the operator has an existing bitmap history, combine the last entry with `quorumBitmap`
-         * and set its `nextUpdateBlockNumber` to the current block
+         * and set its `nextUpdateBlockNumber` to the current block.
+         * Skip this step if the `nextUpdateBlockNumber` is already set for the last entry in the operator's bitmap history,
+         * as this indicates that the operator previously completely deregistered, and thus is no longer registered for any quorums.
          */
         uint256 historyLength = _operatorIdToQuorumBitmapHistory[operatorId].length;
-        if(historyLength > 0) {
+        if (historyLength != 0 && _operatorIdToQuorumBitmapHistory[operatorId][historyLength - 1].nextUpdateBlockNumber == 0) {
             uint256 prevQuorumBitmap = _operatorIdToQuorumBitmapHistory[operatorId][historyLength - 1].quorumBitmap;
             require(prevQuorumBitmap & quorumBitmap == 0, "BLSRegistryCoordinatorWithIndices._registerOperatorWithCoordinator: operator already registered for some quorums being registered for");
             // new stored quorumBitmap is the previous quorumBitmap or'd with the new quorumBitmap to register for

--- a/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
+++ b/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
@@ -579,6 +579,23 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         );
     }
 
+    // @notice verify that it is possible for an operator to register, deregister, and then register again!
+    function testReregisterOperatorWithCoordinator_Valid() public {
+        testDeregisterOperatorWithCoordinatorForSingleQuorumAndSingleOperator_Valid();
+
+        uint32 registrationBlockNumber = 201;
+
+        bytes memory quorumNumbers = new bytes(1);
+        quorumNumbers[0] = bytes1(defaultQuorumNumber);
+
+        cheats.startPrank(defaultOperator);
+        
+        cheats.roll(registrationBlockNumber);
+        
+        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, defaultPubKey, defaultSocket);
+
+        uint256 quorumBitmap = BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers);
+    }
 
     function testRegisterOperatorWithCoordinatorWithKicks_Valid(uint256 pseudoRandomNumber) public {
         uint32 numOperators = defaultMaxOperatorCount;

--- a/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
+++ b/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
@@ -583,18 +583,47 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
     function testReregisterOperatorWithCoordinator_Valid() public {
         testDeregisterOperatorWithCoordinatorForSingleQuorumAndSingleOperator_Valid();
 
-        uint32 registrationBlockNumber = 201;
+        uint32 reregistrationBlockNumber = 201;
 
         bytes memory quorumNumbers = new bytes(1);
         quorumNumbers[0] = bytes1(defaultQuorumNumber);
 
         cheats.startPrank(defaultOperator);
         
-        cheats.roll(registrationBlockNumber);
+        cheats.roll(reregistrationBlockNumber);
         
+        // store data before registering, to check against later
+        IRegistryCoordinator.QuorumBitmapUpdate memory previousQuorumBitmapUpdate =
+            registryCoordinator.getQuorumBitmapUpdateByOperatorIdByIndex(defaultOperatorId, 0);
+
+        // re-register the operator
         registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, defaultPubKey, defaultSocket);
 
+        // check success of registration
         uint256 quorumBitmap = BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers);
+        assertEq(registryCoordinator.getOperatorId(defaultOperator), defaultOperatorId);
+        assertEq(
+            keccak256(abi.encode(registryCoordinator.getOperator(defaultOperator))), 
+            keccak256(abi.encode(IRegistryCoordinator.Operator({
+                operatorId: defaultOperatorId,
+                status: IRegistryCoordinator.OperatorStatus.REGISTERED
+            })))
+        );
+        assertEq(registryCoordinator.getCurrentQuorumBitmapByOperatorId(defaultOperatorId), quorumBitmap);
+        // check that previous entry in bitmap history was not changed
+        assertEq(
+            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByOperatorIdByIndex(defaultOperatorId, 0))), 
+            keccak256(abi.encode(previousQuorumBitmapUpdate))
+        );
+        // check that new entry in bitmap history is as expected
+        assertEq(
+            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByOperatorIdByIndex(defaultOperatorId, 1))), 
+            keccak256(abi.encode(IRegistryCoordinator.QuorumBitmapUpdate({
+                quorumBitmap: uint192(quorumBitmap),
+                updateBlockNumber: uint32(reregistrationBlockNumber),
+                nextUpdateBlockNumber: 0
+            })))
+        );
     }
 
     function testRegisterOperatorWithCoordinatorWithKicks_Valid(uint256 pseudoRandomNumber) public {


### PR DESCRIPTION
also add a minimal regression test, which simply checks that re-registering is possible!