### PR TITLE
FEAT: update index reg and propagate changes. need to fix indexreg tests

### DIFF
--- a/src/BLSRegistryCoordinatorWithIndices.sol
+++ b/src/BLSRegistryCoordinatorWithIndices.sol
@@ -245,8 +245,7 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
             _deregisterOperatorWithCoordinator({
                 operator: operatorKickParams[i].operator,
                 quorumNumbers: quorumNumbers[i:i+1],
-                pubkey: operatorKickParams[i].pubkey, 
-                operatorIdsToSwap: operatorIdsToSwap
+                pubkey: operatorKickParams[i].pubkey 
             });
         }
     }
@@ -262,14 +261,12 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
         bytes calldata deregistrationData
     ) external onlyWhenNotPaused(PAUSED_DEREGISTER_OPERATOR) {
         // get the operator's deregistration information
-        (BN254.G1Point memory pubkey, bytes32[] memory operatorIdsToSwap) 
-            = abi.decode(deregistrationData, (BN254.G1Point, bytes32[]));
+        (BN254.G1Point memory pubkey) = abi.decode(deregistrationData, (BN254.G1Point));
         // call internal function to deregister the operator
         _deregisterOperatorWithCoordinator({
             operator: msg.sender, 
             quorumNumbers: quorumNumbers, 
-            pubkey: pubkey, 
-            operatorIdsToSwap: operatorIdsToSwap
+            pubkey: pubkey 
         });
     }
 
@@ -277,21 +274,15 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
      * @notice Deregisters the msg.sender as an operator from the middleware
      * @param quorumNumbers are the bytes representing the quorum numbers that the operator is registered for
      * @param pubkey is the BLS public key of the operator
-     * @param operatorIdsToSwap is the list of the operator ids to swap the index of the operator with in each 
-     * quorum when removing the operator from the quorum's ordered list. The provided operator ids should be the 
-     * those of the operator's with the largest index in each quorum that the operator is deregistering from, in
-     * ascending order of quorum number.
      */
     function deregisterOperatorWithCoordinator(
         bytes calldata quorumNumbers,
-        BN254.G1Point memory pubkey,
-        bytes32[] memory operatorIdsToSwap
+        BN254.G1Point memory pubkey
     ) external onlyWhenNotPaused(PAUSED_DEREGISTER_OPERATOR) {
         _deregisterOperatorWithCoordinator({
             operator: msg.sender, 
             quorumNumbers: quorumNumbers, 
-            pubkey: pubkey, 
-            operatorIdsToSwap: operatorIdsToSwap
+            pubkey: pubkey
         });
     }
 
@@ -313,22 +304,16 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
      * @param operator is the operator to eject
      * @param quorumNumbers are the quorum numbers to eject the operator from
      * @param pubkey is the BLS public key of the operator
-     * @param operatorIdsToSwap is the list of the operator ids to swap the index of the operator with in each 
-     * quorum when removing the operator from the quorum's ordered list. The provided operator ids should be the 
-     * those of the operator's with the largest index in each quorum that the operator is being ejected from, in
-     * ascending order of quorum number.
      */
     function ejectOperatorFromCoordinator(
         address operator, 
         bytes calldata quorumNumbers, 
-        BN254.G1Point memory pubkey, 
-        bytes32[] memory operatorIdsToSwap
+        BN254.G1Point memory pubkey
     ) external onlyEjector {
         _deregisterOperatorWithCoordinator({
             operator: operator, 
             quorumNumbers: quorumNumbers, 
-            pubkey: pubkey, 
-            operatorIdsToSwap: operatorIdsToSwap
+            pubkey: pubkey
         });
     }
 
@@ -462,8 +447,7 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
     function _deregisterOperatorWithCoordinator(
         address operator, 
         bytes calldata quorumNumbers, 
-        BN254.G1Point memory pubkey, 
-        bytes32[] memory operatorIdsToSwap
+        BN254.G1Point memory pubkey
     ) internal virtual {
         require(_operators[operator].status == OperatorStatus.REGISTERED, "BLSRegistryCoordinatorWithIndices._deregisterOperatorWithCoordinator: operator is not registered");
 
@@ -495,7 +479,7 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
         stakeRegistry.deregisterOperator(operatorId, quorumNumbersToRemove);
 
         // deregister the operator from the IndexRegistry
-        indexRegistry.deregisterOperator(operatorId, quorumNumbersToRemove, operatorIdsToSwap);
+        indexRegistry.deregisterOperator(operatorId, quorumNumbersToRemove);
 
         // set the toBlockNumber of the operator's quorum bitmap update
         _operatorIdToQuorumBitmapHistory[operatorId][operatorQuorumBitmapHistoryLengthMinusOne].nextUpdateBlockNumber = uint32(block.number);

--- a/src/IndexRegistry.sol
+++ b/src/IndexRegistry.sol
@@ -42,8 +42,6 @@ contract IndexRegistry is IndexRegistryStorage {
         bytes calldata quorumNumbers
     ) public virtual onlyRegistryCoordinator returns(uint32[] memory) {
         uint32[] memory numOperatorsPerQuorum = new uint32[](quorumNumbers.length);
-        //add operator to operatorList
-        globalOperatorList.push(operatorId);
 
         for (uint256 i = 0; i < quorumNumbers.length; i++) {
             uint8 quorumNumber = uint8(quorumNumbers[i]);
@@ -70,8 +68,6 @@ contract IndexRegistry is IndexRegistryStorage {
      * @notice Deregisters the operator with the specified `operatorId` for the quorums specified by `quorumNumbers`.
      * @param operatorId is the id of the operator that is being deregistered
      * @param quorumNumbers is the quorum numbers the operator is deregistered for
-     * @param operatorIdsToSwap is the list of operatorIds that have the largest indexes in each of the `quorumNumbers`
-     * they will be swapped with the operator's current index when the operator is removed from the list
      * @dev access restricted to the RegistryCoordinator
      * @dev Preconditions (these are assumed, not validated in this contract):
      *         1) `quorumNumbers` has no duplicates
@@ -82,22 +78,15 @@ contract IndexRegistry is IndexRegistryStorage {
      */
     function deregisterOperator(
         bytes32 operatorId, 
-        bytes calldata quorumNumbers, 
-        bytes32[] memory operatorIdsToSwap
+        bytes calldata quorumNumbers
     ) public virtual onlyRegistryCoordinator {
-        require(
-            quorumNumbers.length == operatorIdsToSwap.length, 
-            "IndexRegistry.deregisterOperator: quorumNumbers and operatorIdsToSwap must be the same length"
-        );
-
         for (uint256 i = 0; i < quorumNumbers.length; i++) {
             uint8 quorumNumber = uint8(quorumNumbers[i]);
-            uint32 indexOfOperatorToRemove = _operatorIdToIndexHistory[operatorId][quorumNumber][_operatorIdToIndexHistory[operatorId][quorumNumber].length - 1].index;
+            uint32 indexOfOperatorToRemove = operatorIdToIndex[quorumNumber][operatorId];
             _processOperatorRemoval({
                 operatorId: operatorId, 
                 quorumNumber: quorumNumber, 
-                indexOfOperatorToRemove: indexOfOperatorToRemove, 
-                operatorIdToSwap: operatorIdsToSwap[i]
+                indexOfOperatorToRemove: indexOfOperatorToRemove 
             });
             _updateTotalOperatorHistory({
                 quorumNumber: quorumNumber, 
@@ -130,15 +119,17 @@ contract IndexRegistry is IndexRegistryStorage {
      * @param index the latest index of that operator in the list of operators registered for this quorum
      */ 
     function _updateOperatorIdToIndexHistory(bytes32 operatorId, uint8 quorumNumber, uint32 index) internal {
-        OperatorIndexUpdate memory latestOperatorIndex;
-        latestOperatorIndex.index = index;
-        latestOperatorIndex.fromBlockNumber = uint32(block.number);
-        _operatorIdToIndexHistory[operatorId][quorumNumber].push(latestOperatorIndex);
+        OperatorUpdate memory latestOperatorUpdate;
+        latestOperatorUpdate.operatorId = operatorId;
+        latestOperatorUpdate.fromBlockNumber = uint32(block.number);
+        _indexToOperatorIdHistory[quorumNumber][index].push(latestOperatorUpdate);
+
+        operatorIdToIndex[quorumNumber][operatorId] = index;
 
         emit QuorumIndexUpdate(operatorId, quorumNumber, index);
     }
 
-    /**
+    /**v
      * @notice when we remove an operator from a quorum, we simply update the operator's index history
      * as well as any operatorIds we have to swap
      * @param quorumNumber quorum number of the operator to remove
@@ -147,15 +138,10 @@ contract IndexRegistry is IndexRegistryStorage {
     function _processOperatorRemoval(
         bytes32 operatorId, 
         uint8 quorumNumber, 
-        uint32 indexOfOperatorToRemove, 
-        bytes32 operatorIdToSwap
+        uint32 indexOfOperatorToRemove 
     ) internal {   
-        uint32 operatorIdToSwapIndex = _operatorIdToIndexHistory[operatorIdToSwap][quorumNumber][_operatorIdToIndexHistory[operatorIdToSwap][quorumNumber].length - 1].index;
-        require(
-            _totalOperatorsHistory[quorumNumber][_totalOperatorsHistory[quorumNumber].length - 1].numOperators - 1 == operatorIdToSwapIndex, 
-            "IndexRegistry._processOperatorRemoval: operatorIdToSwap is not the last operator in the quorum"
-        );
-
+        uint32 currentNumOperators = _totalOperatorsHistory[quorumNumber][_totalOperatorsHistory[quorumNumber].length - 1].numOperators;
+        bytes32 operatorIdToSwap = _indexToOperatorIdHistory[quorumNumber][currentNumOperators - 1][_indexToOperatorIdHistory[quorumNumber][currentNumOperators - 1].length - 1].operatorId;
         // if the operator is not the last in the list, we must swap the last operator into their positon
         if (operatorId != operatorIdToSwap) {
             //update the swapped operator's operatorIdToIndexHistory list with a new entry, as their index has now changed
@@ -163,14 +149,13 @@ contract IndexRegistry is IndexRegistryStorage {
                 operatorId: operatorIdToSwap, 
                 quorumNumber: quorumNumber, 
                 index: indexOfOperatorToRemove
-            });
+            }); 
         } 
-        // marking the final entry in the deregistering operator's operatorIdToIndexHistory entry with the deregistration block number, 
-        // setting the index to OPERATOR_DEREGISTERED_INDEX. Note that this is a special meaning, and any other index value represents a real index
+        // marking the last index with OPERATOR_DOES_NOT_EXIST_ID, to signal that the index it not at use at the block number 
         _updateOperatorIdToIndexHistory({
-            operatorId: operatorId, 
+            operatorId: OPERATOR_DOES_NOT_EXIST_ID, 
             quorumNumber: quorumNumber, 
-            index: OPERATOR_DEREGISTERED_INDEX
+            index: currentNumOperators - 1
         });
     }
 
@@ -207,90 +192,42 @@ contract IndexRegistry is IndexRegistryStorage {
         return _totalOperatorsHistory[quorumNumber][0].numOperators;
     }
     
-    /** 
-     * @notice Returns the index of the `operatorId` at the given `blockNumber` for the given `quorumNumber`, or
-     * `OPERATOR_DEREGISTERED_INDEX` if the operator was not registered for the `quorumNumber` at blockNumber
+    /**
+     * @return operatorId at the given `index` at the given `blockNumber` for the given `quorumNumber`
+     * Precondition: requires that the index was used active at the given block number for quorum
      */
-    function _getIndexOfOperatorForQuorumAtBlockNumber(
-        bytes32 operatorId, 
+    function _getOperatorIdAtIndexForQuorumAtBlockNumber(
+        uint32 index, 
         uint8 quorumNumber, 
         uint32 blockNumber
-    ) internal view returns(uint32) {
-        uint256 operatorIndexHistoryLength = _operatorIdToIndexHistory[operatorId][quorumNumber].length;
+    ) internal view returns(bytes32) {
+        uint256 indexOperatorHistoryLength = _indexToOperatorIdHistory[quorumNumber][index].length;
         // loop backward through index history to find the index of the operator at the given block number
-        for (uint256 i = 0; i < operatorIndexHistoryLength; i++) {
-            uint256 listIndex = (operatorIndexHistoryLength - 1) - i;
-            OperatorIndexUpdate memory operatorIndexUpdate = _operatorIdToIndexHistory[operatorId][quorumNumber][listIndex];
+        for (uint256 i = 0; i < indexOperatorHistoryLength; i++) {
+            uint256 listIndex = (indexOperatorHistoryLength - 1) - i;
+            OperatorUpdate memory operatorIndexUpdate = _indexToOperatorIdHistory[quorumNumber][index][listIndex];
             if (operatorIndexUpdate.fromBlockNumber <= blockNumber) {
-                // one special case is that this will be OPERATOR_DEREGISTERED_INDEX if the operator was deregistered from the quorum
-                return operatorIndexUpdate.index;
+                // one special case is that this will be OPERATOR_DOES_NOT_EXIST_ID if this index was not used at the block number
+                return operatorIndexUpdate.operatorId;
             }
         }
 
-        // the operator is still active or not in the quorum, so we return the latest index or the default max uint32
-        // this will be hit if `blockNumber` is before when the operator registered or the operator has never registered for the given quorum
-        return OPERATOR_DEREGISTERED_INDEX;
+        // we should only it this if the index was never used before blockNumber
+        return OPERATOR_DOES_NOT_EXIST_ID;
     }
 
     /*******************************************************************************
                                  VIEW FUNCTIONS
     *******************************************************************************/
 
-    /// @notice Returns the length of the globalOperatorList
-    function getGlobalOperatorListLength() external view returns (uint256) {
-        return globalOperatorList.length;
-    }
-
-    /// @notice Returns the _operatorIdToIndexHistory entry for the specified `operatorId` and `quorumNumber` at the specified `index`
-    function getOperatorIndexUpdateOfOperatorIdForQuorumAtIndex(
-        bytes32 operatorId, 
-        uint8 quorumNumber, 
-        uint32 index
-    ) external view returns (OperatorIndexUpdate memory) {
-        return _operatorIdToIndexHistory[operatorId][quorumNumber][index];
+    /// @notice Returns the _indexToOperatorIdHistory entry for the specified `operatorIndex` and `quorumNumber` at the specified `index`
+    function getOperatorIndexUpdateOfIndexForQuorumAtIndex(uint32 operatorIndex, uint8 quorumNumber, uint32 index) external view returns (OperatorUpdate memory) {
+        return _indexToOperatorIdHistory[quorumNumber][operatorIndex][index];
     }
 
     /// @notice Returns the _totalOperatorsHistory entry for the specified `quorumNumber` at the specified `index`
-    function getQuorumUpdateAtIndex(
-        uint8 quorumNumber, 
-        uint32 index
-    ) external view returns (QuorumUpdate memory) {
+    function getQuorumUpdateAtIndex(uint8 quorumNumber, uint32 index) external view returns (QuorumUpdate memory) {
         return _totalOperatorsHistory[quorumNumber][index];
-    }
-
-    /**
-     * @notice Looks up the `operator`'s index in the set of operators for `quorumNumber` at the specified `blockNumber` using the `index`.
-     * @param operatorId is the id of the operator for which the index is desired
-     * @param quorumNumber is the quorum number for which the operator index is desired
-     * @param blockNumber is the block number at which the index of the operator is desired
-     * @param index Used to specify the entry within the dynamic array `_operatorIdToIndexHistory[operatorId]` to 
-     * read data from
-     * @dev Function will revert in the event that the specified `index` input does not identify the appropriate entry in the
-     * array `_operatorIdToIndexHistory[operatorId][quorumNumber]` to pull the info from.
-     */
-    function getOperatorIndexForQuorumAtBlockNumberByIndex(
-        bytes32 operatorId, 
-        uint8 quorumNumber, 
-        uint32 blockNumber, 
-        uint32 index
-    ) external view returns (uint32) {
-        OperatorIndexUpdate memory operatorIndexToCheck = _operatorIdToIndexHistory[operatorId][quorumNumber][index];
-
-        // blocknumber must be at or after the "index'th" entry's fromBlockNumber
-        require(
-            blockNumber >= operatorIndexToCheck.fromBlockNumber, 
-            "IndexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex: provided index is too far in the past for provided block number"
-        );
-       
-        // if there is an index update after the "index'th" update, the blocknumber must be before the next entry's fromBlockNumber
-        if (index != _operatorIdToIndexHistory[operatorId][quorumNumber].length - 1) {
-            OperatorIndexUpdate memory nextOperatorIndex = _operatorIdToIndexHistory[operatorId][quorumNumber][index + 1];
-            require(
-                blockNumber < nextOperatorIndex.fromBlockNumber, 
-                "IndexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex: provided index is too far in the future for provided block number"
-            );
-        }
-        return operatorIndexToCheck.index;
     }
 
     /**
@@ -330,13 +267,12 @@ contract IndexRegistry is IndexRegistryStorage {
         uint32 blockNumber
     ) external view returns (bytes32[] memory){
         bytes32[] memory quorumOperatorList = new bytes32[](_getTotalOperatorsForQuorumAtBlockNumber(quorumNumber, blockNumber));
-        for (uint256 i = 0; i < globalOperatorList.length; i++) {
-            bytes32 operatorId = globalOperatorList[i];
-            uint32 index = _getIndexOfOperatorForQuorumAtBlockNumber(operatorId, quorumNumber, blockNumber);
-            // if the operator was not in the quorum at the given block number, skip it
-            if (index == OPERATOR_DEREGISTERED_INDEX)
-                continue;
-            quorumOperatorList[index] = operatorId;
+        for (uint256 i = 0; i < quorumOperatorList.length; i++) {
+            quorumOperatorList[i] = _getOperatorIdAtIndexForQuorumAtBlockNumber(uint32(i), quorumNumber, blockNumber);
+            require(
+                quorumOperatorList[i] != OPERATOR_DOES_NOT_EXIST_ID, 
+                "IndexRegistry.getOperatorListForQuorumAtBlockNumber: operator does not exist at the given block number"
+            );
         }
         return quorumOperatorList;
     }

--- a/src/IndexRegistry.sol
+++ b/src/IndexRegistry.sol
@@ -140,7 +140,7 @@ contract IndexRegistry is IndexRegistryStorage {
         uint8 quorumNumber, 
         uint32 indexOfOperatorToRemove 
     ) internal {   
-        uint32 currentNumOperators = _totalOperatorsHistory[quorumNumber][_totalOperatorsHistory[quorumNumber].length - 1].numOperators;
+        uint32 currentNumOperators = _totalOperatorsForQuorum(quorumNumber);
         bytes32 operatorIdToSwap = _indexToOperatorIdHistory[quorumNumber][currentNumOperators - 1][_indexToOperatorIdHistory[quorumNumber][currentNumOperators - 1].length - 1].operatorId;
         // if the operator is not the last in the list, we must swap the last operator into their positon
         if (operatorId != operatorIdToSwap) {
@@ -190,6 +190,15 @@ contract IndexRegistry is IndexRegistryStorage {
             }
         }        
         return _totalOperatorsHistory[quorumNumber][0].numOperators;
+    }
+
+    /// @notice Returns the total number of operators for a given `quorumNumber`
+    function _totalOperatorsForQuorum(uint8 quorumNumber) internal view returns (uint32){
+        uint256 totalOperatorsHistoryLength = _totalOperatorsHistory[quorumNumber].length;
+        if (totalOperatorsHistoryLength == 0) {
+            return 0;
+        }
+        return _totalOperatorsHistory[quorumNumber][totalOperatorsHistoryLength - 1].numOperators;
     }
     
     /**
@@ -279,10 +288,6 @@ contract IndexRegistry is IndexRegistryStorage {
 
     /// @notice Returns the total number of operators for a given `quorumNumber`
     function totalOperatorsForQuorum(uint8 quorumNumber) external view returns (uint32){
-        uint256 totalOperatorsHistoryLength = _totalOperatorsHistory[quorumNumber].length;
-        if (totalOperatorsHistoryLength == 0) {
-            return 0;
-        }
-        return _totalOperatorsHistory[quorumNumber][totalOperatorsHistoryLength - 1].numOperators;
+        return _totalOperatorsForQuorum(quorumNumber);
     }
 }

--- a/src/IndexRegistryStorage.sol
+++ b/src/IndexRegistryStorage.sol
@@ -13,8 +13,8 @@ import "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";
  */
 abstract contract IndexRegistryStorage is Initializable, IIndexRegistry {
 
-    /// @notice The value that indices of deregistered operators are set to
-    uint32 public constant OPERATOR_DEREGISTERED_INDEX = type(uint32).max;
+    /// @notice The value that is returned when an operator does not exist at an index at a certain block
+    bytes32 public constant OPERATOR_DOES_NOT_EXIST_ID = bytes32(0);
 
     /// @notice The RegistryCoordinator contract for this middleware
     IRegistryCoordinator public immutable registryCoordinator;
@@ -22,8 +22,10 @@ abstract contract IndexRegistryStorage is Initializable, IIndexRegistry {
     /// @notice list of all operators ever registered, may include duplicates. used to avoid running an indexer on nodes
     bytes32[] public globalOperatorList;
 
-    /// @notice mapping of operatorId => quorumNumber => index history of that operator
-    mapping(bytes32 => mapping(uint8 => OperatorIndexUpdate[])) internal _operatorIdToIndexHistory;
+    /// @notice mapping of quorumNumber => operator id => current index
+    mapping(uint8 => mapping(bytes32 => uint32)) public operatorIdToIndex;
+    /// @notice mapping of quorumNumber => index => operator id history for that index
+    mapping(uint8 => mapping(uint32 => OperatorUpdate[])) internal _indexToOperatorIdHistory;
     /// @notice mapping of quorumNumber => history of numbers of unique registered operators
     mapping(uint8 => QuorumUpdate[]) internal _totalOperatorsHistory;
 

--- a/src/interfaces/IBLSRegistryCoordinatorWithIndices.sol
+++ b/src/interfaces/IBLSRegistryCoordinatorWithIndices.sol
@@ -59,12 +59,10 @@ interface IBLSRegistryCoordinatorWithIndices is ISignatureUtils, IRegistryCoordi
      * @param operator is the operator to eject
      * @param quorumNumbers are the quorum numbers to eject the operator from
      * @param pubkey is the BLS public key of the operator
-     * @param operatorIdsToSwap is the list of the operator ids tho swap the index of the operator with in each
      */
     function ejectOperatorFromCoordinator(
         address operator, 
         bytes calldata quorumNumbers, 
-        BN254.G1Point memory pubkey, 
-        bytes32[] memory operatorIdsToSwap
+        BN254.G1Point memory pubkey 
     ) external;
 }

--- a/src/interfaces/IIndexRegistry.sol
+++ b/src/interfaces/IIndexRegistry.sol
@@ -16,13 +16,12 @@ interface IIndexRegistry is IRegistry {
     // DATA STRUCTURES
 
     // struct used to give definitive ordering to operators at each blockNumber. 
-    struct OperatorIndexUpdate {
+    struct OperatorUpdate {
         // blockNumber number from which `index` was the operators index
         // the operator's index is the first entry such that `blockNumber >= entry.fromBlockNumber`
         uint32 fromBlockNumber;
-        // index of the operator in array of operators
-        // index = type(uint32).max = OPERATOR_DEREGISTERED_INDEX implies the operator was deregistered
-        uint32 index;
+        // the operator at this index
+        bytes32 operatorId;
     }
 
     // struct used to denote the number of operators in a quorum at a given blockNumber
@@ -51,8 +50,6 @@ interface IIndexRegistry is IRegistry {
      * @notice Deregisters the operator with the specified `operatorId` for the quorums specified by `quorumNumbers`.
      * @param operatorId is the id of the operator that is being deregistered
      * @param quorumNumbers is the quorum numbers the operator is deregistered for
-     * @param operatorIdsToSwap is the list of operatorIds that have the largest indexes in each of the `quorumNumbers`
-     * they will be swapped with the operator's current index when the operator is removed from the list
      * @dev access restricted to the RegistryCoordinator
      * @dev Preconditions (these are assumed, not validated in this contract):
      *         1) `quorumNumbers` has no duplicates
@@ -61,28 +58,13 @@ interface IIndexRegistry is IRegistry {
      *         4) the operator is not already deregistered
      *         5) `quorumNumbers` is a subset of the quorumNumbers that the operator is registered for
      */
-    function deregisterOperator(bytes32 operatorId, bytes calldata quorumNumbers, bytes32[] memory operatorIdsToSwap) external;
+    function deregisterOperator(bytes32 operatorId, bytes calldata quorumNumbers) external;
 
-    /// @notice Returns the length of the globalOperatorList
-    function getGlobalOperatorListLength() external view returns (uint256);
-
-    /// @notice Returns the _operatorIdToIndexHistory entry for the specified `operatorId` and `quorumNumber` at the specified `index`
-    function getOperatorIndexUpdateOfOperatorIdForQuorumAtIndex(bytes32 operatorId, uint8 quorumNumber, uint32 index) external view returns (OperatorIndexUpdate memory);
+    /// @notice Returns the _indexToOperatorIdHistory entry for the specified `operatorIndex` and `quorumNumber` at the specified `index`
+    function getOperatorIndexUpdateOfIndexForQuorumAtIndex(uint32 operatorIndex, uint8 quorumNumber, uint32 index) external view returns (OperatorUpdate memory);
 
     /// @notice Returns the _totalOperatorsHistory entry for the specified `quorumNumber` at the specified `index`
     function getQuorumUpdateAtIndex(uint8 quorumNumber, uint32 index) external view returns (QuorumUpdate memory);
-
-    /**
-     * @notice Looks up the `operator`'s index for `quorumNumber` at the specified `blockNumber` using the `index`.
-     * @param operatorId is the id of the operator for which the index is desired
-     * @param quorumNumber is the quorum number for which the operator index is desired
-     * @param blockNumber is the block number at which the index of the operator is desired
-     * @param index Used to specify the entry within the dynamic array `operatorIdToIndexHistory[operatorId]` to 
-     * read data from
-     * @dev Function will revert in the event that the specified `index` input does not identify the appropriate entry in the
-     * array `operatorIdToIndexHistory[operatorId][quorumNumber]` to pull the info from.
-     */
-    function getOperatorIndexForQuorumAtBlockNumberByIndex(bytes32 operatorId, uint8 quorumNumber, uint32 blockNumber, uint32 index) external view returns (uint32);
 
     /**
      * @notice Looks up the number of total operators for `quorumNumber` at the specified `blockNumber`.

--- a/test/unit/BLSOperatorStateRetrieverUnit.t.sol
+++ b/test/unit/BLSOperatorStateRetrieverUnit.t.sol
@@ -42,19 +42,12 @@ contract BLSOperatorStateRetrieverUnitTests is MockAVSDeployer {
         // choose a random operator to deregister
         uint256 operatorIndexToDeregister = pseudoRandomNumber % maxOperatorsToRegister;
         bytes memory quorumNumbersToDeregister = BitmapUtils.bitmapToBytesArray(operatorMetadatas[operatorIndexToDeregister].quorumBitmap);
-        // get the operatorIds of the last operators in each quorum to swap with the operator to deregister
-        bytes32[] memory operatorIdsToSwap = new bytes32[](quorumNumbersToDeregister.length);
-        for (uint i = 0; i < quorumNumbersToDeregister.length; i++) {
-            uint8 quorumNumber = uint8(quorumNumbersToDeregister[i]);
-            operatorIdsToSwap[i] = operatorMetadatas[expectedOperatorOverallIndices[quorumNumber][expectedOperatorOverallIndices[quorumNumber].length - 1]].operatorId;
-        }
 
         uint32 deregistrationBlockNumber = registrationBlockNumber + blocksBetweenRegistrations * (uint32(operatorMetadatas.length) + 1);
         cheats.roll(deregistrationBlockNumber);
 
         cheats.prank(_incrementAddress(defaultOperator, operatorIndexToDeregister));
-        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbersToDeregister, operatorMetadatas[operatorIndexToDeregister].pubkey, operatorIdsToSwap);
-
+        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbersToDeregister, operatorMetadatas[operatorIndexToDeregister].pubkey);
         // modify expectedOperatorOverallIndices by moving th operatorIdsToSwap to the index where the operatorIndexToDeregister was
         for (uint i = 0; i < quorumNumbersToDeregister.length; i++) {
             uint8 quorumNumber = uint8(quorumNumbersToDeregister[i]);

--- a/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
+++ b/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
@@ -349,7 +349,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
         cheats.expectRevert(bytes("Pausable: index is paused"));
         cheats.prank(defaultOperator);
-        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbers, defaultPubKey, new bytes32[](0));
+        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbers, defaultPubKey);
     }
 
     function testDeregisterOperatorWithCoordinator_NotRegistered_Reverts() public {
@@ -358,7 +358,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
         cheats.expectRevert("BLSRegistryCoordinatorWithIndices._deregisterOperatorWithCoordinator: operator is not registered");
         cheats.prank(defaultOperator);
-        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbers, defaultPubKey, new bytes32[](0));
+        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbers, defaultPubKey);
     }
 
     function testDeregisterOperatorWithCoordinator_IncorrectPubkey_Reverts() public {
@@ -372,7 +372,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
         cheats.expectRevert("BLSRegistryCoordinatorWithIndices._deregisterOperatorWithCoordinator: operatorId does not match pubkey hash");
         cheats.prank(defaultOperator);
-        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbers, incorrectPubKey, new bytes32[](0));
+        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbers, incorrectPubKey);
     }
 
     function testDeregisterOperatorWithCoordinator_IncorrectQuorums_Reverts() public {
@@ -388,7 +388,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
         cheats.expectRevert("BLSRegistryCoordinatorWithIndices._deregisterOperatorWithCoordinator: operator is not registered for any of the provided quorums");
         cheats.prank(defaultOperator);
-        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbers, defaultPubKey, new bytes32[](0));
+        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbers, defaultPubKey);
     }
 
     function testDeregisterOperatorWithCoordinatorForSingleQuorumAndSingleOperator_Valid() public {
@@ -408,9 +408,6 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
         uint256 quorumBitmap = BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers);
 
-        bytes32[] memory operatorIdsToSwap = new bytes32[](1);
-        operatorIdsToSwap[0] = defaultOperatorId;
-
         cheats.expectEmit(true, true, true, true, address(blsPubkeyRegistry));
         emit OperatorRemovedFromQuorums(defaultOperator, quorumNumbers);
         cheats.expectEmit(true, true, true, true, address(stakeRegistry));
@@ -419,7 +416,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         cheats.roll(deregistrationBlockNumber);
 
         uint256 gasBefore = gasleft();
-        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbers, defaultPubKey, operatorIdsToSwap);
+        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbers, defaultPubKey);
         uint256 gasAfter = gasleft();
         emit log_named_uint("gasUsed", gasBefore - gasAfter);
 
@@ -459,11 +456,6 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         
         registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, defaultPubKey, defaultSocket);
 
-        bytes32[] memory operatorIdsToSwap = new bytes32[](quorumNumbers.length);
-        for (uint i = 0; i < operatorIdsToSwap.length; i++) {
-            operatorIdsToSwap[i] = defaultOperatorId;
-        }
-
         cheats.expectEmit(true, true, true, true, address(blsPubkeyRegistry));
         emit OperatorRemovedFromQuorums(defaultOperator, quorumNumbers);
         for (uint i = 0; i < quorumNumbers.length; i++) {
@@ -474,7 +466,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         cheats.roll(deregistrationBlockNumber);
 
         uint256 gasBefore = gasleft();
-        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbers, defaultPubKey, operatorIdsToSwap);
+        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbers, defaultPubKey);
         uint256 gasAfter = gasleft();
         emit log_named_uint("gasUsed", gasBefore - gasAfter);
         emit log_named_uint("numQuorums", quorumNumbers.length);
@@ -548,18 +540,10 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
             emit StakeUpdate(operatorToDerigisterId, uint8(operatorToDeregisterQuorumNumbers[i]), 0);
         }
 
-        // expect events from the index registry
-        for (uint i = 0; i < operatorToDeregisterQuorumNumbers.length; i++) {
-            if(operatorIdsToSwap[i] != operatorToDerigisterId) {
-                cheats.expectEmit(true, true, false, false, address(indexRegistry));
-                emit QuorumIndexUpdate(operatorIdsToSwap[i], uint8(operatorToDeregisterQuorumNumbers[i]), 0);
-            }
-        }
-
         cheats.roll(deregistrationBlockNumber);
 
         cheats.prank(operatorToDerigister);
-        registryCoordinator.deregisterOperatorWithCoordinator(operatorToDeregisterQuorumNumbers, operatorToDeregisterPubKey, operatorIdsToSwap);
+        registryCoordinator.deregisterOperatorWithCoordinator(operatorToDeregisterQuorumNumbers, operatorToDeregisterPubKey);
 
         assertEq(
             keccak256(abi.encode(registryCoordinator.getOperator(operatorToDerigister))), 
@@ -827,10 +811,6 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         cheats.prank(defaultOperator);
         registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, defaultPubKey, defaultSocket);
 
-        // operator is the only one registered so they are the one with the largest index
-        bytes32[] memory operatorIdsToSwap = new bytes32[](1);
-        operatorIdsToSwap[0] = defaultOperatorId;
-
         cheats.expectEmit(true, true, true, true, address(blsPubkeyRegistry));
         emit OperatorRemovedFromQuorums(defaultOperator, quorumNumbers);
 
@@ -839,7 +819,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
         // eject
         cheats.prank(ejector);
-        registryCoordinator.ejectOperatorFromCoordinator(defaultOperator, quorumNumbers, defaultPubKey, operatorIdsToSwap);
+        registryCoordinator.ejectOperatorFromCoordinator(defaultOperator, quorumNumbers, defaultPubKey);
         
         // make sure the operator is deregistered
         assertEq(
@@ -870,10 +850,6 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         bytes memory quorumNumbersToEject = new bytes(1);
         quorumNumbersToEject[0] = quorumNumbers[0];
 
-        // operator is the only one registered so they are the one with the largest index
-        bytes32[] memory operatorIdsToSwap = new bytes32[](1);
-        operatorIdsToSwap[0] = defaultOperatorId;
-
         cheats.expectEmit(true, true, true, true, address(blsPubkeyRegistry));
         emit OperatorRemovedFromQuorums(defaultOperator, quorumNumbersToEject);
 
@@ -881,7 +857,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         emit StakeUpdate(defaultOperatorId, uint8(quorumNumbersToEject[0]), 0);
 
         cheats.prank(ejector);
-        registryCoordinator.ejectOperatorFromCoordinator(defaultOperator, quorumNumbersToEject, defaultPubKey, operatorIdsToSwap);
+        registryCoordinator.ejectOperatorFromCoordinator(defaultOperator, quorumNumbersToEject, defaultPubKey);
         
         // make sure the operator is registered
         assertEq(
@@ -906,13 +882,10 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
         cheats.prank(defaultOperator);
         registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, defaultPubKey, defaultSocket);
-
-        bytes32[] memory operatorIdsToSwap = new bytes32[](1);
-        operatorIdsToSwap[0] = defaultOperatorId;
-
+        
         cheats.expectRevert("BLSRegistryCoordinatorWithIndices.onlyEjector: caller is not the ejector");
         cheats.prank(defaultOperator);
-        registryCoordinator.ejectOperatorFromCoordinator(defaultOperator, quorumNumbers, defaultPubKey, operatorIdsToSwap);
+        registryCoordinator.ejectOperatorFromCoordinator(defaultOperator, quorumNumbers, defaultPubKey);
     }
 
     function testUpdateSocket() public {

--- a/test/unit/IndexRegistryUnit.t.sol
+++ b/test/unit/IndexRegistryUnit.t.sol
@@ -60,20 +60,11 @@ contract IndexRegistryUnitTests is Test {
         );
         require(numOperatorsPerQuorum[0] == 1, "IndexRegistry.registerOperator: numOperatorsPerQuorum[0] not 1");
 
-        // Check globalOperatorList updates
-        require(
-            indexRegistry.globalOperatorList(0) == operatorId1,
-            "IndexRegistry.registerOperator: operator not appened to globalOperatorList"
-        );
-        require(
-            indexRegistry.getGlobalOperatorListLength() == 1,
-            "IndexRegistry.registerOperator: globalOperatorList length incorrect"
-        );
 
         // Check _operatorIdToIndexHistory updates
         IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
             .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 0, quorumNumber: 1, index: 0});
-        require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: index not 0");
+        require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: operatorId not operatorId1");
         require(
             operatorUpdate.fromBlockNumber == block.number,
             "IndexRegistry.registerOperator: fromBlockNumber not correct"
@@ -115,20 +106,10 @@ contract IndexRegistryUnitTests is Test {
         );
         require(numOperatorsPerQuorum[0] == 1, "IndexRegistry.registerOperator: numOperatorsPerQuorum[1] not 1");
 
-        // Check globalOperatorList updates
-        require(
-            indexRegistry.globalOperatorList(1) == operatorId1,
-            "IndexRegistry.registerOperator: operator not appened to globalOperatorList"
-        );
-        require(
-            indexRegistry.getGlobalOperatorListLength() == 2,
-            "IndexRegistry.registerOperator: globalOperatorList length incorrect"
-        );
-
         // Check _operatorIdToIndexHistory updates
         IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
             .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 0, quorumNumber: 2, index: 0});
-        require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: index not 0");
+        require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: operatorId not operatorId1");
         require(
             operatorUpdate.fromBlockNumber == block.number,
             "IndexRegistry.registerOperator: fromBlockNumber not correct"
@@ -168,20 +149,10 @@ contract IndexRegistryUnitTests is Test {
         require(numOperatorsPerQuorum[0] == 1, "IndexRegistry.registerOperator: numOperatorsPerQuorum[0] not 1");
         require(numOperatorsPerQuorum[1] == 1, "IndexRegistry.registerOperator: numOperatorsPerQuorum[1] not 1");
 
-        // Check globalOperatorList updates
-        require(
-            indexRegistry.globalOperatorList(0) == operatorId1,
-            "IndexRegistry.registerOperator: operator not appened to globalOperatorList"
-        );
-        require(
-            indexRegistry.getGlobalOperatorListLength() == 1,
-            "IndexRegistry.registerOperator: globalOperatorList length incorrect"
-        );
-
         // Check _operatorIdToIndexHistory updates for quorum 1
         IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
             .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 0, quorumNumber: 1, index: 0});
-        require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: index not 0");
+        require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: operatorId not 1operatorId1");
         require(
             operatorUpdate.fromBlockNumber == block.number,
             "IndexRegistry.registerOperator: fromBlockNumber not correct"
@@ -204,8 +175,8 @@ contract IndexRegistryUnitTests is Test {
         );
 
         // Check _operatorIdToIndexHistory updates for quorum 2
-        operatorUpdate = indexRegistry.getOperatorUpdateOfOperatorIdForQuorumAtIndex(operatorId1, 2, 0);
-        require(operatorUpdate.index == 0, "IndexRegistry.registerOperator: index not 0");
+        operatorUpdate = indexRegistry.getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 0 , quorumNumber: 2, index: 0});
+        require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: operatorId not operatorId1");
         require(
             operatorUpdate.fromBlockNumber == block.number,
             "IndexRegistry.registerOperator: fromBlockNumber not correct"
@@ -245,22 +216,12 @@ contract IndexRegistryUnitTests is Test {
         );
         require(numOperatorsPerQuorum[0] == 2, "IndexRegistry.registerOperator: numOperatorsPerQuorum[0] not 2");
 
-        // Check globalOperatorList updates
-        require(
-            indexRegistry.globalOperatorList(1) == operatorId2,
-            "IndexRegistry.registerOperator: operator not appened to globalOperatorList"
-        );
-        require(
-            indexRegistry.getGlobalOperatorListLength() == 2,
-            "IndexRegistry.registerOperator: globalOperatorList length incorrect"
-        );
-
         // Check _operatorIdToIndexHistory updates
-        IIndexRegistry.OperatorUpdate memory indexUpdate = indexRegistry
-            .getOperatorUpdateOfOperatorIdForQuorumAtIndex(operatorId2, 1, 0);
-        require(indexUpdate.index == 1, "IndexRegistry.registerOperator: index not 1");
+        IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
+            .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 1, quorumNumber: 1, index: 0});
+        require(operatorUpdate.operatorId == operatorId2, "IndexRegistry.registerOperator: operatorId not operatorId2");
         require(
-            indexUpdate.fromBlockNumber == block.number,
+            operatorUpdate.fromBlockNumber == block.number,
             "IndexRegistry.registerOperator: fromBlockNumber not correct"
         );
 
@@ -285,18 +246,6 @@ contract IndexRegistryUnitTests is Test {
                             UNIT TESTS - DEREGISTRATION
     *******************************************************************************/
 
-    function testDeregisterOperatorRevertMismatchInputLengths() public {
-        bytes memory quorumNumbers = new bytes(1);
-        bytes32[] memory operatorIdsToSwap = new bytes32[](2);
-
-        //deregister the operatorId1, removing it from both quorum 1 and 2.
-        cheats.prank(address(registryCoordinatorMock));
-        cheats.expectRevert(
-            bytes("IndexRegistry.deregisterOperator: quorumNumbers and operatorIdsToSwap must be the same length")
-        );
-        indexRegistry.deregisterOperator(operatorId1, quorumNumbers, operatorIdsToSwap);
-    }
-
     function testDeregisterOperatorSingleOperator() public {
         // Register operator
         bytes memory quorumNumbers = new bytes(1);
@@ -304,16 +253,14 @@ contract IndexRegistryUnitTests is Test {
         _registerOperator(operatorId1, quorumNumbers);
 
         // Deregister operator
-        bytes32[] memory operatorIdsToSwap = new bytes32[](1);
-        operatorIdsToSwap[0] = operatorId1;
         cheats.prank(address(registryCoordinatorMock));
-        indexRegistry.deregisterOperator(operatorId1, quorumNumbers, operatorIdsToSwap);
+        indexRegistry.deregisterOperator(operatorId1, quorumNumbers);
 
         // Check operator's index
-        IIndexRegistry.OperatorUpdate memory indexUpdate = indexRegistry
-            .getOperatorUpdateOfOperatorIdForQuorumAtIndex(operatorId1, defaultQuorumNumber, 1);
-        require(indexUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
-        require(indexUpdate.index == type(uint32).max, "incorrect index");
+        IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
+            .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 0, quorumNumber: defaultQuorumNumber, index: 1});
+        require(operatorUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
+        require(operatorUpdate.operatorId == bytes32(0), "incorrect operatorId");
 
         // Check total operators
         IIndexRegistry.QuorumUpdate memory quorumUpdate = indexRegistry
@@ -321,25 +268,6 @@ contract IndexRegistryUnitTests is Test {
         require(quorumUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
         require(quorumUpdate.numOperators == 0, "incorrect total number of operators");
         require(indexRegistry.totalOperatorsForQuorum(1) == 0, "operator not deregistered correctly");
-    }
-
-    function testDeregisterOperatorRevertIncorrectOperatorToSwap() public {
-        // Register 3 operators
-        bytes memory quorumNumbers = new bytes(1);
-        quorumNumbers[0] = bytes1(defaultQuorumNumber);
-        _registerOperator(operatorId1, quorumNumbers);
-        _registerOperator(operatorId2, quorumNumbers);
-        _registerOperator(operatorId3, quorumNumbers);
-
-        bytes32[] memory operatorIdsToSwap = new bytes32[](1);
-        operatorIdsToSwap[0] = operatorId2;
-
-        //deregister the operatorId1, removing it from both quorum 1 and 2.
-        cheats.prank(address(registryCoordinatorMock));
-        cheats.expectRevert(
-            bytes("IndexRegistry._processOperatorRemoval: operatorIdToSwap is not the last operator in the quorum")
-        );
-        indexRegistry.deregisterOperator(operatorId1, quorumNumbers, operatorIdsToSwap);
     }
 
     function testDeregisterOperatorMultipleQuorums() public {
@@ -356,19 +284,16 @@ contract IndexRegistryUnitTests is Test {
         bytes memory quorumsToRemove = new bytes(2);
         quorumsToRemove[0] = bytes1(defaultQuorumNumber);
         quorumsToRemove[1] = bytes1(defaultQuorumNumber + 1);
-        bytes32[] memory operatorIdsToSwap = new bytes32[](2);
-        operatorIdsToSwap[0] = operatorId3;
-        operatorIdsToSwap[1] = operatorId3;
 
         cheats.prank(address(registryCoordinatorMock));
-        indexRegistry.deregisterOperator(operatorId1, quorumsToRemove, operatorIdsToSwap);
+        indexRegistry.deregisterOperator(operatorId1, quorumsToRemove);
 
         // Check operator's index for removed quorums
         for (uint256 i = 0; i < quorumsToRemove.length; i++) {
-            IIndexRegistry.OperatorUpdate memory indexUpdate = indexRegistry
-                .getOperatorUpdateOfOperatorIdForQuorumAtIndex(operatorId1, uint8(quorumsToRemove[i]), 1); // 2 indexes -> 1 update and 1 remove
-            require(indexUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
-            require(indexUpdate.index == type(uint32).max, "incorrect index");
+            IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
+                .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 2, quorumNumber: uint8(quorumsToRemove[i]), index: 1}); // 2 indexes -> 1 update and 1 remove
+            require(operatorUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
+            require(operatorUpdate.operatorId == bytes32(0), "incorrect operatorId");
         }
 
         // Check total operators for removed quorums
@@ -385,95 +310,16 @@ contract IndexRegistryUnitTests is Test {
 
         // Check swapped operator's index for removed quorums
         for (uint256 i = 0; i < quorumsToRemove.length; i++) {
-            IIndexRegistry.OperatorUpdate memory indexUpdate = indexRegistry
-                .getOperatorUpdateOfOperatorIdForQuorumAtIndex(operatorId3, uint8(quorumsToRemove[i]), 1); // 2 indexes -> 1 update and 1 swap
-            require(indexUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
-            require(indexUpdate.index == 0, "incorrect index");
+            IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
+                .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 0, quorumNumber: uint8(quorumsToRemove[i]), index: 1}); // 2 indexes -> 1 update and 1 swap
+            require(operatorUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
+            require(operatorUpdate.operatorId == operatorId3, "incorrect operatorId");
         }
     }
 
     /*******************************************************************************
                                 UNIT TESTS - GETTERS
     *******************************************************************************/
-
-    function testGetOperatorIndexForQuorumAtBlockNumberByIndex_revert_earlyBlockNumber() public {
-        bytes memory quorumNumbers = new bytes(1);
-        quorumNumbers[0] = bytes1(defaultQuorumNumber);
-        _registerOperator(operatorId1, quorumNumbers);
-        cheats.expectRevert(
-            bytes(
-                "IndexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex: provided index is too far in the past for provided block number"
-            )
-        );
-        indexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex(
-            operatorId1,
-            defaultQuorumNumber,
-            uint32(block.number - 1),
-            0
-        );
-    }
-
-    function testGetOperatorIndexForQuorumAtBlockNumberByIndex_revert_indexBlockMismatch() public {
-        // Register operator for first quorum
-        bytes memory quorumNumbers = new bytes(1);
-        quorumNumbers[0] = bytes1(defaultQuorumNumber);
-        _registerOperator(operatorId1, quorumNumbers);
-
-        // Deregister operator from first quorum
-        vm.roll(block.number + 10);
-        bytes32[] memory operatorIdsToSwap = new bytes32[](1);
-        operatorIdsToSwap[0] = operatorId1;
-        cheats.prank(address(registryCoordinatorMock));
-        indexRegistry.deregisterOperator(operatorId1, quorumNumbers, operatorIdsToSwap);
-
-        // Fails due to block number corresponding to a later index (from the deregistration)
-        cheats.expectRevert(
-            bytes(
-                "IndexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex: provided index is too far in the future for provided block number"
-            )
-        );
-        indexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex(
-            operatorId1,
-            defaultQuorumNumber,
-            uint32(block.number),
-            0
-        );
-    }
-
-    function testGetOperatorIndexForQuorumAtBlockNumberByIndex() public {
-        // Register operator for first quorum
-        bytes memory quorumNumbers = new bytes(1);
-        quorumNumbers[0] = bytes1(defaultQuorumNumber);
-        _registerOperator(operatorId1, quorumNumbers);
-
-        // Deregister operator from first quorum
-        vm.roll(block.number + 10);
-        bytes32[] memory operatorIdsToSwap = new bytes32[](1);
-        operatorIdsToSwap[0] = operatorId1;
-        cheats.prank(address(registryCoordinatorMock));
-        indexRegistry.deregisterOperator(operatorId1, quorumNumbers, operatorIdsToSwap);
-
-        // Check that the first index is correct
-        uint32 firstIndex = indexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex(
-            operatorId1,
-            defaultQuorumNumber,
-            uint32(block.number - 10),
-            0
-        );
-        require(firstIndex == 0, "IndexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex: first index not 0");
-
-        // Check that the index is correct
-        uint32 index = indexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex(
-            operatorId1,
-            defaultQuorumNumber,
-            uint32(block.number),
-            1
-        );
-        require(
-            index == type(uint32).max,
-            "IndexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex: second index not deregistered"
-        );
-    }
 
     function testGetTotalOperatorsForQuorumAtBlockNumberByIndex_revert_indexTooEarly() public {
         // Add operator
@@ -536,10 +382,8 @@ contract IndexRegistryUnitTests is Test {
 
         // Deregister first operator
         vm.roll(block.number + 10);
-        bytes32[] memory operatorIdsToSwap = new bytes32[](1);
-        operatorIdsToSwap[0] = operatorId2;
         cheats.prank(address(registryCoordinatorMock));
-        indexRegistry.deregisterOperator(operatorId1, quorumNumbers, operatorIdsToSwap);
+        indexRegistry.deregisterOperator(operatorId1, quorumNumbers);
 
         // Check the operator list after first registration
         bytes32[] memory operatorList = indexRegistry.getOperatorListForQuorumAtBlockNumber(
@@ -638,27 +482,17 @@ contract IndexRegistryUnitTests is Test {
             require(numOperatorsPerQuorum[i] == 1, "IndexRegistry.registerOperator: numOperatorsPerQuorum not 1");
         }
 
-        // Check globalOperatorList updates
-        require(
-            indexRegistry.globalOperatorList(0) == operatorId1,
-            "IndexRegistry.registerOperator: operator not appened to globalOperatorList"
-        );
-        require(
-            indexRegistry.getGlobalOperatorListLength() == 1,
-            "IndexRegistry.registerOperator: globalOperatorList length incorrect"
-        );
-
         // Check _operatorIdToIndexHistory updates
-        IIndexRegistry.OperatorUpdate memory indexUpdate;
+        IIndexRegistry.OperatorUpdate memory operatorUpdate;
         for (uint256 i = 0; i < quorumNumbers.length; i++) {
-            indexUpdate = indexRegistry.getOperatorUpdateOfOperatorIdForQuorumAtIndex(
-                operatorId1,
-                uint8(quorumNumbers[i]),
-                0
-            );
-            require(indexUpdate.index == 0, "IndexRegistry.registerOperator: index not 0");
+            operatorUpdate = indexRegistry.getOperatorIndexUpdateOfIndexForQuorumAtIndex({
+                operatorIndex: 0,
+                quorumNumber: uint8(quorumNumbers[i]),
+                index: 0
+            });
+            require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: operatorId not operatorId1");
             require(
-                indexUpdate.fromBlockNumber == block.number,
+                operatorUpdate.fromBlockNumber == block.number,
                 "IndexRegistry.registerOperator: fromBlockNumber not correct"
             );
         }
@@ -696,12 +530,6 @@ contract IndexRegistryUnitTests is Test {
         vm.roll(block.number + 10);
         _registerOperator(operatorId3, quorumNumbers);
 
-        // Check globalOperatorList updates
-        require(
-            indexRegistry.getGlobalOperatorListLength() == 3,
-            "IndexRegistry.registerOperator: globalOperatorList length incorrect"
-        );
-
         // Check history of _totalOperatorsHistory updates at each blockNumber
         IIndexRegistry.QuorumUpdate memory quorumUpdate;
         uint256 numOperators = 1;
@@ -728,11 +556,10 @@ contract IndexRegistryUnitTests is Test {
         cheats.assume(address(registryCoordinatorMock) != nonRegistryCoordinator);
         // de-register an operator
         bytes memory quorumNumbers = new bytes(defaultQuorumNumber);
-        bytes32[] memory operatorIdsToSwap = new bytes32[](1);
 
         cheats.prank(nonRegistryCoordinator);
         cheats.expectRevert(bytes("IndexRegistry.onlyRegistryCoordinator: caller is not the registry coordinator"));
-        indexRegistry.deregisterOperator(bytes32(0), quorumNumbers, operatorIdsToSwap);
+        indexRegistry.deregisterOperator(bytes32(0), quorumNumbers);
     }
 
     function testFuzzDeregisterOperator(bytes memory quorumsToAdd, uint256 bitsToFlip) public {
@@ -764,19 +591,15 @@ contract IndexRegistryUnitTests is Test {
         _registerOperator(operatorId2, quorumsToAdd);
 
         // Deregister operator
-        bytes32[] memory operatorIdsToSwap = new bytes32[](quorumsToRemove.length);
-        for (uint256 i = 0; i < quorumsToRemove.length; i++) {
-            operatorIdsToSwap[i] = operatorId2;
-        }
         cheats.prank(address(registryCoordinatorMock));
-        indexRegistry.deregisterOperator(operatorId1, quorumsToRemove, operatorIdsToSwap);
+        indexRegistry.deregisterOperator(operatorId1, quorumsToRemove);
 
         // Check operator's index for removed quorums
         for (uint256 i = 0; i < quorumsToRemove.length; i++) {
-            IIndexRegistry.OperatorUpdate memory indexUpdate = indexRegistry
-                .getOperatorUpdateOfOperatorIdForQuorumAtIndex(operatorId1, uint8(quorumsToRemove[i]), 1); // 2 indexes -> 1 update and 1 remove
-            require(indexUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
-            require(indexUpdate.index == type(uint32).max, "incorrect index");
+            IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
+                .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 1, quorumNumber: uint8(quorumsToRemove[i]), index: 1}); // 2 indexes -> 1 update and 1 remove
+            require(operatorUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
+            require(operatorUpdate.operatorId == bytes32(0), "incorrect operatorId");
         }
 
         // Check total operators for removed quorums
@@ -793,10 +616,10 @@ contract IndexRegistryUnitTests is Test {
 
         // Check swapped operator's index for removed quorums
         for (uint256 i = 0; i < quorumsToRemove.length; i++) {
-            IIndexRegistry.OperatorUpdate memory indexUpdate = indexRegistry
-                .getOperatorUpdateOfOperatorIdForQuorumAtIndex(operatorId2, uint8(quorumsToRemove[i]), 1); // 2 indexes -> 1 update and 1 swap
-            require(indexUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
-            require(indexUpdate.index == 0, "incorrect index");
+            IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
+                .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 0, quorumNumber: uint8(quorumsToRemove[i]), index: 1}); // 2 indexes -> 1 update and 1 swap
+            require(operatorUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
+            require(operatorUpdate.operatorId == operatorId2, "incorrect operatorId");
         }
     }
 

--- a/test/unit/IndexRegistryUnit.t.sol
+++ b/test/unit/IndexRegistryUnit.t.sol
@@ -71,11 +71,11 @@ contract IndexRegistryUnitTests is Test {
         );
 
         // Check _operatorIdToIndexHistory updates
-        IIndexRegistry.OperatorIndexUpdate memory indexUpdate = indexRegistry
-            .getOperatorIndexUpdateOfOperatorIdForQuorumAtIndex(operatorId1, 1, 0);
-        require(indexUpdate.index == 0, "IndexRegistry.registerOperator: index not 0");
+        IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
+            .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 0, quorumNumber: 1, index: 0});
+        require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: index not 0");
         require(
-            indexUpdate.fromBlockNumber == block.number,
+            operatorUpdate.fromBlockNumber == block.number,
             "IndexRegistry.registerOperator: fromBlockNumber not correct"
         );
 
@@ -126,11 +126,11 @@ contract IndexRegistryUnitTests is Test {
         );
 
         // Check _operatorIdToIndexHistory updates
-        IIndexRegistry.OperatorIndexUpdate memory indexUpdate = indexRegistry
-            .getOperatorIndexUpdateOfOperatorIdForQuorumAtIndex(operatorId1, 2, 0);
-        require(indexUpdate.index == 0, "IndexRegistry.registerOperator: index not 0");
+        IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
+            .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 0, quorumNumber: 2, index: 0});
+        require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: index not 0");
         require(
-            indexUpdate.fromBlockNumber == block.number,
+            operatorUpdate.fromBlockNumber == block.number,
             "IndexRegistry.registerOperator: fromBlockNumber not correct"
         );
 
@@ -179,11 +179,11 @@ contract IndexRegistryUnitTests is Test {
         );
 
         // Check _operatorIdToIndexHistory updates for quorum 1
-        IIndexRegistry.OperatorIndexUpdate memory indexUpdate = indexRegistry
-            .getOperatorIndexUpdateOfOperatorIdForQuorumAtIndex(operatorId1, 1, 0);
-        require(indexUpdate.index == 0, "IndexRegistry.registerOperator: index not 0");
+        IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
+            .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 0, quorumNumber: 1, index: 0});
+        require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: index not 0");
         require(
-            indexUpdate.fromBlockNumber == block.number,
+            operatorUpdate.fromBlockNumber == block.number,
             "IndexRegistry.registerOperator: fromBlockNumber not correct"
         );
 
@@ -204,10 +204,10 @@ contract IndexRegistryUnitTests is Test {
         );
 
         // Check _operatorIdToIndexHistory updates for quorum 2
-        indexUpdate = indexRegistry.getOperatorIndexUpdateOfOperatorIdForQuorumAtIndex(operatorId1, 2, 0);
-        require(indexUpdate.index == 0, "IndexRegistry.registerOperator: index not 0");
+        operatorUpdate = indexRegistry.getOperatorUpdateOfOperatorIdForQuorumAtIndex(operatorId1, 2, 0);
+        require(operatorUpdate.index == 0, "IndexRegistry.registerOperator: index not 0");
         require(
-            indexUpdate.fromBlockNumber == block.number,
+            operatorUpdate.fromBlockNumber == block.number,
             "IndexRegistry.registerOperator: fromBlockNumber not correct"
         );
 
@@ -256,8 +256,8 @@ contract IndexRegistryUnitTests is Test {
         );
 
         // Check _operatorIdToIndexHistory updates
-        IIndexRegistry.OperatorIndexUpdate memory indexUpdate = indexRegistry
-            .getOperatorIndexUpdateOfOperatorIdForQuorumAtIndex(operatorId2, 1, 0);
+        IIndexRegistry.OperatorUpdate memory indexUpdate = indexRegistry
+            .getOperatorUpdateOfOperatorIdForQuorumAtIndex(operatorId2, 1, 0);
         require(indexUpdate.index == 1, "IndexRegistry.registerOperator: index not 1");
         require(
             indexUpdate.fromBlockNumber == block.number,
@@ -310,8 +310,8 @@ contract IndexRegistryUnitTests is Test {
         indexRegistry.deregisterOperator(operatorId1, quorumNumbers, operatorIdsToSwap);
 
         // Check operator's index
-        IIndexRegistry.OperatorIndexUpdate memory indexUpdate = indexRegistry
-            .getOperatorIndexUpdateOfOperatorIdForQuorumAtIndex(operatorId1, defaultQuorumNumber, 1);
+        IIndexRegistry.OperatorUpdate memory indexUpdate = indexRegistry
+            .getOperatorUpdateOfOperatorIdForQuorumAtIndex(operatorId1, defaultQuorumNumber, 1);
         require(indexUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
         require(indexUpdate.index == type(uint32).max, "incorrect index");
 
@@ -365,8 +365,8 @@ contract IndexRegistryUnitTests is Test {
 
         // Check operator's index for removed quorums
         for (uint256 i = 0; i < quorumsToRemove.length; i++) {
-            IIndexRegistry.OperatorIndexUpdate memory indexUpdate = indexRegistry
-                .getOperatorIndexUpdateOfOperatorIdForQuorumAtIndex(operatorId1, uint8(quorumsToRemove[i]), 1); // 2 indexes -> 1 update and 1 remove
+            IIndexRegistry.OperatorUpdate memory indexUpdate = indexRegistry
+                .getOperatorUpdateOfOperatorIdForQuorumAtIndex(operatorId1, uint8(quorumsToRemove[i]), 1); // 2 indexes -> 1 update and 1 remove
             require(indexUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
             require(indexUpdate.index == type(uint32).max, "incorrect index");
         }
@@ -385,8 +385,8 @@ contract IndexRegistryUnitTests is Test {
 
         // Check swapped operator's index for removed quorums
         for (uint256 i = 0; i < quorumsToRemove.length; i++) {
-            IIndexRegistry.OperatorIndexUpdate memory indexUpdate = indexRegistry
-                .getOperatorIndexUpdateOfOperatorIdForQuorumAtIndex(operatorId3, uint8(quorumsToRemove[i]), 1); // 2 indexes -> 1 update and 1 swap
+            IIndexRegistry.OperatorUpdate memory indexUpdate = indexRegistry
+                .getOperatorUpdateOfOperatorIdForQuorumAtIndex(operatorId3, uint8(quorumsToRemove[i]), 1); // 2 indexes -> 1 update and 1 swap
             require(indexUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
             require(indexUpdate.index == 0, "incorrect index");
         }
@@ -649,9 +649,9 @@ contract IndexRegistryUnitTests is Test {
         );
 
         // Check _operatorIdToIndexHistory updates
-        IIndexRegistry.OperatorIndexUpdate memory indexUpdate;
+        IIndexRegistry.OperatorUpdate memory indexUpdate;
         for (uint256 i = 0; i < quorumNumbers.length; i++) {
-            indexUpdate = indexRegistry.getOperatorIndexUpdateOfOperatorIdForQuorumAtIndex(
+            indexUpdate = indexRegistry.getOperatorUpdateOfOperatorIdForQuorumAtIndex(
                 operatorId1,
                 uint8(quorumNumbers[i]),
                 0
@@ -773,8 +773,8 @@ contract IndexRegistryUnitTests is Test {
 
         // Check operator's index for removed quorums
         for (uint256 i = 0; i < quorumsToRemove.length; i++) {
-            IIndexRegistry.OperatorIndexUpdate memory indexUpdate = indexRegistry
-                .getOperatorIndexUpdateOfOperatorIdForQuorumAtIndex(operatorId1, uint8(quorumsToRemove[i]), 1); // 2 indexes -> 1 update and 1 remove
+            IIndexRegistry.OperatorUpdate memory indexUpdate = indexRegistry
+                .getOperatorUpdateOfOperatorIdForQuorumAtIndex(operatorId1, uint8(quorumsToRemove[i]), 1); // 2 indexes -> 1 update and 1 remove
             require(indexUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
             require(indexUpdate.index == type(uint32).max, "incorrect index");
         }
@@ -793,8 +793,8 @@ contract IndexRegistryUnitTests is Test {
 
         // Check swapped operator's index for removed quorums
         for (uint256 i = 0; i < quorumsToRemove.length; i++) {
-            IIndexRegistry.OperatorIndexUpdate memory indexUpdate = indexRegistry
-                .getOperatorIndexUpdateOfOperatorIdForQuorumAtIndex(operatorId2, uint8(quorumsToRemove[i]), 1); // 2 indexes -> 1 update and 1 swap
+            IIndexRegistry.OperatorUpdate memory indexUpdate = indexRegistry
+                .getOperatorUpdateOfOperatorIdForQuorumAtIndex(operatorId2, uint8(quorumsToRemove[i]), 1); // 2 indexes -> 1 update and 1 swap
             require(indexUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
             require(indexUpdate.index == 0, "incorrect index");
         }


### PR DESCRIPTION
Simplify index registry.

The aim to to get rid of the operators to swap param.

Some downsides: 
- operatorUpdate is now 2 storage slots
- new map for current operator index for quorums

However, the global operator list is removed, so that reduces a fair amount of storage