### PR TITLE
Gas Analysis: StakeRegistry.updateStakes() setup as a cronjob

### DIFF
--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -540,6 +540,7 @@ contract StakeRegistryUnitTests is Test {
         }
     }
 
+    /// forge-config: default.fuzz.runs = 5
     function testUpdateStakes_200Operators(
         address[200] calldata operators,
         uint256[200] calldata pseudoRandomNumbers


### PR DESCRIPTION
Description: 
We want to get some gas cost estimates for performing a weekly running cronjob that performs stake updates for 
operators. Assuming ~200 operators, and varying quorums, this action would probably have to be batched into multiple update calls.