### PR TITLE
fix: Revert blsPubkeyRegistry interface return type

### DIFF
--- a/src/BLSSignatureChecker.sol
+++ b/src/BLSSignatureChecker.sol
@@ -25,12 +25,12 @@ contract BLSSignatureChecker is IBLSSignatureChecker {
 
     IRegistryCoordinator public immutable registryCoordinator;
     IStakeRegistry public immutable stakeRegistry;
-    address public immutable blsPubkeyRegistry;
+    IBLSPubkeyRegistry public immutable blsPubkeyRegistry;
 
     constructor(IBLSRegistryCoordinatorWithIndices _registryCoordinator) {
         registryCoordinator = IRegistryCoordinator(_registryCoordinator);
         stakeRegistry = _registryCoordinator.stakeRegistry();
-        blsPubkeyRegistry = address(_registryCoordinator.blsPubkeyRegistry());
+        blsPubkeyRegistry = _registryCoordinator.blsPubkeyRegistry();
     }
 
     /**

--- a/src/interfaces/IBLSSignatureChecker.sol
+++ b/src/interfaces/IBLSSignatureChecker.sol
@@ -43,7 +43,7 @@ interface IBLSSignatureChecker {
 
     function registryCoordinator() external view returns (IRegistryCoordinator);
     function stakeRegistry() external view returns (IStakeRegistry);
-    function blsPubkeyRegistry() external view returns (address);
+    function blsPubkeyRegistry() external view returns (IBLSPubkeyRegistry);
 
     /**
      * @notice This function is called by disperser when it has aggregated all the signatures of the operators


### PR DESCRIPTION
Reverting a change to return an address instead of the interface that I had made while troubleshooting the migration