### PR TITLE
Refactor StakeRegistry to use a signed delta for stake updates

### DIFF
--- a/src/BLSRegistryCoordinatorWithIndices.sol
+++ b/src/BLSRegistryCoordinatorWithIndices.sol
@@ -449,7 +449,7 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
             socket: socket
         });
         
-        for (uint i = 0; i < numOperatorsPerQuorum.length; i++) {
+        for (uint256 i = 0; i < numOperatorsPerQuorum.length; i++) {
             require(
                 numOperatorsPerQuorum[i] <= _quorumOperatorSetParams[uint8(quorumNumbers[i])].maxOperatorCount,
                 "BLSRegistryCoordinatorWithIndices._registerOperatorWithCoordinatorAndNoOverfilledQuorums: quorum is overfilled"
@@ -586,8 +586,8 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
     ) external view returns (uint32[] memory) {
         uint32[] memory indices = new uint32[](operatorIds.length);
         for (uint256 i = 0; i < operatorIds.length; i++) {
-            uint length = _operatorIdToQuorumBitmapHistory[operatorIds[i]].length;
-            for (uint j = 0; j < length; j++) {
+            uint256 length = _operatorIdToQuorumBitmapHistory[operatorIds[i]].length;
+            for (uint256 j = 0; j < length; j++) {
                 if (_operatorIdToQuorumBitmapHistory[operatorIds[i]][length - j - 1].updateBlockNumber <= blockNumber) {
                     uint32 nextUpdateBlockNumber = 
                         _operatorIdToQuorumBitmapHistory[operatorIds[i]][length - j - 1].nextUpdateBlockNumber;

--- a/src/BLSRegistryCoordinatorWithIndices.sol
+++ b/src/BLSRegistryCoordinatorWithIndices.sol
@@ -586,15 +586,16 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
     ) external view returns (uint32[] memory) {
         uint32[] memory indices = new uint32[](operatorIds.length);
         for (uint256 i = 0; i < operatorIds.length; i++) {
-            uint32 length = uint32(_operatorIdToQuorumBitmapHistory[operatorIds[i]].length);
-            for (uint32 j = 0; j < length; j++) {
+            uint length = _operatorIdToQuorumBitmapHistory[operatorIds[i]].length;
+            for (uint j = 0; j < length; j++) {
                 if (_operatorIdToQuorumBitmapHistory[operatorIds[i]][length - j - 1].updateBlockNumber <= blockNumber) {
+                    uint32 nextUpdateBlockNumber = 
+                        _operatorIdToQuorumBitmapHistory[operatorIds[i]][length - j - 1].nextUpdateBlockNumber;
                     require(
-                        _operatorIdToQuorumBitmapHistory[operatorIds[i]][length - j - 1].nextUpdateBlockNumber == 0 ||
-                        _operatorIdToQuorumBitmapHistory[operatorIds[i]][length - j - 1].nextUpdateBlockNumber > blockNumber,
+                        nextUpdateBlockNumber == 0 || nextUpdateBlockNumber > blockNumber,
                         "BLSRegistryCoordinatorWithIndices.getQuorumBitmapIndicesByOperatorIdsAtBlockNumber: operatorId has no quorumBitmaps at blockNumber"
                     );
-                    indices[i] = length - j - 1;
+                    indices[i] = uint32(length - j - 1);
                     break;
                 }
             }

--- a/src/StakeRegistry.sol
+++ b/src/StakeRegistry.sol
@@ -81,7 +81,7 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
         for (uint8 quorumNumber = 0; quorumNumber < quorumCount; ) {
             int256 totalStakeDelta;
 
-            for (uint i = 0; i < operators.length; ) {
+            for (uint256 i = 0; i < operators.length; ) {
                 bytes32 operatorId = registryCoordinator.getOperatorId(operators[i]);
                 uint192 quorumBitmap = registryCoordinator.getCurrentQuorumBitmapByOperatorId(operatorId);
 
@@ -144,7 +144,7 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
             "StakeRegistry._registerOperator: greatest quorumNumber must be less than quorumCount"
         );
 
-        for (uint i = 0; i < quorumNumbers.length; ) {            
+        for (uint256 i = 0; i < quorumNumbers.length; ) {            
             /**
              * Update the operator's stake for the quorum and retrieve their current stake
              * as well as the change in stake.
@@ -192,7 +192,7 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
          * For each quorum, remove the operator's stake for the quorum and update
          * the quorum's total stake to account for the removal
          */
-        for (uint i = 0; i < quorumNumbers.length; ) {
+        for (uint256 i = 0; i < quorumNumbers.length; ) {
             // Update the operator's stake for the quorum and retrieve the shares removed
             uint8 quorumNumber = uint8(quorumNumbers[i]);
             int256 stakeDelta = _recordOperatorStakeUpdate({
@@ -228,8 +228,8 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
         uint8 quorumNumber,
         uint32 blockNumber
     ) internal view returns (uint32) {
-        uint length = operatorIdToStakeHistory[operatorId][quorumNumber].length;
-        for (uint i = 0; i < length; i++) {
+        uint256 length = operatorIdToStakeHistory[operatorId][quorumNumber].length;
+        for (uint256 i = 0; i < length; i++) {
             if (operatorIdToStakeHistory[operatorId][quorumNumber][length - i - 1].updateBlockNumber <= blockNumber) {
                 uint32 nextUpdateBlockNumber = 
                     operatorIdToStakeHistory[operatorId][quorumNumber][length - i - 1].nextUpdateBlockNumber;
@@ -342,11 +342,7 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
 
     /// @notice Returns the change between a previous and current value as a signed int
     function _calculateDelta(uint96 prev, uint96 cur) internal pure returns (int256) {
-        if (cur >= prev) {
-            return int256(uint256(cur - prev));
-        } else {
-            return -int256(uint256(prev - cur));
-        }
+        return int256(uint256(cur)) - int256(uint256(prev));
     }
 
     /// @notice Adds or subtracts delta from value, according to its sign
@@ -442,8 +438,8 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
                 _totalStakeHistory[quorumNumber][0].updateBlockNumber <= blockNumber,
                 "StakeRegistry.getTotalStakeIndicesByQuorumNumbersAtBlockNumber: quorum has no stake history at blockNumber"
             );
-            uint length = _totalStakeHistory[quorumNumber].length;
-            for (uint j = 0; j < length; j++) {
+            uint256 length = _totalStakeHistory[quorumNumber].length;
+            for (uint256 j = 0; j < length; j++) {
                 if (_totalStakeHistory[quorumNumber][length - j - 1].updateBlockNumber <= blockNumber) {
                     indices[i] = uint32(length - j - 1);
                     break;

--- a/src/StakeRegistry.sol
+++ b/src/StakeRegistry.sol
@@ -158,9 +158,9 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
         // add the `updateBlockNumber` info
         _newTotalStakeUpdate.updateBlockNumber = uint32(block.number);
         // for each quorum, evaluate stake and add to total stake
-        for (uint8 quorumNumbersIndex = 0; quorumNumbersIndex < quorumNumbers.length; ) {
+        for (uint i = 0; i < quorumNumbers.length; ) {
             // get the next quorumNumber
-            uint8 quorumNumber = uint8(quorumNumbers[quorumNumbersIndex]);
+            uint8 quorumNumber = uint8(quorumNumbers[i]);
             // evaluate the stake for the operator
             // since we don't use the first output, this will use 1 extra sload when deregistered operator's register again
             (, uint96 stake) = _updateOperatorStake({
@@ -186,7 +186,7 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
             // update storage of total stake
             _recordTotalStakeUpdate(quorumNumber, _newTotalStakeUpdate);
             unchecked {
-                ++quorumNumbersIndex;
+                ++i;
             }
         }
     }
@@ -214,8 +214,8 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
         // add the `updateBlockNumber` info
         _newTotalStakeUpdate.updateBlockNumber = uint32(block.number);
         // loop through the operator's quorums and remove the operator's stake for each quorum
-        for (uint8 quorumNumbersIndex = 0; quorumNumbersIndex < quorumNumbers.length; ) {
-            uint8 quorumNumber = uint8(quorumNumbers[quorumNumbersIndex]);
+        for (uint i = 0; i < quorumNumbers.length; ) {
+            uint8 quorumNumber = uint8(quorumNumbers[i]);
             // update the operator's stake
             uint96 stakeBeforeUpdate = _recordOperatorStakeUpdate({
                 operatorId: operatorId, 
@@ -237,7 +237,7 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
                 0
             );
             unchecked {
-                ++quorumNumbersIndex;
+                ++i;
             }
         }
     }
@@ -260,16 +260,16 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
         uint8 quorumNumber,
         uint32 blockNumber
     ) internal view returns (uint32) {
-        uint32 length = uint32(operatorIdToStakeHistory[operatorId][quorumNumber].length);
-        for (uint32 i = 0; i < length; i++) {
+        uint length = operatorIdToStakeHistory[operatorId][quorumNumber].length;
+        for (uint i = 0; i < length; i++) {
             if (operatorIdToStakeHistory[operatorId][quorumNumber][length - i - 1].updateBlockNumber <= blockNumber) {
+                uint32 nextUpdateBlockNumber = 
+                    operatorIdToStakeHistory[operatorId][quorumNumber][length - i - 1].nextUpdateBlockNumber;
                 require(
-                    operatorIdToStakeHistory[operatorId][quorumNumber][length - i - 1].nextUpdateBlockNumber == 0 ||
-                        operatorIdToStakeHistory[operatorId][quorumNumber][length - i - 1].nextUpdateBlockNumber >
-                        blockNumber,
+                    nextUpdateBlockNumber == 0 || nextUpdateBlockNumber > blockNumber,
                     "StakeRegistry._getStakeUpdateIndexForOperatorIdForQuorumAtBlockNumber: operatorId has no stake update at blockNumber"
                 );
-                return length - i - 1;
+                return uint32(length - i - 1);
             }
         }
         revert(
@@ -434,10 +434,10 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
                 _totalStakeHistory[quorumNumber][0].updateBlockNumber <= blockNumber,
                 "StakeRegistry.getTotalStakeIndicesByQuorumNumbersAtBlockNumber: quorum has no stake history at blockNumber"
             );
-            uint32 length = uint32(_totalStakeHistory[quorumNumber].length);
-            for (uint32 j = 0; j < length; j++) {
+            uint length = _totalStakeHistory[quorumNumber].length;
+            for (uint j = 0; j < length; j++) {
                 if (_totalStakeHistory[quorumNumber][length - j - 1].updateBlockNumber <= blockNumber) {
-                    indices[i] = length - j - 1;
+                    indices[i] = uint32(length - j - 1);
                     break;
                 }
             }

--- a/src/StakeRegistry.sol
+++ b/src/StakeRegistry.sol
@@ -79,53 +79,42 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
         // if they are, get their new weight and update their individual stake history and the
         // quorum's total stake history accordingly
         for (uint8 quorumNumber = 0; quorumNumber < quorumCount; ) {
-            OperatorStakeUpdate memory totalStakeUpdate;
-            // for each operator
+            int256 totalStakeDelta;
+
             for (uint i = 0; i < operators.length; ) {
                 bytes32 operatorId = registryCoordinator.getOperatorId(operators[i]);
                 uint192 quorumBitmap = registryCoordinator.getCurrentQuorumBitmapByOperatorId(operatorId);
-                // if the operator is not a part of any quorums, skip
-                if (quorumBitmap == 0) {
-                    continue;
-                }
-                // if the operator is a part of the quorum
+
+                /**
+                 * If the operator is a part of the quorum, update their current stake
+                 * and apply the delta to the total
+                 */ 
                 if (BitmapUtils.numberIsInBitmap(quorumBitmap, quorumNumber)) {
-                    // if the total stake has not been loaded yet, load it
-                    if (totalStakeUpdate.updateBlockNumber == 0) {
-                        totalStakeUpdate = _totalStakeHistory[quorumNumber][
-                            _totalStakeHistory[quorumNumber].length - 1
-                        ];
-                    }
-                    // update the operator's stake based on current state
-                    (uint96 stakeBeforeUpdate, uint96 stakeAfterUpdate) = _updateOperatorStake({
+                    (int256 stakeDelta, ) = _updateOperatorStake({
                         operator: operators[i],
                         operatorId: operatorId,
                         quorumNumber: quorumNumber
                     });
-                    // calculate the new total stake for the quorum
-                    totalStakeUpdate.stake = totalStakeUpdate.stake - stakeBeforeUpdate + stakeAfterUpdate;
+
+                    totalStakeDelta += stakeDelta;
                 }
                 unchecked {
                     ++i;
                 }
             }
-            // if the total stake for this quorum was updated, record it in storage
-            if (totalStakeUpdate.updateBlockNumber != 0) {
-                // update the total stake history for the quorum
-                _recordTotalStakeUpdate(quorumNumber, totalStakeUpdate);
+
+            // If we have a change in total stake for this quorum, update state
+            // TODO - do we want to record the update, even if the delta is zero?
+            //        maybe this makes sense in the case that the quorum doesn't have
+            //        an update for this block?
+            if (totalStakeDelta != 0) {
+                _recordTotalStakeUpdate(quorumNumber, totalStakeDelta);
             }
+
             unchecked {
                 ++quorumNumber;
             }
         }
-
-        // TODO after slashing enabled: record stake updates in the EigenLayer Slasher
-        // for (uint i = 0; i < operators.length;) {
-        //     serviceManager.recordStakeUpdate(operators[i], uint32(block.number), serviceManager.latestServeUntilBlock(), prevElements[i]);
-        //     unchecked {
-        //         ++i;
-        //     }
-        // }
     }
 
     /*******************************************************************************
@@ -154,37 +143,29 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
             uint8(quorumNumbers[quorumNumbers.length - 1]) < quorumCount,
             "StakeRegistry._registerOperator: greatest quorumNumber must be less than quorumCount"
         );
-        OperatorStakeUpdate memory _newTotalStakeUpdate;
-        // add the `updateBlockNumber` info
-        _newTotalStakeUpdate.updateBlockNumber = uint32(block.number);
-        // for each quorum, evaluate stake and add to total stake
-        for (uint i = 0; i < quorumNumbers.length; ) {
-            // get the next quorumNumber
+
+        for (uint i = 0; i < quorumNumbers.length; ) {            
+            /**
+             * Update the operator's stake for the quorum and retrieve their current stake
+             * as well as the change in stake.
+             * If this method returns `stake == 0`, the operator has not met the minimum requirement
+             * 
+             * TODO - we only use the `stake` return here. It's probably better to use a bool instead
+             *        of relying on the method returning "0" in only this one case.
+             */
             uint8 quorumNumber = uint8(quorumNumbers[i]);
-            // evaluate the stake for the operator
-            // since we don't use the first output, this will use 1 extra sload when deregistered operator's register again
-            (, uint96 stake) = _updateOperatorStake({
+            (int256 stakeDelta, uint96 stake) = _updateOperatorStake({
                 operator: operator, 
                 operatorId: operatorId, 
                 quorumNumber: quorumNumber
             });
-            // check if minimum requirement has been met, will be 0 if not
             require(
                 stake != 0,
                 "StakeRegistry._registerOperator: Operator does not meet minimum stake requirement for quorum"
             );
-            // add operator stakes to total stake before update (in memory)
-            uint256 _totalStakeHistoryLength = _totalStakeHistory[quorumNumber].length;
-            // add calculate the total stake for the quorum
-            uint96 totalStakeAfterUpdate = stake;
-            if (_totalStakeHistoryLength != 0) {
-                // only add the stake if there is a previous total stake
-                // overwrite `stake` variable
-                totalStakeAfterUpdate += _totalStakeHistory[quorumNumber][_totalStakeHistoryLength - 1].stake;
-            }
-            _newTotalStakeUpdate.stake = totalStakeAfterUpdate;
-            // update storage of total stake
-            _recordTotalStakeUpdate(quorumNumber, _newTotalStakeUpdate);
+
+            // Update this quorum's total stake
+            _recordTotalStakeUpdate(quorumNumber, stakeDelta);
             unchecked {
                 ++i;
             }
@@ -207,35 +188,22 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
         bytes32 operatorId,
         bytes calldata quorumNumbers
     ) public virtual onlyRegistryCoordinator {
-        OperatorStakeUpdate memory _operatorStakeUpdate;
-        // add the `updateBlockNumber` info
-        _operatorStakeUpdate.updateBlockNumber = uint32(block.number);
-        OperatorStakeUpdate memory _newTotalStakeUpdate;
-        // add the `updateBlockNumber` info
-        _newTotalStakeUpdate.updateBlockNumber = uint32(block.number);
-        // loop through the operator's quorums and remove the operator's stake for each quorum
+        /**
+         * For each quorum, remove the operator's stake for the quorum and update
+         * the quorum's total stake to account for the removal
+         */
         for (uint i = 0; i < quorumNumbers.length; ) {
+            // Update the operator's stake for the quorum and retrieve the shares removed
             uint8 quorumNumber = uint8(quorumNumbers[i]);
-            // update the operator's stake
-            uint96 stakeBeforeUpdate = _recordOperatorStakeUpdate({
+            int256 stakeDelta = _recordOperatorStakeUpdate({
                 operatorId: operatorId, 
                 quorumNumber: quorumNumber, 
-                operatorStakeUpdate: _operatorStakeUpdate
+                newStake: 0
             });
-            // subtract the amounts staked by the operator that is getting deregistered from the total stake before deregistration
-            // copy latest totalStakes to memory
-            _newTotalStakeUpdate.stake =
-                _totalStakeHistory[quorumNumber][_totalStakeHistory[quorumNumber].length - 1].stake -
-                stakeBeforeUpdate;
-            // update storage of total stake
-            _recordTotalStakeUpdate(quorumNumber, _newTotalStakeUpdate);
 
-            emit StakeUpdate(
-                operatorId,
-                quorumNumber,
-                // new stakes are zero
-                0
-            );
+            // Apply the operator's stake delta to the total stake for this quorum
+            _recordTotalStakeUpdate(quorumNumber, stakeDelta);
+
             unchecked {
                 ++i;
             }
@@ -283,71 +251,111 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
     }
 
     /**
-     * @notice Finds the updated stake for `operator` for `quorumNumber`, stores it, records the update,
-     * and returns both the previous stake then updated stake.
+     * @notice Finds the updated stake for `operator` for `quorumNumber`, stores it and records the update
      * @dev **DOES NOT UPDATE `totalStake` IN ANY WAY** -- `totalStake` updates must be done elsewhere.
+     * @return `int256` The change in the operator's stake as a signed int256
+     * @return `uint96` The operator's new stake after the update
      */
     function _updateOperatorStake(
         address operator,
         bytes32 operatorId,
         uint8 quorumNumber
-    ) internal returns (uint96, uint96) {
-        // determine new stakes
-        OperatorStakeUpdate memory operatorStakeUpdate;
-        operatorStakeUpdate.updateBlockNumber = uint32(block.number);
-        operatorStakeUpdate.stake = weightOfOperatorForQuorum(quorumNumber, operator);
-
-        // check if minimum requirements have been met
-        if (operatorStakeUpdate.stake < minimumStakeForQuorum[quorumNumber]) {
-            // set staker to 0
-            operatorStakeUpdate.stake = uint96(0);
+    ) internal returns (int256, uint96) {
+        /**
+         * Get the operator's current stake for the quorum. If their stake
+         * is below the quorum's threshold, set their stake to 0
+         */
+        uint96 currentStake = weightOfOperatorForQuorum(quorumNumber, operator);
+        if (currentStake < minimumStakeForQuorum[quorumNumber]) {
+            currentStake = uint96(0);
         }
-        // get stakeBeforeUpdate and update with new stake
-        uint96 stakeBeforeUpdate = _recordOperatorStakeUpdate({
+        
+        // Update the operator's stake and retrieve the delta
+        int256 delta = _recordOperatorStakeUpdate({
             operatorId: operatorId, 
             quorumNumber: quorumNumber, 
-            operatorStakeUpdate: operatorStakeUpdate
+            newStake: currentStake
         });
 
-        emit StakeUpdate(operatorId, quorumNumber, operatorStakeUpdate.stake);
-
-        return (stakeBeforeUpdate, operatorStakeUpdate.stake);
+        return (delta, currentStake);
     }
 
     /**
      * @notice Records that `operatorId`'s current stake for `quorumNumber` is now param @operatorStakeUpdate
-     * and returns the previous stake.
+     * @return The change in the operator's stake as a signed int256
      */
     function _recordOperatorStakeUpdate(
         bytes32 operatorId,
         uint8 quorumNumber,
-        OperatorStakeUpdate memory operatorStakeUpdate
-    ) internal returns (uint96) {
-        // initialize stakeBeforeUpdate to 0
-        uint96 stakeBeforeUpdate;
-        uint256 operatorStakeHistoryLength = operatorIdToStakeHistory[operatorId][quorumNumber].length;
-
-        if (operatorStakeHistoryLength != 0) {
-            // set nextUpdateBlockNumber in prev stakes
-            operatorIdToStakeHistory[operatorId][quorumNumber][operatorStakeHistoryLength - 1]
+        uint96 newStake
+    ) internal returns (int256) {
+        /**
+         * If the operator has previous stake history, update the previous entry
+         * and fetch their previous stake
+         */
+        uint96 prevStake;
+        uint256 historyLength = operatorIdToStakeHistory[operatorId][quorumNumber].length;
+        if (historyLength != 0) {
+            operatorIdToStakeHistory[operatorId][quorumNumber][historyLength - 1]
                 .nextUpdateBlockNumber = uint32(block.number);
-            // load stake before update into memory if it exists
-            stakeBeforeUpdate = operatorIdToStakeHistory[operatorId][quorumNumber][operatorStakeHistoryLength - 1]
-                .stake;
+
+            prevStake = 
+                operatorIdToStakeHistory[operatorId][quorumNumber][historyLength - 1].stake;
         }
-        // push new stake to storage
-        operatorIdToStakeHistory[operatorId][quorumNumber].push(operatorStakeUpdate);
-        return stakeBeforeUpdate;
+        
+        // Create a new stake update and push it to storage
+        // TODO - update the entry instead of pushing, if the last update block is this block
+        operatorIdToStakeHistory[operatorId][quorumNumber].push(OperatorStakeUpdate({
+            updateBlockNumber: uint32(block.number),
+            nextUpdateBlockNumber: 0,
+            stake: newStake
+        }));
+
+        emit StakeUpdate(operatorId, quorumNumber, newStake);
+
+        // Return the change in stake
+        return _calculateDelta({ prev: prevStake, cur: newStake });
     }
 
     /// @notice Records that the `totalStake` for `quorumNumber` is now equal to the input param @_totalStake
-    function _recordTotalStakeUpdate(uint8 quorumNumber, OperatorStakeUpdate memory _totalStake) internal {
-        uint256 _totalStakeHistoryLength = _totalStakeHistory[quorumNumber].length;
-        if (_totalStakeHistoryLength != 0) {
-            _totalStakeHistory[quorumNumber][_totalStakeHistoryLength - 1].nextUpdateBlockNumber = uint32(block.number);
+    function _recordTotalStakeUpdate(uint8 quorumNumber, int256 stakeDelta) internal {
+        /**
+         * If this quorum has previous stake history, update the previous entry
+         * and fetch the previous total stake
+         */
+        uint96 prevStake;
+        uint256 historyLength = _totalStakeHistory[quorumNumber].length;
+        if (historyLength != 0) {
+            _totalStakeHistory[quorumNumber][historyLength - 1].nextUpdateBlockNumber = uint32(block.number);
+
+            prevStake = _totalStakeHistory[quorumNumber][historyLength - 1].stake;
         }
-        _totalStake.updateBlockNumber = uint32(block.number);
-        _totalStakeHistory[quorumNumber].push(_totalStake);
+        
+        // Apply the stake delta to the previous stake, and push an update to the
+        // quorum's stake history
+        _totalStakeHistory[quorumNumber].push(OperatorStakeUpdate({
+            updateBlockNumber: uint32(block.number),
+            nextUpdateBlockNumber: 0,
+            stake: _applyDelta(prevStake, stakeDelta)
+        }));
+    }
+
+    /// @notice Returns the change between a previous and current value as a signed int
+    function _calculateDelta(uint96 prev, uint96 cur) internal pure returns (int256) {
+        if (cur >= prev) {
+            return int256(uint256(cur - prev));
+        } else {
+            return -int256(uint256(prev - cur));
+        }
+    }
+
+    /// @notice Adds or subtracts delta from value, according to its sign
+    function _applyDelta(uint96 value, int256 delta) internal pure returns (uint96) {
+        if (delta < 0) {
+            return value - uint96(uint256(-delta));
+        } else {
+            return value + uint96(uint256(delta));
+        }
     }
 
     /// @notice Validates that the `operatorStake` was accurate at the given `blockNumber`

--- a/test/harnesses/StakeRegistryHarness.sol
+++ b/test/harnesses/StakeRegistryHarness.sol
@@ -18,7 +18,7 @@ contract StakeRegistryHarness is StakeRegistry {
         return _recordOperatorStakeUpdate(operatorId, quorumNumber, newStake);
     }
 
-    function updateOperatorStake(address operator, bytes32 operatorId, uint8 quorumNumber) external returns (int256, uint96) {
+    function updateOperatorStake(address operator, bytes32 operatorId, uint8 quorumNumber) external returns (int256, bool) {
         return _updateOperatorStake(operator, operatorId, quorumNumber);
     }
 
@@ -50,23 +50,21 @@ contract StakeRegistryHarness is StakeRegistry {
             "StakeRegistry._registerOperator: greatest quorumNumber must be less than quorumCount"
         );
 
-        for (uint i = 0; i < quorumNumbers.length; ) {            
+        for (uint256 i = 0; i < quorumNumbers.length; ) {            
             /**
              * Update the operator's stake for the quorum and retrieve their current stake
              * as well as the change in stake.
-             * If this method returns `stake == 0`, the operator has not met the minimum requirement
-             * 
-             * TODO - we only use the `stake` return here. It's probably better to use a bool instead
-             *        of relying on the method returning "0" in only this one case.
+             * - If this method returns `hasMinimumStake == false`, the operator has not met 
+             *   the minimum stake requirement for this quorum
              */
             uint8 quorumNumber = uint8(quorumNumbers[i]);
-            (int256 stakeDelta, uint96 stake) = _updateOperatorStake({
+            (int256 stakeDelta, bool hasMinimumStake) = _updateOperatorStake({
                 operator: operator, 
                 operatorId: operatorId, 
                 quorumNumber: quorumNumber
             });
             require(
-                stake != 0,
+                hasMinimumStake,
                 "StakeRegistry._registerOperator: Operator does not meet minimum stake requirement for quorum"
             );
 

--- a/test/harnesses/StakeRegistryHarness.sol
+++ b/test/harnesses/StakeRegistryHarness.sol
@@ -14,16 +14,16 @@ contract StakeRegistryHarness is StakeRegistry {
     ) StakeRegistry(_registryCoordinator, _strategyManager, _serviceManager) {
     }
 
-    function recordOperatorStakeUpdate(bytes32 operatorId, uint8 quorumNumber, OperatorStakeUpdate memory operatorStakeUpdate) external returns(uint96) {
-        return _recordOperatorStakeUpdate(operatorId, quorumNumber, operatorStakeUpdate);
+    function recordOperatorStakeUpdate(bytes32 operatorId, uint8 quorumNumber, uint96 newStake) external returns(int256) {
+        return _recordOperatorStakeUpdate(operatorId, quorumNumber, newStake);
     }
 
-    function updateOperatorStake(address operator, bytes32 operatorId, uint8 quorumNumber) external returns (uint96, uint96) {
+    function updateOperatorStake(address operator, bytes32 operatorId, uint8 quorumNumber) external returns (int256, uint96) {
         return _updateOperatorStake(operator, operatorId, quorumNumber);
     }
 
-    function recordTotalStakeUpdate(uint8 quorumNumber, OperatorStakeUpdate memory totalStakeUpdate) external {
-        _recordTotalStakeUpdate(quorumNumber, totalStakeUpdate);
+    function recordTotalStakeUpdate(uint8 quorumNumber, int256 stakeDelta) external {
+        _recordTotalStakeUpdate(quorumNumber, stakeDelta);
     }
 
     // mocked function so we can set this arbitrarily without having to mock other elements
@@ -49,35 +49,31 @@ contract StakeRegistryHarness is StakeRegistry {
             uint8(quorumNumbers[quorumNumbers.length - 1]) < quorumCount,
             "StakeRegistry._registerOperator: greatest quorumNumber must be less than quorumCount"
         );
-        OperatorStakeUpdate memory _newTotalStakeUpdate;
-        // add the `updateBlockNumber` info
-        _newTotalStakeUpdate.updateBlockNumber = uint32(block.number);
-        // for each quorum, evaluate stake and add to total stake
-        for (uint8 quorumNumbersIndex = 0; quorumNumbersIndex < quorumNumbers.length; ) {
-            // get the next quorumNumber
-            uint8 quorumNumber = uint8(quorumNumbers[quorumNumbersIndex]);
-            // evaluate the stake for the operator
-            // since we don't use the first output, this will use 1 extra sload when deregistered operator's register again
-            (, uint96 stake) = _updateOperatorStake(operator, operatorId, quorumNumber);
-            // check if minimum requirement has been met, will be 0 if not
+
+        for (uint i = 0; i < quorumNumbers.length; ) {            
+            /**
+             * Update the operator's stake for the quorum and retrieve their current stake
+             * as well as the change in stake.
+             * If this method returns `stake == 0`, the operator has not met the minimum requirement
+             * 
+             * TODO - we only use the `stake` return here. It's probably better to use a bool instead
+             *        of relying on the method returning "0" in only this one case.
+             */
+            uint8 quorumNumber = uint8(quorumNumbers[i]);
+            (int256 stakeDelta, uint96 stake) = _updateOperatorStake({
+                operator: operator, 
+                operatorId: operatorId, 
+                quorumNumber: quorumNumber
+            });
             require(
                 stake != 0,
                 "StakeRegistry._registerOperator: Operator does not meet minimum stake requirement for quorum"
             );
-            // add operator stakes to total stake before update (in memory)
-            uint256 _totalStakeHistoryLength = _totalStakeHistory[quorumNumber].length;
-            // add calculate the total stake for the quorum
-            uint96 totalStakeAfterUpdate = stake;
-            if (_totalStakeHistoryLength != 0) {
-                // only add the stake if there is a previous total stake
-                // overwrite `stake` variable
-                totalStakeAfterUpdate += _totalStakeHistory[quorumNumber][_totalStakeHistoryLength - 1].stake;
-            }
-            _newTotalStakeUpdate.stake = totalStakeAfterUpdate;
-            // update storage of total stake
-            _recordTotalStakeUpdate(quorumNumber, _newTotalStakeUpdate);
+
+            // Update this quorum's total stake
+            _recordTotalStakeUpdate(quorumNumber, stakeDelta);
             unchecked {
-                ++quorumNumbersIndex;
+                ++i;
             }
         }
     }

--- a/test/unit/BLSSignatureCheckerUnit.t.sol
+++ b/test/unit/BLSSignatureCheckerUnit.t.sol
@@ -133,11 +133,7 @@ contract BLSSignatureCheckerUnitTests is BLSMockAVSDeployer {
         stakeRegistry.recordOperatorStakeUpdate(
             nonSignerOperatorId, 
             uint8(quorumNumbers[0]), 
-            IStakeRegistry.OperatorStakeUpdate({
-                updateBlockNumber: uint32(block.number),
-                nextUpdateBlockNumber: 0,
-                stake: 1234
-            })
+            1234
         );
         
         // set the nonSignerStakeIndices to a different value

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -299,39 +299,39 @@ contract StakeRegistryUnitTests is Test {
             // reset the cumulative block number
             cumulativeBlockNumber = initialBlockNumber;
 
-            // make sure the number of total stake updates is as expected
-            assertEq(stakeRegistry.getLengthOfTotalStakeHistoryForQuorum(i), numOperatorsInQuorum[i]);
-
             uint96 cumulativeStake = 0;
             // for each operator
             for (uint256 j = 0; j < quorumBitmaps.length; j++) {
                 // if the operator is in the quorum
                 if (quorumBitmaps[j] >> i & 1 == 1) {
                     cumulativeStake += paddedStakesForQuorums[j][operatorQuorumIndices[j]];
-                    // make sure the number of stake updates is as expected
-                    assertEq(stakeRegistry.getLengthOfOperatorIdStakeHistoryForQuorum(_incrementBytes32(defaultOperatorId, j), i), 1);
-
-                    // make sure that the stake update is as expected
-                    IStakeRegistry.OperatorStakeUpdate memory totalStakeUpdate =
-                        stakeRegistry.getTotalStakeUpdateForQuorumFromIndex(i, operatorCount);
-
-                    assertEq(totalStakeUpdate.stake, cumulativeStake);
-                    assertEq(totalStakeUpdate.updateBlockNumber, cumulativeBlockNumber);
-                    // make sure that the next update block number of the previous stake update is as expected
-                    if (operatorCount != 0) {
-                        IStakeRegistry.OperatorStakeUpdate memory prevTotalStakeUpdate =
-                            stakeRegistry.getTotalStakeUpdateForQuorumFromIndex(i, operatorCount - 1);
-                        assertEq(prevTotalStakeUpdate.nextUpdateBlockNumber, cumulativeBlockNumber);
-                    }
 
                     operatorQuorumIndices[j]++;
                     operatorCount++;
-                } else {
-                    // make sure the number of stake updates is as expected
-                    assertEq(stakeRegistry.getLengthOfOperatorIdStakeHistoryForQuorum(_incrementBytes32(defaultOperatorId, j), i), 0);
                 }
                 cumulativeBlockNumber += blocksPassed[j];
-            }   
+            }
+
+            uint historyLength = stakeRegistry.getLengthOfTotalStakeHistoryForQuorum(i);
+
+            // If we don't have stake history, it should be because there is no stake
+            if (historyLength == 0) {
+                assertEq(cumulativeStake, 0);
+                continue;
+            }
+
+            // make sure that the stake update is as expected
+            IStakeRegistry.OperatorStakeUpdate memory totalStakeUpdate =
+            stakeRegistry.getTotalStakeUpdateForQuorumFromIndex(i, historyLength-1);
+
+            assertEq(totalStakeUpdate.stake, cumulativeStake);
+            assertEq(totalStakeUpdate.updateBlockNumber, cumulativeBlockNumber);
+            // make sure that the next update block number of the previous stake update is as expected
+            if (historyLength >= 2) {
+                IStakeRegistry.OperatorStakeUpdate memory prevTotalStakeUpdate =
+                    stakeRegistry.getTotalStakeUpdateForQuorumFromIndex(i, historyLength-2);
+                assertEq(prevTotalStakeUpdate.nextUpdateBlockNumber, cumulativeBlockNumber);
+            }
         }
     }
 
@@ -452,27 +452,9 @@ contract StakeRegistryUnitTests is Test {
             cheats.roll(cumulativeBlockNumber);
         }
 
-        // reset for checking indices
-        cumulativeBlockNumber = intialBlockNumber;
-        // make sure that the stake updates are as expected
-        for (uint256 i = 0; i < blocksPassed.length - 1; i++) {
-            IStakeRegistry.OperatorStakeUpdate memory operatorStakeUpdate = stakeRegistry.getStakeUpdateForQuorumFromOperatorIdAndIndex(defaultQuorumNumber, defaultOperatorId, i);
-            
-            uint96 expectedStake = stakes[i];
-            if (expectedStake < stakeRegistry.minimumStakeForQuorum(defaultQuorumNumber)) {
-                expectedStake = 0;
-            }
-
-            assertEq(operatorStakeUpdate.stake, expectedStake);
-            assertEq(operatorStakeUpdate.updateBlockNumber, cumulativeBlockNumber);
-            cumulativeBlockNumber += blocksPassed[i];
-            assertEq(operatorStakeUpdate.nextUpdateBlockNumber, cumulativeBlockNumber);
-        }
-
         // make sure that the last stake update is as expected
-        IStakeRegistry.OperatorStakeUpdate memory lastOperatorStakeUpdate = stakeRegistry.getStakeUpdateForQuorumFromOperatorIdAndIndex(defaultQuorumNumber, defaultOperatorId, blocksPassed.length - 1);
+        IStakeRegistry.OperatorStakeUpdate memory lastOperatorStakeUpdate = stakeRegistry.getMostRecentStakeUpdateByOperatorId(defaultOperatorId, defaultQuorumNumber);
         assertEq(lastOperatorStakeUpdate.stake, stakes[blocksPassed.length - 1]);
-        assertEq(lastOperatorStakeUpdate.updateBlockNumber, cumulativeBlockNumber);
         assertEq(lastOperatorStakeUpdate.nextUpdateBlockNumber, uint32(0));
     }
 
@@ -492,37 +474,18 @@ contract StakeRegistryUnitTests is Test {
             } else {
                 stakeDelta = _calculateDelta({prev: stakes[i-1], cur: stakes[i]});
             }
-
-            // Get previous history length and total stake update
-            uint prevHistoryLength = stakeRegistry.getLengthOfTotalStakeHistoryForQuorum(defaultQuorumNumber);
-            IStakeRegistry.OperatorStakeUpdate memory prevStakeUpdate;
-            if (prevHistoryLength != 0) {
-                prevStakeUpdate = stakeRegistry.getTotalStakeUpdateForQuorumFromIndex(defaultQuorumNumber, prevHistoryLength-1);
-            }
                 
 
             // Perform the update
             stakeRegistry.recordTotalStakeUpdate(defaultQuorumNumber, stakeDelta);
-
-            // Get new history length and total stake update
-            uint newHistoryLength = stakeRegistry.getLengthOfTotalStakeHistoryForQuorum(defaultQuorumNumber);
-            IStakeRegistry.OperatorStakeUpdate memory newStakeUpdate;
-            if (newHistoryLength != 0) {
-                newStakeUpdate = stakeRegistry.getTotalStakeUpdateForQuorumFromIndex(defaultQuorumNumber, newHistoryLength-1);
-            }
             
+            IStakeRegistry.OperatorStakeUpdate memory newStakeUpdate;
+            uint historyLength = stakeRegistry.getLengthOfTotalStakeHistoryForQuorum(defaultQuorumNumber);
+            if (historyLength != 0) {
+                newStakeUpdate = stakeRegistry.getTotalStakeUpdateForQuorumFromIndex(defaultQuorumNumber, historyLength-1);
+            }
             // Check that the most recent entry reflects the correct stake
             assertEq(newStakeUpdate.stake, stakes[i]);
-
-            if (stakeDelta == 0) {
-                // Check that no update occurred
-                assertEq(prevHistoryLength, newHistoryLength);
-                assertEq(prevStakeUpdate.stake, newStakeUpdate.stake);
-                assertEq(prevStakeUpdate.updateBlockNumber, newStakeUpdate.updateBlockNumber);
-                assertEq(prevStakeUpdate.nextUpdateBlockNumber, newStakeUpdate.nextUpdateBlockNumber);
-            } else {
-                assertEq(newStakeUpdate.updateBlockNumber, cumulativeBlockNumber);
-            }
 
             cumulativeBlockNumber += blocksPassed;
             cheats.roll(cumulativeBlockNumber);

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -619,10 +619,6 @@ contract StakeRegistryUnitTests is Test {
     }
 
     function _calculateDelta(uint96 prev, uint96 cur) internal pure returns (int256) {
-        if (cur >= prev) {
-            return int256(uint256(cur - prev));
-        } else {
-            return -int256(uint256(prev - cur));
-        }
+        return int256(uint256(cur)) - int256(uint256(prev));
     }
 }


### PR DESCRIPTION
This PR:
* changes for loop index names to things like "i" or "j" when the index is just an index. The wordy index names were bugging me.
* Refactors StakeRegsitry to use a signed delta in most places, which allows us to get rid of a lot of bloat

Functional changes in StakeRegistry:
* Total stake updates are only made if we have a nonzero stake delta. Otherwise we skip them.
* For both total and operator updates, if the most recent entry was made during this block, we update that entry rather than pushing a new one. This should mean that all histories only have one entry per block.