### PR TITLE
fix: remove possible infinite loop when updating stakes

### DIFF
--- a/src/StakeRegistry.sol
+++ b/src/StakeRegistry.sol
@@ -84,10 +84,7 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
             for (uint i = 0; i < operators.length; ) {
                 bytes32 operatorId = registryCoordinator.getOperatorId(operators[i]);
                 uint192 quorumBitmap = registryCoordinator.getCurrentQuorumBitmapByOperatorId(operatorId);
-                // if the operator is not a part of any quorums, skip
-                if (quorumBitmap == 0) {
-                    continue;
-                }
+
                 // if the operator is a part of the quorum
                 if (BitmapUtils.numberIsInBitmap(quorumBitmap, quorumNumber)) {
                     // if the total stake has not been loaded yet, load it


### PR DESCRIPTION
The removed code made it possible for `updateStakes` to infinitely loop when processing an empty bitmap. Will open an issue to add a regression test.