### PR TITLE
refactor: simplify naming and logic in registries and registry coordinator

### DIFF
--- a/src/BLSOperatorStateRetriever.sol
+++ b/src/BLSOperatorStateRetriever.sol
@@ -76,7 +76,7 @@ contract BLSOperatorStateRetriever {
                 bytes32 operatorId = bytes32(operatorIds[j]);
                 operators[i][j] = Operator({
                     operatorId: operatorId,
-                    stake: stakeRegistry.getStakeForOperatorIdForQuorumAtBlockNumber(operatorId, quorumNumber, blockNumber)
+                    stake: stakeRegistry.getOperatorStakeAtBlockNumber(operatorId, quorumNumber, blockNumber)
                 });
             }
         }
@@ -110,7 +110,7 @@ contract BLSOperatorStateRetriever {
         // get the indices of the quorumBitmap updates for each of the operators in the nonSignerOperatorIds array
         checkSignaturesIndices.nonSignerQuorumBitmapIndices = registryCoordinator.getQuorumBitmapIndicesAtBlockNumber(referenceBlockNumber, nonSignerOperatorIds);
         // get the indices of the totalStake updates for each of the quorums in the quorumNumbers array
-        checkSignaturesIndices.totalStakeIndices = stakeRegistry.getTotalStakeIndicesByQuorumNumbersAtBlockNumber(referenceBlockNumber, quorumNumbers);
+        checkSignaturesIndices.totalStakeIndices = stakeRegistry.getTotalStakeIndicesAtBlockNumber(referenceBlockNumber, quorumNumbers);
         
         checkSignaturesIndices.nonSignerStakeIndices = new uint32[][](quorumNumbers.length);
         for (uint8 quorumNumberIndex = 0; quorumNumberIndex < quorumNumbers.length; quorumNumberIndex++) {
@@ -130,7 +130,7 @@ contract BLSOperatorStateRetriever {
                 // if the operator was a part of the quorum and the quorum is a part of the provided quorumNumbers
                 if ((nonSignerQuorumBitmap >> uint8(quorumNumbers[quorumNumberIndex])) & 1 == 1) {
                     // get the index of the stake update for the operator at the given blocknumber and quorum number
-                    checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex][numNonSignersForQuorum] = stakeRegistry.getStakeUpdateIndexForOperatorIdForQuorumAtBlockNumber(
+                    checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex][numNonSignersForQuorum] = stakeRegistry.getStakeUpdateIndexForOperatorAtBlockNumber(
                         nonSignerOperatorIds[i],
                         uint8(quorumNumbers[quorumNumberIndex]),
                         referenceBlockNumber

--- a/src/BLSOperatorStateRetriever.sol
+++ b/src/BLSOperatorStateRetriever.sol
@@ -70,7 +70,7 @@ contract BLSOperatorStateRetriever {
         Operator[][] memory operators = new Operator[][](quorumNumbers.length);
         for (uint256 i = 0; i < quorumNumbers.length; i++) {
             uint8 quorumNumber = uint8(quorumNumbers[i]);
-            bytes32[] memory operatorIds = indexRegistry.getOperatorListForQuorumAtBlockNumber(quorumNumber, blockNumber);
+            bytes32[] memory operatorIds = indexRegistry.getOperatorListAtBlockNumber(quorumNumber, blockNumber);
             operators[i] = new Operator[](operatorIds.length);
             for (uint256 j = 0; j < operatorIds.length; j++) {
                 bytes32 operatorId = bytes32(operatorIds[j]);

--- a/src/BLSOperatorStateRetriever.sol
+++ b/src/BLSOperatorStateRetriever.sol
@@ -42,9 +42,9 @@ contract BLSOperatorStateRetriever {
     ) external view returns (uint256, Operator[][] memory) {
         bytes32[] memory operatorIds = new bytes32[](1);
         operatorIds[0] = operatorId;
-        uint256 index = registryCoordinator.getQuorumBitmapIndicesByOperatorIdsAtBlockNumber(blockNumber, operatorIds)[0];
+        uint256 index = registryCoordinator.getQuorumBitmapIndicesAtBlockNumber(blockNumber, operatorIds)[0];
     
-        uint256 quorumBitmap = registryCoordinator.getQuorumBitmapByOperatorIdAtBlockNumberByIndex(operatorId, blockNumber, index);
+        uint256 quorumBitmap = registryCoordinator.getQuorumBitmapAtBlockNumberByIndex(operatorId, blockNumber, index);
 
         bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(quorumBitmap);
 
@@ -108,7 +108,7 @@ contract BLSOperatorStateRetriever {
         CheckSignaturesIndices memory checkSignaturesIndices;
 
         // get the indices of the quorumBitmap updates for each of the operators in the nonSignerOperatorIds array
-        checkSignaturesIndices.nonSignerQuorumBitmapIndices = registryCoordinator.getQuorumBitmapIndicesByOperatorIdsAtBlockNumber(referenceBlockNumber, nonSignerOperatorIds);
+        checkSignaturesIndices.nonSignerQuorumBitmapIndices = registryCoordinator.getQuorumBitmapIndicesAtBlockNumber(referenceBlockNumber, nonSignerOperatorIds);
         // get the indices of the totalStake updates for each of the quorums in the quorumNumbers array
         checkSignaturesIndices.totalStakeIndices = stakeRegistry.getTotalStakeIndicesByQuorumNumbersAtBlockNumber(referenceBlockNumber, quorumNumbers);
         
@@ -121,7 +121,7 @@ contract BLSOperatorStateRetriever {
             for (uint i = 0; i < nonSignerOperatorIds.length; i++) {
                 // get the quorumBitmap for the operator at the given blocknumber and index
                 uint192 nonSignerQuorumBitmap = 
-                    registryCoordinator.getQuorumBitmapByOperatorIdAtBlockNumberByIndex(
+                    registryCoordinator.getQuorumBitmapAtBlockNumberByIndex(
                         nonSignerOperatorIds[i], 
                         referenceBlockNumber, 
                         checkSignaturesIndices.nonSignerQuorumBitmapIndices[i]

--- a/src/BLSRegistryCoordinatorWithIndices.sol
+++ b/src/BLSRegistryCoordinatorWithIndices.sol
@@ -112,7 +112,7 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
         uint256 _initialPausedStatus,
         OperatorSetParam[] memory _operatorSetParams,
         uint96[] memory _minimumStakes,
-        IStakeRegistry.StrategyAndWeightingMultiplier[][] memory _strategyParams
+        IStakeRegistry.StrategyParams[][] memory _strategyParams
     ) external initializer {
         require(
             _operatorSetParams.length == _minimumStakes.length && _minimumStakes.length == _strategyParams.length,
@@ -307,7 +307,7 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
     function createQuorum(
         OperatorSetParam memory operatorSetParams,
         uint96 minimumStake,
-        IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategyParams
+        IStakeRegistry.StrategyParams[] memory strategyParams
     ) external virtual onlyServiceManagerOwner {
         _createQuorum(operatorSetParams, minimumStake, strategyParams);
     }
@@ -490,7 +490,7 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
     function _createQuorum(
         OperatorSetParam memory operatorSetParams,
         uint96 minimumStake,
-        IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategyParams
+        IStakeRegistry.StrategyParams[] memory strategyParams
     ) internal {
         // Increment the total quorum count. Fails if we're already at the max
         uint8 prevQuorumCount = quorumCount;

--- a/src/BLSSignatureChecker.sol
+++ b/src/BLSSignatureChecker.sol
@@ -139,7 +139,7 @@ contract BLSSignatureChecker is IBLSSignatureChecker {
                     // if the nonSigner is a part of the quorum, subtract their stake from the running total
                     if (BitmapUtils.numberIsInBitmap(nonSignerQuorumBitmaps[i], quorumNumber)) {
                         quorumStakeTotals.signedStakeForQuorum[quorumNumberIndex] -=
-                            stakeRegistry.getStakeForQuorumAtBlockNumberFromOperatorIdAndIndex(
+                            stakeRegistry.getOperatorStakeAtBlockNumberAndIndex(
                                 quorumNumber,
                                 referenceBlockNumber,
                                 nonSignerPubkeyHashes[i],

--- a/src/BLSSignatureChecker.sol
+++ b/src/BLSSignatureChecker.sol
@@ -106,7 +106,7 @@ contract BLSSignatureChecker is IBLSSignatureChecker {
                     }
 
                     nonSignerQuorumBitmaps[i] = 
-                        registryCoordinator.getQuorumBitmapByOperatorIdAtBlockNumberByIndex(
+                        registryCoordinator.getQuorumBitmapAtBlockNumberByIndex(
                             nonSignerPubkeyHashes[i], 
                             referenceBlockNumber, 
                             nonSignerStakesAndSignature.nonSignerQuorumBitmapIndices[i]

--- a/src/IndexRegistry.sol
+++ b/src/IndexRegistry.sol
@@ -132,16 +132,7 @@ contract IndexRegistry is IndexRegistryStorage {
         QuorumUpdate storage lastUpdate = _latestQuorumUpdate(quorumNumber);
         uint32 newOperatorCount = lastUpdate.numOperators + 1;
         
-        // If the last update was made in this block, update the entry
-        // Otherwise, push a new historical entry.
-        if (lastUpdate.fromBlockNumber == uint32(block.number)) {
-            lastUpdate.numOperators = newOperatorCount;
-        } else {
-            _operatorCountHistory[quorumNumber].push(QuorumUpdate({
-                numOperators: newOperatorCount,
-                fromBlockNumber: uint32(block.number)
-            }));
-        }
+        _updateOperatorCountHistory(quorumNumber, lastUpdate, newOperatorCount);
 
         return newOperatorCount;
     }
@@ -153,8 +144,21 @@ contract IndexRegistry is IndexRegistryStorage {
         QuorumUpdate storage lastUpdate = _latestQuorumUpdate(quorumNumber);
         uint32 newOperatorCount = lastUpdate.numOperators - 1;
         
-        // If the last update was made in this block, update the entry
-        // Otherwise, push a new historical entry.
+        _updateOperatorCountHistory(quorumNumber, lastUpdate, newOperatorCount);
+        
+        return newOperatorCount;
+    }
+
+    /**
+     * @notice Update `_operatorCountHistory` with a new operator count
+     * @dev If the lastUpdate was made in the this block, update the entry.
+     * Otherwise, push a new historical entry.
+     */
+    function _updateOperatorCountHistory(
+        uint8 quorumNumber,
+        QuorumUpdate storage lastUpdate,
+        uint32 newOperatorCount
+    ) internal {
         if (lastUpdate.fromBlockNumber == uint32(block.number)) {
             lastUpdate.numOperators = newOperatorCount;
         } else {
@@ -163,8 +167,6 @@ contract IndexRegistry is IndexRegistryStorage {
                 fromBlockNumber: uint32(block.number)
             }));
         }
-
-        return newOperatorCount;
     }
 
     /**

--- a/src/IndexRegistry.sol
+++ b/src/IndexRegistry.sol
@@ -324,37 +324,6 @@ contract IndexRegistry is IndexRegistryStorage {
         return _latestIndexUpdate(quorumNumber, index);
     }
 
-    /**
-     * @notice Looks up the number of total operators for `quorumNumber` at the specified `blockNumber`.
-     * @param quorumNumber is the quorum number for which the total number of operators is desired
-     * @param blockNumber is the block number at which the total number of operators is desired
-     * @param index is the index of the entry in the dynamic array `_operatorCountHistory[quorumNumber]` to read data from
-     * @dev Function will revert in the event that the specified `index` input is outisde the bounds of the provided `blockNumber`
-     */
-    function getTotalOperatorsForIndexAtBlockNumber(
-        uint8 quorumNumber, 
-        uint32 blockNumber, 
-        uint32 index
-    ) external view returns (uint32){
-        QuorumUpdate memory quorumUpdate = _operatorCountHistory[quorumNumber][index];
-
-        // blocknumber must be at or after the "index'th" entry's fromBlockNumber
-        require(
-            blockNumber >= quorumUpdate.fromBlockNumber, 
-            "IndexRegistry.getTotalOperatorsForIndexAtBlockNumber: provided index is too far in the past for provided block number"
-        );
-        
-        // if there is an index update after the "index'th" update, the blocknumber must be before the next entry's fromBlockNumber
-        if (index != _operatorCountHistory[quorumNumber].length - 1){
-            QuorumUpdate memory nextQuorumUpdate = _operatorCountHistory[quorumNumber][index + 1];
-            require(
-                blockNumber < nextQuorumUpdate.fromBlockNumber, 
-                "IndexRegistry.getTotalOperatorsForIndexAtBlockNumber: provided index is too far in the future for provided block number"
-            );
-        }
-        return quorumUpdate.numOperators;
-    }
-
     /// @notice Returns an ordered list of operators of the services for the given `quorumNumber` at the given `blockNumber`
     function getOperatorListAtBlockNumber(
         uint8 quorumNumber, 

--- a/src/IndexRegistry.sol
+++ b/src/IndexRegistry.sol
@@ -134,6 +134,15 @@ contract IndexRegistry is IndexRegistryStorage {
         
         _updateOperatorCountHistory(quorumNumber, lastUpdate, newOperatorCount);
 
+        // If this is the first time we're using this index, push its first update
+        // This maintains an invariant: existing indices have nonzero history
+        if (_indexHistory[quorumNumber][newOperatorCount - 1].length == 0) {
+            _indexHistory[quorumNumber][newOperatorCount - 1].push(OperatorUpdate({
+                operatorId: OPERATOR_DOES_NOT_EXIST_ID,
+                fromBlockNumber: uint32(block.number)
+            }));
+        }
+
         return newOperatorCount;
     }
 
@@ -303,6 +312,18 @@ contract IndexRegistry is IndexRegistryStorage {
         return _operatorCountHistory[quorumNumber][index];
     }
 
+    /// @notice Returns the most recent _operatorCountHistory entry for the specified quorumNumber
+    /// @dev Reverts if the quorum does not exist
+    function getLatestQuorumUpdate(uint8 quorumNumber) external view returns (QuorumUpdate memory) {
+        return _latestQuorumUpdate(quorumNumber);
+    }
+
+    /// @notice Returns the most recent _operatorCountHistory entry for the specified quorumNumber
+    /// @dev Reverts if there is no update for the given index
+    function getLatestOperatorUpdate(uint8 quorumNumber, uint32 index) external view returns (OperatorUpdate memory) {
+        return _latestIndexUpdate(quorumNumber, index);
+    }
+
     /**
      * @notice Looks up the number of total operators for `quorumNumber` at the specified `blockNumber`.
      * @param quorumNumber is the quorum number for which the total number of operators is desired
@@ -320,7 +341,7 @@ contract IndexRegistry is IndexRegistryStorage {
         // blocknumber must be at or after the "index'th" entry's fromBlockNumber
         require(
             blockNumber >= quorumUpdate.fromBlockNumber, 
-            "IndexRegistry.getTotalOperatorsForQuorumAtBlockNumberByIndex: provided index is too far in the past for provided block number"
+            "IndexRegistry.getTotalOperatorsForIndexAtBlockNumber: provided index is too far in the past for provided block number"
         );
         
         // if there is an index update after the "index'th" update, the blocknumber must be before the next entry's fromBlockNumber
@@ -328,7 +349,7 @@ contract IndexRegistry is IndexRegistryStorage {
             QuorumUpdate memory nextQuorumUpdate = _operatorCountHistory[quorumNumber][index + 1];
             require(
                 blockNumber < nextQuorumUpdate.fromBlockNumber, 
-                "IndexRegistry.getTotalOperatorsForQuorumAtBlockNumberByIndex: provided index is too far in the future for provided block number"
+                "IndexRegistry.getTotalOperatorsForIndexAtBlockNumber: provided index is too far in the future for provided block number"
             );
         }
         return quorumUpdate.numOperators;

--- a/src/IndexRegistry.sol
+++ b/src/IndexRegistry.sol
@@ -254,10 +254,6 @@ contract IndexRegistry is IndexRegistryStorage {
     ) internal view returns (uint32){
         uint256 historyLength = _operatorCountHistory[quorumNumber].length;
         require(historyLength != 0, "IndexRegistry._operatorCountAtBlockNumber: quorum does not exist");
-        require(
-            blockNumber >= _operatorCountHistory[quorumNumber][0].fromBlockNumber, 
-            "IndexRegistry._operatorCountAtBlockNumber: quorum did not exist at given block number"
-        );
 
         // Loop backwards through the total operator history
         for (uint256 i = 0; i < historyLength; i++) {
@@ -269,7 +265,6 @@ contract IndexRegistry is IndexRegistryStorage {
             }
         }
         
-        // Shouldn't be able to reach this point
         revert("IndexRegistry._operatorCountAtBlockNumber: quorum did not exist at given block number");
     }
     
@@ -278,8 +273,8 @@ contract IndexRegistry is IndexRegistryStorage {
      * Precondition: requires that the index was used active at the given block number for quorum
      */
     function _operatorIdForIndexAtBlockNumber(
-        uint32 index, 
         uint8 quorumNumber, 
+        uint32 index, 
         uint32 blockNumber
     ) internal view returns(bytes32) {
         uint256 historyLength = _indexHistory[quorumNumber][index].length;
@@ -303,7 +298,7 @@ contract IndexRegistry is IndexRegistryStorage {
     *******************************************************************************/
 
     /// @notice Returns the _indexHistory entry for the specified `operatorIndex` and `quorumNumber` at the specified `index`
-    function getOperatorUpdateAtIndex(uint32 operatorIndex, uint8 quorumNumber, uint32 index) external view returns (OperatorUpdate memory) {
+    function getOperatorUpdateAtIndex(uint8 quorumNumber, uint32 operatorIndex, uint32 index) external view returns (OperatorUpdate memory) {
         return _indexHistory[quorumNumber][operatorIndex][index];
     }
 
@@ -332,7 +327,7 @@ contract IndexRegistry is IndexRegistryStorage {
         uint32 operatorCount = _operatorCountAtBlockNumber(quorumNumber, blockNumber);
         bytes32[] memory operatorList = new bytes32[](operatorCount);
         for (uint256 i = 0; i < operatorCount; i++) {
-            operatorList[i] = _operatorIdForIndexAtBlockNumber(uint32(i), quorumNumber, blockNumber);
+            operatorList[i] = _operatorIdForIndexAtBlockNumber(quorumNumber, uint32(i), blockNumber);
             require(
                 operatorList[i] != OPERATOR_DOES_NOT_EXIST_ID, 
                 "IndexRegistry.getOperatorListAtBlockNumber: operator does not exist at the given block number"

--- a/src/IndexRegistryStorage.sol
+++ b/src/IndexRegistryStorage.sol
@@ -19,15 +19,12 @@ abstract contract IndexRegistryStorage is Initializable, IIndexRegistry {
     /// @notice The RegistryCoordinator contract for this middleware
     IRegistryCoordinator public immutable registryCoordinator;
 
-    /// @notice list of all operators ever registered, may include duplicates. used to avoid running an indexer on nodes
-    bytes32[] public globalOperatorList;
-
-    /// @notice mapping of quorumNumber => operator id => current index
-    mapping(uint8 => mapping(bytes32 => uint32)) public operatorIdToIndex;
-    /// @notice mapping of quorumNumber => index => operator id history for that index
-    mapping(uint8 => mapping(uint32 => OperatorUpdate[])) internal _indexToOperatorIdHistory;
-    /// @notice mapping of quorumNumber => history of numbers of unique registered operators
-    mapping(uint8 => QuorumUpdate[]) internal _totalOperatorsHistory;
+    /// @notice maps quorumNumber => operator id => current index
+    mapping(uint8 => mapping(bytes32 => uint32)) public currentOperatorIndex;
+    /// @notice maps quorumNumber => index => historical operator ids at that index
+    mapping(uint8 => mapping(uint32 => OperatorUpdate[])) internal _indexHistory;
+    /// @notice maps quorumNumber => historical number of unique registered operators
+    mapping(uint8 => QuorumUpdate[]) internal _operatorCountHistory;
 
     constructor(
         IRegistryCoordinator _registryCoordinator

--- a/src/StakeRegistry.sol
+++ b/src/StakeRegistry.sol
@@ -386,35 +386,26 @@ contract StakeRegistry is StakeRegistryStorage {
             return;
         }
 
-        uint96 prevStake;
+        // Get our last-recorded stake update
         uint256 historyLength = _totalStakeHistory[quorumNumber].length;
+        OperatorStakeUpdate storage lastStakeUpdate = _totalStakeHistory[quorumNumber][historyLength - 1];
+        
+        // Calculate the new total stake by applying the delta to our previous stake
+        uint96 newStake = _applyDelta(lastStakeUpdate.stake, stakeDelta);
 
-        if (historyLength == 0) {
-            // No prior stake history - push our first entry
+        /**
+         * If our last stake entry was made in the current block, update the entry
+         * Otherwise, push a new entry and update the previous entry's "next" field
+         */
+        if (lastStakeUpdate.updateBlockNumber == uint32(block.number)) {
+            lastStakeUpdate.stake = newStake;
+        } else {
+            lastStakeUpdate.nextUpdateBlockNumber = uint32(block.number);
             _totalStakeHistory[quorumNumber].push(OperatorStakeUpdate({
                 updateBlockNumber: uint32(block.number),
                 nextUpdateBlockNumber: 0,
-                stake: _applyDelta(prevStake, stakeDelta)
+                stake: newStake
             }));
-        } else {
-            // We have prior stake history - calculate our new stake as a function of our last-recorded stake
-            prevStake = _totalStakeHistory[quorumNumber][historyLength - 1].stake;
-            uint96 newStake = _applyDelta(prevStake, stakeDelta);
-
-            /**
-             * If our last stake entry was made in the current block, update the entry
-             * Otherwise, push a new entry and update the previous entry's "next" field
-             */
-            if (_totalStakeHistory[quorumNumber][historyLength-1].updateBlockNumber == uint32(block.number)) {
-                _totalStakeHistory[quorumNumber][historyLength-1].stake = newStake;
-            } else {
-                _totalStakeHistory[quorumNumber][historyLength-1].nextUpdateBlockNumber = uint32(block.number);
-                _totalStakeHistory[quorumNumber].push(OperatorStakeUpdate({
-                    updateBlockNumber: uint32(block.number),
-                    nextUpdateBlockNumber: 0,
-                    stake: newStake
-                }));
-            }
         }
     }
 

--- a/src/StakeRegistry.sol
+++ b/src/StakeRegistry.sol
@@ -66,7 +66,7 @@ contract StakeRegistry is StakeRegistryStorage {
 
             for (uint256 i = 0; i < operators.length; ) {
                 bytes32 operatorId = registryCoordinator.getOperatorId(operators[i]);
-                uint192 quorumBitmap = registryCoordinator.getCurrentQuorumBitmapByOperatorId(operatorId);
+                uint192 quorumBitmap = registryCoordinator.getCurrentQuorumBitmap(operatorId);
 
                 /**
                  * If the operator is a part of the quorum, update their current stake

--- a/src/StakeRegistryStorage.sol
+++ b/src/StakeRegistryStorage.sol
@@ -39,13 +39,13 @@ abstract contract StakeRegistryStorage is IStakeRegistry {
     OperatorStakeUpdate[][256] internal _totalStakeHistory;
 
     /// @notice mapping from operator's operatorId to the history of their stake updates
-    mapping(bytes32 => mapping(uint8 => OperatorStakeUpdate[])) internal operatorIdToStakeHistory;
+    mapping(bytes32 => mapping(uint8 => OperatorStakeUpdate[])) internal operatorStakeHistory;
 
     /**
      * @notice mapping from quorum number to the list of strategies considered and their
      * corresponding multipliers for that specific quorum
      */
-    mapping(uint8 => StrategyAndWeightingMultiplier[]) public strategiesConsideredAndMultipliers;
+    mapping(uint8 => StrategyParams[]) public strategyParams;
 
     constructor(
         IRegistryCoordinator _registryCoordinator, 

--- a/src/interfaces/IBLSRegistryCoordinatorWithIndices.sol
+++ b/src/interfaces/IBLSRegistryCoordinatorWithIndices.sol
@@ -60,7 +60,7 @@ interface IBLSRegistryCoordinatorWithIndices is ISignatureUtils, IRegistryCoordi
      * @param quorumNumbers are the quorum numbers to eject the operator from
      * @param pubkey is the BLS public key of the operator
      */
-    function ejectOperatorFromCoordinator(
+    function ejectOperator(
         address operator, 
         bytes calldata quorumNumbers, 
         BN254.G1Point memory pubkey 

--- a/src/interfaces/IIndexRegistry.sol
+++ b/src/interfaces/IIndexRegistry.sol
@@ -72,14 +72,6 @@ interface IIndexRegistry is IRegistry {
     /// @notice Returns the _operatorCountHistory entry for the specified `quorumNumber` at the specified `index`
     function getQuorumUpdateAtIndex(uint8 quorumNumber, uint32 index) external view returns (QuorumUpdate memory);
 
-    /**
-     * @notice Looks up the number of total operators for `quorumNumber` at the specified `blockNumber`.
-     * @param quorumNumber is the quorum number for which the total number of operators is desired
-     * @param blockNumber is the block number at which the total number of operators is desired
-     * @param index is the index of the entry in the dynamic array `_operatorCountHistory[quorumNumber]` to read data from
-     */
-    function getTotalOperatorsForIndexAtBlockNumber(uint8 quorumNumber, uint32 blockNumber, uint32 index) external view returns (uint32);
-
     /// @notice Returns the current number of operators of this service for `quorumNumber`.
     function totalOperatorsForQuorum(uint8 quorumNumber) external view returns (uint32);
 

--- a/src/interfaces/IIndexRegistry.sol
+++ b/src/interfaces/IIndexRegistry.sol
@@ -66,23 +66,23 @@ interface IIndexRegistry is IRegistry {
      */
     function initializeQuorum(uint8 quorumNumber) external;
 
-    /// @notice Returns the _indexToOperatorIdHistory entry for the specified `operatorIndex` and `quorumNumber` at the specified `index`
-    function getOperatorIndexUpdateOfIndexForQuorumAtIndex(uint32 operatorIndex, uint8 quorumNumber, uint32 index) external view returns (OperatorUpdate memory);
+    /// @notice Returns the _indexHistory entry for the specified `operatorIndex` and `quorumNumber` at the specified `index`
+    function getOperatorUpdateAtIndex(uint32 operatorIndex, uint8 quorumNumber, uint32 index) external view returns (OperatorUpdate memory);
 
-    /// @notice Returns the _totalOperatorsHistory entry for the specified `quorumNumber` at the specified `index`
+    /// @notice Returns the _operatorCountHistory entry for the specified `quorumNumber` at the specified `index`
     function getQuorumUpdateAtIndex(uint8 quorumNumber, uint32 index) external view returns (QuorumUpdate memory);
 
     /**
      * @notice Looks up the number of total operators for `quorumNumber` at the specified `blockNumber`.
      * @param quorumNumber is the quorum number for which the total number of operators is desired
      * @param blockNumber is the block number at which the total number of operators is desired
-     * @param index is the index of the entry in the dynamic array `totalOperatorsHistory[quorumNumber]` to read data from
+     * @param index is the index of the entry in the dynamic array `_operatorCountHistory[quorumNumber]` to read data from
      */
-    function getTotalOperatorsForQuorumAtBlockNumberByIndex(uint8 quorumNumber, uint32 blockNumber, uint32 index) external view returns (uint32);
+    function getTotalOperatorsForIndexAtBlockNumber(uint8 quorumNumber, uint32 blockNumber, uint32 index) external view returns (uint32);
 
     /// @notice Returns the current number of operators of this service for `quorumNumber`.
     function totalOperatorsForQuorum(uint8 quorumNumber) external view returns (uint32);
 
     /// @notice Returns an ordered list of operators of the services for the given `quorumNumber` at the given `blockNumber`
-    function getOperatorListForQuorumAtBlockNumber(uint8 quorumNumber, uint32 blockNumber) external view returns (bytes32[] memory);
+    function getOperatorListAtBlockNumber(uint8 quorumNumber, uint32 blockNumber) external view returns (bytes32[] memory);
 }

--- a/src/interfaces/IIndexRegistry.sol
+++ b/src/interfaces/IIndexRegistry.sol
@@ -67,7 +67,7 @@ interface IIndexRegistry is IRegistry {
     function initializeQuorum(uint8 quorumNumber) external;
 
     /// @notice Returns the _indexHistory entry for the specified `operatorIndex` and `quorumNumber` at the specified `index`
-    function getOperatorUpdateAtIndex(uint32 operatorIndex, uint8 quorumNumber, uint32 index) external view returns (OperatorUpdate memory);
+    function getOperatorUpdateAtIndex(uint8 quorumNumber, uint32 operatorIndex, uint32 index) external view returns (OperatorUpdate memory);
 
     /// @notice Returns the _operatorCountHistory entry for the specified `quorumNumber` at the specified `index`
     function getQuorumUpdateAtIndex(uint8 quorumNumber, uint32 index) external view returns (QuorumUpdate memory);

--- a/src/interfaces/IRegistryCoordinator.sol
+++ b/src/interfaces/IRegistryCoordinator.sol
@@ -83,18 +83,4 @@ interface IRegistryCoordinator {
 
     /// @notice Returns the number of registries
     function numRegistries() external view returns (uint256);
-
-    /**
-     * @notice Registers msg.sender as an operator with the middleware
-     * @param quorumNumbers are the bytes representing the quorum numbers that the operator is registering for
-     * @param registrationData is the data that is decoded to get the operator's registration information
-     */
-    function registerOperatorWithCoordinator(bytes memory quorumNumbers, bytes calldata registrationData) external;
-
-    /**
-     * @notice Deregisters the msg.sender as an operator from the middleware
-     * @param quorumNumbers are the bytes representing the quorum numbers that the operator is registered for
-     * @param deregistrationData is the the data that is decoded to get the operator's deregistration information
-     */
-    function deregisterOperatorWithCoordinator(bytes calldata quorumNumbers, bytes calldata deregistrationData) external;
 }

--- a/src/interfaces/IRegistryCoordinator.sol
+++ b/src/interfaces/IRegistryCoordinator.sol
@@ -61,22 +61,22 @@ interface IRegistryCoordinator {
     function getOperatorStatus(address operator) external view returns (IRegistryCoordinator.OperatorStatus);
 
     /// @notice Returns the indices of the quorumBitmaps for the provided `operatorIds` at the given `blockNumber`
-    function getQuorumBitmapIndicesByOperatorIdsAtBlockNumber(uint32 blockNumber, bytes32[] memory operatorIds) external view returns (uint32[] memory);
+    function getQuorumBitmapIndicesAtBlockNumber(uint32 blockNumber, bytes32[] memory operatorIds) external view returns (uint32[] memory);
 
     /**
      * @notice Returns the quorum bitmap for the given `operatorId` at the given `blockNumber` via the `index`
      * @dev reverts if `index` is incorrect 
      */ 
-    function getQuorumBitmapByOperatorIdAtBlockNumberByIndex(bytes32 operatorId, uint32 blockNumber, uint256 index) external view returns (uint192);
+    function getQuorumBitmapAtBlockNumberByIndex(bytes32 operatorId, uint32 blockNumber, uint256 index) external view returns (uint192);
 
     /// @notice Returns the `index`th entry in the operator with `operatorId`'s bitmap history
-    function getQuorumBitmapUpdateByOperatorIdByIndex(bytes32 operatorId, uint256 index) external view returns (QuorumBitmapUpdate memory);
+    function getQuorumBitmapUpdateByIndex(bytes32 operatorId, uint256 index) external view returns (QuorumBitmapUpdate memory);
 
     /// @notice Returns the current quorum bitmap for the given `operatorId`
-    function getCurrentQuorumBitmapByOperatorId(bytes32 operatorId) external view returns (uint192);
+    function getCurrentQuorumBitmap(bytes32 operatorId) external view returns (uint192);
 
     /// @notice Returns the length of the quorum bitmap history for the given `operatorId`
-    function getQuorumBitmapUpdateByOperatorIdLength(bytes32 operatorId) external view returns (uint256);
+    function getQuorumBitmapHistoryLength(bytes32 operatorId) external view returns (uint256);
 
     /// @notice Returns the registry at the desired index
     function registries(uint256) external view returns (address);

--- a/src/interfaces/IStakeRegistry.sol
+++ b/src/interfaces/IStakeRegistry.sol
@@ -30,7 +30,7 @@ interface IStakeRegistry is IRegistry {
      * @notice In weighing a particular strategy, the amount of underlying asset for that strategy is
      * multiplied by its multiplier, then divided by WEIGHTING_DIVISOR
      */
-    struct StrategyAndWeightingMultiplier {
+    struct StrategyParams {
         IStrategy strategy;
         uint96 multiplier;
     }
@@ -47,11 +47,11 @@ interface IStakeRegistry is IRegistry {
     event MinimumStakeForQuorumUpdated(uint8 indexed quorumNumber, uint96 minimumStake);
     /// @notice emitted when a new quorum is created
     event QuorumCreated(uint8 indexed quorumNumber);
-    /// @notice emitted when `strategy` has been added to the array at `strategiesConsideredAndMultipliers[quorumNumber]`
+    /// @notice emitted when `strategy` has been added to the array at `strategyParams[quorumNumber]`
     event StrategyAddedToQuorum(uint8 indexed quorumNumber, IStrategy strategy);
-    /// @notice emitted when `strategy` has removed from the array at `strategiesConsideredAndMultipliers[quorumNumber]`
+    /// @notice emitted when `strategy` has removed from the array at `strategyParams[quorumNumber]`
     event StrategyRemovedFromQuorum(uint8 indexed quorumNumber, IStrategy strategy);
-    /// @notice emitted when `strategy` has its `multiplier` updated in the array at `strategiesConsideredAndMultipliers[quorumNumber]`
+    /// @notice emitted when `strategy` has its `multiplier` updated in the array at `strategyParams[quorumNumber]`
     event StrategyMultiplierUpdated(uint8 indexed quorumNumber, IStrategy strategy, uint256 multiplier);
 
     /**
@@ -85,17 +85,17 @@ interface IStakeRegistry is IRegistry {
     /**
      * @notice Initialize a new quorum created by the registry coordinator by setting strategies, weights, and minimum stake
      */
-    function initializeQuorum(uint8 quorumNumber, uint96 minimumStake, StrategyAndWeightingMultiplier[] memory strategyParams) external;
+    function initializeQuorum(uint8 quorumNumber, uint96 minimumStake, StrategyParams[] memory strategyParams) external;
 
     /// @notice Adds new strategies and the associated multipliers to the @param quorumNumber.
     function addStrategies(
         uint8 quorumNumber,
-        StrategyAndWeightingMultiplier[] memory strategyParams
+        StrategyParams[] memory strategyParams
     ) external;
 
     /**
      * @notice This function is used for removing strategies and their associated weights from the
-     * mapping strategiesConsideredAndMultipliers for a specific @param quorumNumber.
+     * mapping strategyParams for a specific @param quorumNumber.
      * @dev higher indices should be *first* in the list of @param indicesToRemove, since otherwise
      * the removal of lower index entries will cause a shift in the indices of the other strategiesToRemove
      */
@@ -103,7 +103,7 @@ interface IStakeRegistry is IRegistry {
 
     /**
      * @notice This function is used for modifying the weights of strategies that are already in the
-     * mapping strategiesConsideredAndMultipliers for a specific
+     * mapping strategyParams for a specific
      * @param quorumNumber is the quorum number to change the strategy for
      * @param strategyIndices are the indices of the strategies to change
      * @param newMultipliers are the new multipliers for the strategies
@@ -126,14 +126,14 @@ interface IStakeRegistry is IRegistry {
     /// @notice In order to register for a quorum i, an operator must have at least `minimumStakeForQuorum[i]`
     function minimumStakeForQuorum(uint256 quorumNumber) external view returns (uint96);
 
-    /// @notice Returns the length of the dynamic array stored in `strategiesConsideredAndMultipliers[quorumNumber]`.
-    function strategiesConsideredAndMultipliersLength(uint8 quorumNumber) external view returns (uint256);
+    /// @notice Returns the length of the dynamic array stored in `strategyParams[quorumNumber]`.
+    function strategyParamsLength(uint8 quorumNumber) external view returns (uint256);
 
     /// @notice Returns the strategy and weight multiplier for the `index`'th strategy in the quorum `quorumNumber`
-    function strategyAndWeightingMultiplierForQuorumByIndex(
+    function strategyParamsByIndex(
         uint8 quorumNumber,
         uint256 index
-    ) external view returns (StrategyAndWeightingMultiplier memory);
+    ) external view returns (StrategyParams memory);
 
     /**
      * @notice This function computes the total weight of the @param operator in the quorum @param quorumNumber.
@@ -146,25 +146,25 @@ interface IStakeRegistry is IRegistry {
      * @param operatorId The id of the operator of interest.
      * @param quorumNumber The quorum number to get the stake for.
      */
-    function getOperatorIdToStakeHistory(bytes32 operatorId, uint8 quorumNumber) external view returns (OperatorStakeUpdate[] memory);
+    function getOperatorStakeHistory(bytes32 operatorId, uint8 quorumNumber) external view returns (OperatorStakeUpdate[] memory);
 
-    function getLengthOfTotalStakeHistoryForQuorum(uint8 quorumNumber) external view returns (uint256);
+    function getTotalStakeHistoryLength(uint8 quorumNumber) external view returns (uint256);
 
     /**
      * @notice Returns the `index`-th entry in the dynamic array of total stake, `totalStakeHistory` for quorum `quorumNumber`.
      * @param quorumNumber The quorum number to get the stake for.
      * @param index Array index for lookup, within the dynamic array `totalStakeHistory[quorumNumber]`.
      */
-    function getTotalStakeUpdateForQuorumFromIndex(uint8 quorumNumber, uint256 index) external view returns (OperatorStakeUpdate memory);
+    function getTotalStakeUpdateAtIndex(uint8 quorumNumber, uint256 index) external view returns (OperatorStakeUpdate memory);
 
     /// @notice Returns the indices of the operator stakes for the provided `quorumNumber` at the given `blockNumber`
-    function getStakeUpdateIndexForOperatorIdForQuorumAtBlockNumber(bytes32 operatorId, uint8 quorumNumber, uint32 blockNumber)
+    function getStakeUpdateIndexForOperatorAtBlockNumber(bytes32 operatorId, uint8 quorumNumber, uint32 blockNumber)
         external
         view
         returns (uint32);
 
     /// @notice Returns the indices of the total stakes for the provided `quorumNumbers` at the given `blockNumber`
-    function getTotalStakeIndicesByQuorumNumbersAtBlockNumber(uint32 blockNumber, bytes calldata quorumNumbers) external view returns(uint32[] memory) ;
+    function getTotalStakeIndicesAtBlockNumber(uint32 blockNumber, bytes calldata quorumNumbers) external view returns(uint32[] memory) ;
 
     /**
      * @notice Returns the `index`-th entry in the `operatorIdToStakeHistory[operatorId][quorumNumber]` array.
@@ -173,7 +173,7 @@ interface IStakeRegistry is IRegistry {
      * @param index Array index for lookup, within the dynamic array `operatorIdToStakeHistory[operatorId][quorumNumber]`.
      * @dev Function will revert if `index` is out-of-bounds.
      */
-    function getStakeUpdateForQuorumFromOperatorIdAndIndex(uint8 quorumNumber, bytes32 operatorId, uint256 index)
+    function getStakeUpdateForOperatorAtIndex(uint8 quorumNumber, bytes32 operatorId, uint256 index)
         external
         view
         returns (OperatorStakeUpdate memory);
@@ -195,7 +195,7 @@ interface IStakeRegistry is IRegistry {
      * @dev Function will revert if `index` is out-of-bounds.
      * @dev used the BLSSignatureChecker to get past stakes of signing operators
      */
-    function getStakeForQuorumAtBlockNumberFromOperatorIdAndIndex(uint8 quorumNumber, uint32 blockNumber, bytes32 operatorId, uint256 index)
+    function getOperatorStakeAtBlockNumberAndIndex(uint8 quorumNumber, uint32 blockNumber, bytes32 operatorId, uint256 index)
         external
         view
         returns (uint96);
@@ -219,7 +219,7 @@ interface IStakeRegistry is IRegistry {
     function getCurrentOperatorStakeForQuorum(bytes32 operatorId, uint8 quorumNumber) external view returns (uint96);
 
     /// @notice Returns the stake of the operator for the provided `quorumNumber` at the given `blockNumber`
-    function getStakeForOperatorIdForQuorumAtBlockNumber(bytes32 operatorId, uint8 quorumNumber, uint32 blockNumber)
+    function getOperatorStakeAtBlockNumber(bytes32 operatorId, uint8 quorumNumber, uint32 blockNumber)
         external
         view
         returns (uint96);

--- a/test/harnesses/BLSRegistryCoordinatorWithIndicesHarness.sol
+++ b/test/harnesses/BLSRegistryCoordinatorWithIndicesHarness.sol
@@ -19,16 +19,16 @@ contract BLSRegistryCoordinatorWithIndicesHarness is BLSRegistryCoordinatorWithI
     }
 
     function setOperatorId(address operator, bytes32 operatorId) external {
-        _operators[operator].operatorId = operatorId;
+        _operatorInfo[operator].operatorId = operatorId;
     }
 
     function recordOperatorQuorumBitmapUpdate(bytes32 operatorId, uint192 quorumBitmap) external {
-        uint256 operatorQuorumBitmapHistoryLength = _operatorIdToQuorumBitmapHistory[operatorId].length;
+        uint256 operatorQuorumBitmapHistoryLength = _operatorBitmapHistory[operatorId].length;
         if (operatorQuorumBitmapHistoryLength != 0) {
-            _operatorIdToQuorumBitmapHistory[operatorId][operatorQuorumBitmapHistoryLength - 1].nextUpdateBlockNumber = uint32(block.number);
+            _operatorBitmapHistory[operatorId][operatorQuorumBitmapHistoryLength - 1].nextUpdateBlockNumber = uint32(block.number);
         }
 
-        _operatorIdToQuorumBitmapHistory[operatorId].push(QuorumBitmapUpdate({
+        _operatorBitmapHistory[operatorId].push(QuorumBitmapUpdate({
             updateBlockNumber: uint32(block.number),
             nextUpdateBlockNumber: 0,
             quorumBitmap: quorumBitmap

--- a/test/mocks/RegistryCoordinatorMock.sol
+++ b/test/mocks/RegistryCoordinatorMock.sol
@@ -24,25 +24,25 @@ contract RegistryCoordinatorMock is IRegistryCoordinator {
     /// @notice Returns task number from when `operator` has been registered.
     function getFromTaskNumberForOperator(address operator) external view returns (uint32){}
 
-    function getQuorumBitmapIndicesByOperatorIdsAtBlockNumber(uint32 blockNumber, bytes32[] memory operatorIds) external view returns (uint32[] memory){}
+    function getQuorumBitmapIndicesAtBlockNumber(uint32 blockNumber, bytes32[] memory operatorIds) external view returns (uint32[] memory){}
 
     /// @notice Returns the quorum bitmap for the given `operatorId` at the given `blockNumber` via the `index`
-    function getQuorumBitmapByOperatorIdAtBlockNumberByIndex(bytes32 operatorId, uint32 blockNumber, uint256 index) external view returns (uint192) {}
+    function getQuorumBitmapAtBlockNumberByIndex(bytes32 operatorId, uint32 blockNumber, uint256 index) external view returns (uint192) {}
 
     /// @notice Returns the `index`th entry in the operator with `operatorId`'s bitmap history
-    function getQuorumBitmapUpdateByOperatorIdByIndex(bytes32 operatorId, uint256 index) external view returns (QuorumBitmapUpdate memory) {}
+    function getQuorumBitmapUpdateByIndex(bytes32 operatorId, uint256 index) external view returns (QuorumBitmapUpdate memory) {}
 
     /// @notice Returns the current quorum bitmap for the given `operatorId`
-    function getCurrentQuorumBitmapByOperatorId(bytes32 operatorId) external view returns (uint192) {}
+    function getCurrentQuorumBitmap(bytes32 operatorId) external view returns (uint192) {}
 
     /// @notice Returns the length of the quorum bitmap history for the given `operatorId`
-    function getQuorumBitmapUpdateByOperatorIdLength(bytes32 operatorId) external view returns (uint256) {}
+    function getQuorumBitmapHistoryLength(bytes32 operatorId) external view returns (uint256) {}
 
     function numRegistries() external view returns (uint256){}
 
     function registries(uint256) external view returns (address){}
 
-    function registerOperatorWithCoordinator(bytes memory quorumNumbers, bytes calldata) external {}
+    function registerOperator(bytes memory quorumNumbers, bytes calldata) external {}
 
-    function deregisterOperatorWithCoordinator(bytes calldata quorumNumbers, bytes calldata) external {}
+    function deregisterOperator(bytes calldata quorumNumbers, bytes calldata) external {}
 }

--- a/test/mocks/StakeRegistryMock.sol
+++ b/test/mocks/StakeRegistryMock.sol
@@ -43,12 +43,12 @@ contract StakeRegistryMock is IStakeRegistry {
     /**
      * @notice Initialize a new quorum created by the registry coordinator by setting strategies, weights, and minimum stake
      */
-    function initializeQuorum(uint8 quorumNumber, uint96 minimumStake, StrategyAndWeightingMultiplier[] memory strategyParams) external {}
+    function initializeQuorum(uint8 quorumNumber, uint96 minimumStake, StrategyParams[] memory strategyParams) external {}
 
     /// @notice Adds new strategies and the associated multipliers to the @param quorumNumber.
     function addStrategies(
         uint8 quorumNumber,
-        StrategyAndWeightingMultiplier[] memory strategyParams
+        StrategyParams[] memory strategyParams
     ) external {}
 
     /**
@@ -77,16 +77,16 @@ contract StakeRegistryMock is IStakeRegistry {
 
     function WEIGHTING_DIVISOR() external pure returns (uint256) {}
 
-    function strategiesConsideredAndMultipliersLength(uint8 quorumNumber) external view returns (uint256) {}
+    function strategyParamsLength(uint8 quorumNumber) external view returns (uint256) {}
 
     /// @notice In order to register for a quorum i, an operator must have at least `minimumStakeForQuorum[i]`
     function minimumStakeForQuorum(uint256 quorumNumber) external view returns (uint96) {}
 
     /// @notice Returns the strategy and weight multiplier for the `index`'th strategy in the quorum `quorumNumber`
-    function strategyAndWeightingMultiplierForQuorumByIndex(
+    function strategyParamsByIndex(
         uint8 quorumNumber,
         uint256 index
-    ) external view returns (StrategyAndWeightingMultiplier memory) {}
+    ) external view returns (StrategyParams memory) {}
 
     /**
      * @notice This function computes the total weight of the @param operator in the quorum @param quorumNumber.
@@ -99,25 +99,25 @@ contract StakeRegistryMock is IStakeRegistry {
      * @param operatorId The id of the operator of interest.
      * @param quorumNumber The quorum number to get the stake for.
      */
-    function getOperatorIdToStakeHistory(bytes32 operatorId, uint8 quorumNumber) external view returns (OperatorStakeUpdate[] memory) {}
+    function getOperatorStakeHistory(bytes32 operatorId, uint8 quorumNumber) external view returns (OperatorStakeUpdate[] memory) {}
 
-    function getLengthOfTotalStakeHistoryForQuorum(uint8 quorumNumber) external view returns (uint256) {}
+    function getTotalStakeHistoryLength(uint8 quorumNumber) external view returns (uint256) {}
 
     /**
      * @notice Returns the `index`-th entry in the dynamic array of total stake, `totalStakeHistory` for quorum `quorumNumber`.
      * @param quorumNumber The quorum number to get the stake for.
      * @param index Array index for lookup, within the dynamic array `totalStakeHistory[quorumNumber]`.
      */
-    function getTotalStakeUpdateForQuorumFromIndex(uint8 quorumNumber, uint256 index) external view returns (OperatorStakeUpdate memory) {}
+    function getTotalStakeUpdateAtIndex(uint8 quorumNumber, uint256 index) external view returns (OperatorStakeUpdate memory) {}
 
     /// @notice Returns the indices of the operator stakes for the provided `quorumNumber` at the given `blockNumber`
-    function getStakeUpdateIndexForOperatorIdForQuorumAtBlockNumber(bytes32 operatorId, uint8 quorumNumber, uint32 blockNumber)
+    function getStakeUpdateIndexForOperatorAtBlockNumber(bytes32 operatorId, uint8 quorumNumber, uint32 blockNumber)
         external
         view
         returns (uint32) {}
 
     /// @notice Returns the indices of the total stakes for the provided `quorumNumbers` at the given `blockNumber`
-    function getTotalStakeIndicesByQuorumNumbersAtBlockNumber(uint32 blockNumber, bytes calldata quorumNumbers) external view returns(uint32[] memory) {}
+    function getTotalStakeIndicesAtBlockNumber(uint32 blockNumber, bytes calldata quorumNumbers) external view returns(uint32[] memory) {}
 
     /**
      * @notice Returns the `index`-th entry in the `operatorIdToStakeHistory[operatorId][quorumNumber]` array.
@@ -126,7 +126,7 @@ contract StakeRegistryMock is IStakeRegistry {
      * @param index Array index for lookup, within the dynamic array `operatorIdToStakeHistory[operatorId][quorumNumber]`.
      * @dev Function will revert if `index` is out-of-bounds.
      */
-    function getStakeUpdateForQuorumFromOperatorIdAndIndex(uint8 quorumNumber, bytes32 operatorId, uint256 index)
+    function getStakeUpdateForOperatorAtIndex(uint8 quorumNumber, bytes32 operatorId, uint256 index)
         external
         view
         returns (OperatorStakeUpdate memory) {}
@@ -148,7 +148,7 @@ contract StakeRegistryMock is IStakeRegistry {
      * @dev Function will revert if `index` is out-of-bounds.
      * @dev used the BLSSignatureChecker to get past stakes of signing operators
      */
-    function getStakeForQuorumAtBlockNumberFromOperatorIdAndIndex(uint8 quorumNumber, uint32 blockNumber, bytes32 operatorId, uint256 index)
+    function getOperatorStakeAtBlockNumberAndIndex(uint8 quorumNumber, uint32 blockNumber, bytes32 operatorId, uint256 index)
         external
         view
         returns (uint96) {}
@@ -172,7 +172,7 @@ contract StakeRegistryMock is IStakeRegistry {
     function getCurrentOperatorStakeForQuorum(bytes32 operatorId, uint8 quorumNumber) external view returns (uint96) {}
 
     /// @notice Returns the stake of the operator for the provided `quorumNumber` at the given `blockNumber`
-    function getStakeForOperatorIdForQuorumAtBlockNumber(bytes32 operatorId, uint8 quorumNumber, uint32 blockNumber)
+    function getOperatorStakeAtBlockNumber(bytes32 operatorId, uint8 quorumNumber, uint32 blockNumber)
         external
         view
         returns (uint96){}

--- a/test/unit/BLSOperatorStateRetrieverUnit.t.sol
+++ b/test/unit/BLSOperatorStateRetrieverUnit.t.sol
@@ -47,7 +47,7 @@ contract BLSOperatorStateRetrieverUnitTests is MockAVSDeployer {
         cheats.roll(deregistrationBlockNumber);
 
         cheats.prank(_incrementAddress(defaultOperator, operatorIndexToDeregister));
-        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbersToDeregister, operatorMetadatas[operatorIndexToDeregister].pubkey);
+        registryCoordinator.deregisterOperator(quorumNumbersToDeregister, operatorMetadatas[operatorIndexToDeregister].pubkey);
         // modify expectedOperatorOverallIndices by moving th operatorIdsToSwap to the index where the operatorIndexToDeregister was
         for (uint i = 0; i < quorumNumbersToDeregister.length; i++) {
             uint8 quorumNumber = uint8(quorumNumbersToDeregister[i]);

--- a/test/unit/BLSPubkeyRegistryUnit.t.sol
+++ b/test/unit/BLSPubkeyRegistryUnit.t.sol
@@ -212,13 +212,15 @@ contract BLSPubkeyRegistryUnitTests is Test {
             testRegisterOperatorBLSPubkey(defaultOperator, pk);
             quorumApk = quorumApk.plus(BN254.hashToG1(pk));
             quorumApkHash = bytes24(BN254.hashG1Point(quorumApk));
-            require(quorumApkHash == blsPubkeyRegistry.getApkHashForQuorumAtBlockNumberFromIndex(defaultQuorumNumber, uint32(block.number + blockGap) , i + 1), "incorrect quorum aok updates");
+            uint historyLength = blsPubkeyRegistry.getQuorumApkHistoryLength(defaultQuorumNumber);
+            assertEq(quorumApkHash, blsPubkeyRegistry.getApkHashForQuorumAtBlockNumberFromIndex(defaultQuorumNumber, uint32(block.number + blockGap), historyLength-1), "incorrect quorum apk update");
             cheats.roll(block.number + 100);
             if(_generateRandomNumber(i) % 2 == 0){
-               _deregisterOperator(pk);
-               quorumApk = quorumApk.plus(BN254.hashToG1(pk).negate());
-               quorumApkHash = bytes24(BN254.hashG1Point(quorumApk));
-                require(quorumApkHash == blsPubkeyRegistry.getApkHashForQuorumAtBlockNumberFromIndex(defaultQuorumNumber, uint32(block.number + blockGap) , i + 2), "incorrect quorum aok updates");
+                _deregisterOperator(pk);
+                quorumApk = quorumApk.plus(BN254.hashToG1(pk).negate());
+                quorumApkHash = bytes24(BN254.hashG1Point(quorumApk));
+                historyLength = blsPubkeyRegistry.getQuorumApkHistoryLength(defaultQuorumNumber);
+                assertEq(quorumApkHash, blsPubkeyRegistry.getApkHashForQuorumAtBlockNumberFromIndex(defaultQuorumNumber, uint32(block.number + blockGap), historyLength-1), "incorrect quorum apk update");
                 cheats.roll(block.number + 100);
                 i++;
             }

--- a/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
+++ b/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
@@ -65,7 +65,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
             0/*initialPausedStatus*/, 
             operatorSetParams, 
             new uint96[](0), 
-            new IStakeRegistry.StrategyAndWeightingMultiplier[][](0)
+            new IStakeRegistry.StrategyParams[][](0)
         );
     }
 

--- a/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
+++ b/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
@@ -126,7 +126,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
     function testRegisterOperatorWithCoordinator_EmptyQuorumNumbers_Reverts() public {
         bytes memory emptyQuorumNumbers = new bytes(0);
-        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._registerOperatorWithCoordinator: quorumBitmap cannot be 0");
+        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._registerOperatorWithCoordinator: bitmap cannot be 0");
         cheats.prank(defaultOperator);
         registryCoordinator.registerOperatorWithCoordinator(emptyQuorumNumbers, defaultPubKey, defaultSocket);
     }
@@ -134,7 +134,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
     function testRegisterOperatorWithCoordinator_QuorumNumbersTooLarge_Reverts() public {
         bytes memory quorumNumbersTooLarge = new bytes(1);
         quorumNumbersTooLarge[0] = 0xC0;
-        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._registerOperatorWithCoordinator: quorumBitmap exceeds of max bitmap size");
+        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._registerOperatorWithCoordinator: bitmap exceeds max bitmap size");
         registryCoordinator.registerOperatorWithCoordinator(quorumNumbersTooLarge, defaultPubKey, defaultSocket);
     }
 
@@ -805,7 +805,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         cheats.roll(registrationBlockNumber);
         ISignatureUtils.SignatureWithSaltAndExpiry memory signatureWithSaltAndExpiry = _signOperatorChurnApproval(operatorToRegisterId, operatorKickParams, defaultSalt, block.timestamp - 1);
         cheats.prank(operatorToRegister);
-        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._verifyChurnApproverSignatureOnOperatorChurnApproval: churnApprover signature expired");
+        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._verifyChurnApproverSignature: churnApprover signature expired");
         registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, operatorToRegisterPubKey, defaultSocket, operatorKickParams, signatureWithSaltAndExpiry);
     }
 

--- a/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
+++ b/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
@@ -121,21 +121,21 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
         cheats.startPrank(defaultOperator);
         cheats.expectRevert(bytes("Pausable: index is paused"));
-        registryCoordinator.registerOperatorWithCoordinator(emptyQuorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(emptyQuorumNumbers, defaultPubKey, defaultSocket);
     }
 
     function testRegisterOperatorWithCoordinator_EmptyQuorumNumbers_Reverts() public {
         bytes memory emptyQuorumNumbers = new bytes(0);
-        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._registerOperatorWithCoordinator: bitmap cannot be 0");
+        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._registerOperator: bitmap cannot be 0");
         cheats.prank(defaultOperator);
-        registryCoordinator.registerOperatorWithCoordinator(emptyQuorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(emptyQuorumNumbers, defaultPubKey, defaultSocket);
     }
 
     function testRegisterOperatorWithCoordinator_QuorumNumbersTooLarge_Reverts() public {
         bytes memory quorumNumbersTooLarge = new bytes(1);
         quorumNumbersTooLarge[0] = 0xC0;
-        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._registerOperatorWithCoordinator: bitmap exceeds max bitmap size");
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbersTooLarge, defaultPubKey, defaultSocket);
+        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._registerOperator: bitmap exceeds max bitmap size");
+        registryCoordinator.registerOperator(quorumNumbersTooLarge, defaultPubKey, defaultSocket);
     }
 
     function testRegisterOperatorWithCoordinator_QuorumNotCreated_Reverts() public {
@@ -144,7 +144,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         quorumNumbersNotCreated[0] = 0x0B;
         cheats.prank(defaultOperator);
         cheats.expectRevert("BLSPubkeyRegistry._processQuorumApkUpdate: quorum does not exist");
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbersNotCreated, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbersNotCreated, defaultPubKey, defaultSocket);
     }
 
     function testRegisterOperatorWithCoordinatorForSingleQuorum_Valid() public {
@@ -164,7 +164,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         emit OperatorSocketUpdate(defaultOperatorId, defaultSocket);
 
         uint256 gasBefore = gasleft();
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
         uint256 gasAfter = gasleft();
         emit log_named_uint("gasUsed", gasBefore - gasAfter);
 
@@ -178,9 +178,9 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
                 status: IRegistryCoordinator.OperatorStatus.REGISTERED
             })))
         );
-        assertEq(registryCoordinator.getCurrentQuorumBitmapByOperatorId(defaultOperatorId), quorumBitmap);
+        assertEq(registryCoordinator.getCurrentQuorumBitmap(defaultOperatorId), quorumBitmap);
         assertEq(
-            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByOperatorIdByIndex(defaultOperatorId, 0))), 
+            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByIndex(defaultOperatorId, 0))), 
             keccak256(abi.encode(IRegistryCoordinator.QuorumBitmapUpdate({
                 quorumBitmap: uint192(quorumBitmap),
                 updateBlockNumber: uint32(block.number),
@@ -215,7 +215,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         emit OperatorSocketUpdate(defaultOperatorId, defaultSocket);
 
         uint256 gasBefore = gasleft();
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
         uint256 gasAfter = gasleft();
         emit log_named_uint("gasUsed", gasBefore - gasAfter);
         emit log_named_uint("numQuorums", quorumNumbers.length);
@@ -228,9 +228,9 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
                 status: IRegistryCoordinator.OperatorStatus.REGISTERED
             })))
         );
-        assertEq(registryCoordinator.getCurrentQuorumBitmapByOperatorId(defaultOperatorId), quorumBitmap);
+        assertEq(registryCoordinator.getCurrentQuorumBitmap(defaultOperatorId), quorumBitmap);
         assertEq(
-            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByOperatorIdByIndex(defaultOperatorId, 0))), 
+            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByIndex(defaultOperatorId, 0))), 
             keccak256(abi.encode(IRegistryCoordinator.QuorumBitmapUpdate({
                 quorumBitmap: uint192(quorumBitmap),
                 updateBlockNumber: uint32(block.number),
@@ -249,7 +249,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         stakeRegistry.setOperatorWeight(uint8(quorumNumbers[0]), defaultOperator, defaultStake);
         cheats.prank(defaultOperator);
         cheats.roll(registrationBlockNumber);
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
 
         bytes memory newQuorumNumbers = new bytes(1);
         newQuorumNumbers[0] = bytes1(defaultQuorumNumber+1);
@@ -265,7 +265,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         cheats.expectEmit(true, true, true, true, address(registryCoordinator));
         emit OperatorSocketUpdate(defaultOperatorId, defaultSocket);
         cheats.roll(nextRegistrationBlockNumber);
-        registryCoordinator.registerOperatorWithCoordinator(newQuorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(newQuorumNumbers, defaultPubKey, defaultSocket);
 
         uint256 quorumBitmap = BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers) | BitmapUtils.orderedBytesArrayToBitmap(newQuorumNumbers);
 
@@ -277,9 +277,9 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
                 status: IRegistryCoordinator.OperatorStatus.REGISTERED
             })))
         );
-        assertEq(registryCoordinator.getCurrentQuorumBitmapByOperatorId(defaultOperatorId), quorumBitmap);
+        assertEq(registryCoordinator.getCurrentQuorumBitmap(defaultOperatorId), quorumBitmap);
         assertEq(
-            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByOperatorIdByIndex(defaultOperatorId, 0))), 
+            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByIndex(defaultOperatorId, 0))), 
             keccak256(abi.encode(IRegistryCoordinator.QuorumBitmapUpdate({
                 quorumBitmap: uint192(BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers)),
                 updateBlockNumber: uint32(registrationBlockNumber),
@@ -287,7 +287,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
             })))
         );
         assertEq(
-            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByOperatorIdByIndex(defaultOperatorId, 1))), 
+            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByIndex(defaultOperatorId, 1))), 
             keccak256(abi.encode(IRegistryCoordinator.QuorumBitmapUpdate({
                 quorumBitmap: uint192(quorumBitmap),
                 updateBlockNumber: uint32(nextRegistrationBlockNumber),
@@ -322,8 +322,8 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         stakeRegistry.setOperatorWeight(defaultQuorumNumber, operatorToRegister, defaultStake);
 
         cheats.prank(operatorToRegister);
-        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._registerOperatorWithCoordinatorAndNoOverfilledQuorums: quorum is overfilled");
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, operatorToRegisterPubKey, defaultSocket);
+        cheats.expectRevert("BLSRegistryCoordinatorWithIndices.registerOperator: quorum is overfilled");
+        registryCoordinator.registerOperator(quorumNumbers, operatorToRegisterPubKey, defaultSocket);
     }
 
     function testRegisterOperatorWithCoordinator_RegisteredOperatorForSameQuorums_Reverts() public {
@@ -336,12 +336,12 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         stakeRegistry.setOperatorWeight(uint8(quorumNumbers[0]), defaultOperator, defaultStake);
         cheats.prank(defaultOperator);
         cheats.roll(registrationBlockNumber);
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
 
         cheats.prank(defaultOperator);
         cheats.roll(nextRegistrationBlockNumber);
-        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._registerOperatorWithCoordinator: operator already registered for some quorums being registered for");
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, defaultPubKey, defaultSocket);
+        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._registerOperator: operator already registered for some quorums being registered for");
+        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
     }
 
     function testDeregisterOperatorWithCoordinator_WhenPaused_Reverts() public {
@@ -357,16 +357,16 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
         cheats.expectRevert(bytes("Pausable: index is paused"));
         cheats.prank(defaultOperator);
-        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbers, defaultPubKey);
+        registryCoordinator.deregisterOperator(quorumNumbers, defaultPubKey);
     }
 
     function testDeregisterOperatorWithCoordinator_NotRegistered_Reverts() public {
         bytes memory quorumNumbers = new bytes(1);
         quorumNumbers[0] = bytes1(defaultQuorumNumber);
 
-        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._deregisterOperatorWithCoordinator: operator is not registered");
+        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._deregisterOperator: operator is not registered");
         cheats.prank(defaultOperator);
-        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbers, defaultPubKey);
+        registryCoordinator.deregisterOperator(quorumNumbers, defaultPubKey);
     }
 
     function testDeregisterOperatorWithCoordinator_IncorrectPubkey_Reverts() public {
@@ -378,9 +378,9 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
         BN254.G1Point memory incorrectPubKey = BN254.hashToG1(bytes32(uint256(123)));
 
-        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._deregisterOperatorWithCoordinator: operatorId does not match pubkey hash");
+        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._deregisterOperator: operatorId does not match pubkey hash");
         cheats.prank(defaultOperator);
-        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbers, incorrectPubKey);
+        registryCoordinator.deregisterOperator(quorumNumbers, incorrectPubKey);
     }
 
     function testDeregisterOperatorWithCoordinator_IncorrectQuorums_Reverts() public {
@@ -394,9 +394,9 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         quorumNumbers[0] = bytes1(defaultQuorumNumber + 1);
         quorumNumbers[1] = bytes1(defaultQuorumNumber + 2);
 
-        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._deregisterOperatorWithCoordinator: operator is not registered for any of the provided quorums");
+        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._deregisterOperator: operator is not registered for any of the provided quorums");
         cheats.prank(defaultOperator);
-        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbers, defaultPubKey);
+        registryCoordinator.deregisterOperator(quorumNumbers, defaultPubKey);
     }
 
     function testDeregisterOperatorWithCoordinatorForSingleQuorumAndSingleOperator_Valid() public {
@@ -412,7 +412,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         
         cheats.roll(registrationBlockNumber);
         
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
 
         uint256 quorumBitmap = BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers);
 
@@ -424,7 +424,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         cheats.roll(deregistrationBlockNumber);
 
         uint256 gasBefore = gasleft();
-        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbers, defaultPubKey);
+        registryCoordinator.deregisterOperator(quorumNumbers, defaultPubKey);
         uint256 gasAfter = gasleft();
         emit log_named_uint("gasUsed", gasBefore - gasAfter);
 
@@ -435,9 +435,9 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
                 status: IRegistryCoordinator.OperatorStatus.DEREGISTERED
             })))
         );
-        assertEq(registryCoordinator.getCurrentQuorumBitmapByOperatorId(defaultOperatorId), 0);
+        assertEq(registryCoordinator.getCurrentQuorumBitmap(defaultOperatorId), 0);
         assertEq(
-            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByOperatorIdByIndex(defaultOperatorId, 0))), 
+            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByIndex(defaultOperatorId, 0))), 
             keccak256(abi.encode(IRegistryCoordinator.QuorumBitmapUpdate({
                 quorumBitmap: uint192(quorumBitmap),
                 updateBlockNumber: registrationBlockNumber,
@@ -462,7 +462,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         
         cheats.roll(registrationBlockNumber);
         
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
 
         cheats.expectEmit(true, true, true, true, address(blsPubkeyRegistry));
         emit OperatorRemovedFromQuorums(defaultOperator, quorumNumbers);
@@ -474,7 +474,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         cheats.roll(deregistrationBlockNumber);
 
         uint256 gasBefore = gasleft();
-        registryCoordinator.deregisterOperatorWithCoordinator(quorumNumbers, defaultPubKey);
+        registryCoordinator.deregisterOperator(quorumNumbers, defaultPubKey);
         uint256 gasAfter = gasleft();
         emit log_named_uint("gasUsed", gasBefore - gasAfter);
         emit log_named_uint("numQuorums", quorumNumbers.length);
@@ -486,9 +486,9 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
                 status: IRegistryCoordinator.OperatorStatus.DEREGISTERED
             })))
         );
-        assertEq(registryCoordinator.getCurrentQuorumBitmapByOperatorId(defaultOperatorId), 0);
+        assertEq(registryCoordinator.getCurrentQuorumBitmap(defaultOperatorId), 0);
         assertEq(
-            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByOperatorIdByIndex(defaultOperatorId, 0))), 
+            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByIndex(defaultOperatorId, 0))), 
             keccak256(abi.encode(IRegistryCoordinator.QuorumBitmapUpdate({
                 quorumBitmap: uint192(quorumBitmap),
                 updateBlockNumber: registrationBlockNumber,
@@ -551,7 +551,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         cheats.roll(deregistrationBlockNumber);
 
         cheats.prank(operatorToDerigister);
-        registryCoordinator.deregisterOperatorWithCoordinator(operatorToDeregisterQuorumNumbers, operatorToDeregisterPubKey);
+        registryCoordinator.deregisterOperator(operatorToDeregisterQuorumNumbers, operatorToDeregisterPubKey);
 
         assertEq(
             keccak256(abi.encode(registryCoordinator.getOperator(operatorToDerigister))), 
@@ -560,9 +560,9 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
                 status: IRegistryCoordinator.OperatorStatus.DEREGISTERED
             })))
         );
-        assertEq(registryCoordinator.getCurrentQuorumBitmapByOperatorId(defaultOperatorId), 0);
+        assertEq(registryCoordinator.getCurrentQuorumBitmap(defaultOperatorId), 0);
         assertEq(
-            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByOperatorIdByIndex(operatorToDerigisterId, 0))), 
+            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByIndex(operatorToDerigisterId, 0))), 
             keccak256(abi.encode(IRegistryCoordinator.QuorumBitmapUpdate({
                 quorumBitmap: uint192(operatorToDeregisterQuorumBitmap),
                 updateBlockNumber: registrationBlockNumber,
@@ -586,10 +586,10 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         
         // store data before registering, to check against later
         IRegistryCoordinator.QuorumBitmapUpdate memory previousQuorumBitmapUpdate =
-            registryCoordinator.getQuorumBitmapUpdateByOperatorIdByIndex(defaultOperatorId, 0);
+            registryCoordinator.getQuorumBitmapUpdateByIndex(defaultOperatorId, 0);
 
         // re-register the operator
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
 
         // check success of registration
         uint256 quorumBitmap = BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers);
@@ -601,15 +601,15 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
                 status: IRegistryCoordinator.OperatorStatus.REGISTERED
             })))
         );
-        assertEq(registryCoordinator.getCurrentQuorumBitmapByOperatorId(defaultOperatorId), quorumBitmap);
+        assertEq(registryCoordinator.getCurrentQuorumBitmap(defaultOperatorId), quorumBitmap);
         // check that previous entry in bitmap history was not changed
         assertEq(
-            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByOperatorIdByIndex(defaultOperatorId, 0))), 
+            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByIndex(defaultOperatorId, 0))), 
             keccak256(abi.encode(previousQuorumBitmapUpdate))
         );
         // check that new entry in bitmap history is as expected
         assertEq(
-            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByOperatorIdByIndex(defaultOperatorId, 1))), 
+            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByIndex(defaultOperatorId, 1))), 
             keccak256(abi.encode(IRegistryCoordinator.QuorumBitmapUpdate({
                 quorumBitmap: uint192(quorumBitmap),
                 updateBlockNumber: uint32(reregistrationBlockNumber),
@@ -687,7 +687,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
             ISignatureUtils.SignatureWithSaltAndExpiry memory signatureWithExpiry = _signOperatorChurnApproval(operatorToRegisterId, operatorKickParams, defaultSalt, block.timestamp + 10);
             cheats.prank(operatorToRegister);
             uint256 gasBefore = gasleft();
-            registryCoordinator.registerOperatorWithCoordinator(
+            registryCoordinator.registerOperatorWithChurn(
                 quorumNumbers, 
                 operatorToRegisterPubKey, 
                 defaultSocket, 
@@ -713,7 +713,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
             })))
         );
         assertEq(
-            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByOperatorIdByIndex(operatorToKickId, 0))), 
+            keccak256(abi.encode(registryCoordinator.getQuorumBitmapUpdateByIndex(operatorToKickId, 0))), 
             keccak256(abi.encode(IRegistryCoordinator.QuorumBitmapUpdate({
                 quorumBitmap: uint192(quorumBitmap),
                 updateBlockNumber: kickRegistrationBlockNumber,
@@ -738,8 +738,8 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         cheats.roll(registrationBlockNumber);
         ISignatureUtils.SignatureWithSaltAndExpiry memory signatureWithExpiry = _signOperatorChurnApproval(operatorToRegisterId, operatorKickParams, defaultSalt, block.timestamp + 10);
         cheats.prank(operatorToRegister);
-        cheats.expectRevert("BLSRegistryCoordinatorWithIndices.registerOperatorWithCoordinator: registering operator has less than kickBIPsOfOperatorStake");
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, operatorToRegisterPubKey, defaultSocket, operatorKickParams, signatureWithExpiry);
+        cheats.expectRevert("BLSRegistryCoordinatorWithIndices.registerOperatorWithChurn: registering operator has less than kickBIPsOfOperatorStake");
+        registryCoordinator.registerOperatorWithChurn(quorumNumbers, operatorToRegisterPubKey, defaultSocket, operatorKickParams, signatureWithExpiry);
     }
 
     function testRegisterOperatorWithCoordinatorWithKicks_LessThanKickBIPsOfTotalStake_Reverts(uint256 pseudoRandomNumber) public {
@@ -761,8 +761,8 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         cheats.roll(registrationBlockNumber);
         ISignatureUtils.SignatureWithSaltAndExpiry memory signatureWithExpiry = _signOperatorChurnApproval(operatorToRegisterId, operatorKickParams, defaultSalt, block.timestamp + 10);
         cheats.prank(operatorToRegister);
-        cheats.expectRevert("BLSRegistryCoordinatorWithIndices.registerOperatorWithCoordinator: operator to kick has more than kickBIPSOfTotalStake");
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, operatorToRegisterPubKey, defaultSocket, operatorKickParams, signatureWithExpiry);
+        cheats.expectRevert("BLSRegistryCoordinatorWithIndices.registerOperatorWithChurn: operator to kick has more than kickBIPSOfTotalStake");
+        registryCoordinator.registerOperatorWithChurn(quorumNumbers, operatorToRegisterPubKey, defaultSocket, operatorKickParams, signatureWithExpiry);
     }
 
     function testRegisterOperatorWithCoordinatorWithKicks_InvalidSignatures_Reverts(uint256 pseudoRandomNumber) public {
@@ -785,7 +785,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         signatureWithSaltAndExpiry.salt = defaultSalt;
         cheats.prank(operatorToRegister);
         cheats.expectRevert("ECDSA: invalid signature");
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, operatorToRegisterPubKey, defaultSocket, operatorKickParams, signatureWithSaltAndExpiry);
+        registryCoordinator.registerOperatorWithChurn(quorumNumbers, operatorToRegisterPubKey, defaultSocket, operatorKickParams, signatureWithSaltAndExpiry);
     }
 
     function testRegisterOperatorWithCoordinatorWithKicks_ExpiredSignatures_Reverts(uint256 pseudoRandomNumber) public {
@@ -806,7 +806,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         ISignatureUtils.SignatureWithSaltAndExpiry memory signatureWithSaltAndExpiry = _signOperatorChurnApproval(operatorToRegisterId, operatorKickParams, defaultSalt, block.timestamp - 1);
         cheats.prank(operatorToRegister);
         cheats.expectRevert("BLSRegistryCoordinatorWithIndices._verifyChurnApproverSignature: churnApprover signature expired");
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, operatorToRegisterPubKey, defaultSocket, operatorKickParams, signatureWithSaltAndExpiry);
+        registryCoordinator.registerOperatorWithChurn(quorumNumbers, operatorToRegisterPubKey, defaultSocket, operatorKickParams, signatureWithSaltAndExpiry);
     }
 
     function testEjectOperatorFromCoordinator_AllQuorums_Valid() public {
@@ -817,7 +817,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         stakeRegistry.setOperatorWeight(uint8(quorumNumbers[0]), defaultOperator, defaultStake);
 
         cheats.prank(defaultOperator);
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
 
         cheats.expectEmit(true, true, true, true, address(blsPubkeyRegistry));
         emit OperatorRemovedFromQuorums(defaultOperator, quorumNumbers);
@@ -827,7 +827,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
         // eject
         cheats.prank(ejector);
-        registryCoordinator.ejectOperatorFromCoordinator(defaultOperator, quorumNumbers, defaultPubKey);
+        registryCoordinator.ejectOperator(defaultOperator, quorumNumbers, defaultPubKey);
         
         // make sure the operator is deregistered
         assertEq(
@@ -838,7 +838,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
             })))
         );
         // make sure the operator is not in any quorums
-        assertEq(registryCoordinator.getCurrentQuorumBitmapByOperatorId(defaultOperatorId), 0);
+        assertEq(registryCoordinator.getCurrentQuorumBitmap(defaultOperatorId), 0);
     } 
 
     function testEjectOperatorFromCoordinator_SubsetOfQuorums_Valid() public {
@@ -852,7 +852,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         }
 
         cheats.prank(defaultOperator);
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
 
         // eject from only first quorum
         bytes memory quorumNumbersToEject = new bytes(1);
@@ -865,7 +865,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         emit StakeUpdate(defaultOperatorId, uint8(quorumNumbersToEject[0]), 0);
 
         cheats.prank(ejector);
-        registryCoordinator.ejectOperatorFromCoordinator(defaultOperator, quorumNumbersToEject, defaultPubKey);
+        registryCoordinator.ejectOperator(defaultOperator, quorumNumbersToEject, defaultPubKey);
         
         // make sure the operator is registered
         assertEq(
@@ -877,7 +877,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         );
         // make sure the operator is not in any quorums
         assertEq(
-            registryCoordinator.getCurrentQuorumBitmapByOperatorId(defaultOperatorId), 
+            registryCoordinator.getCurrentQuorumBitmap(defaultOperatorId), 
             BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers) & ~BitmapUtils.orderedBytesArrayToBitmap(quorumNumbersToEject) // quorumsRegisteredFor & ~quorumsEjectedFrom
         );
     }
@@ -889,11 +889,11 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         stakeRegistry.setOperatorWeight(uint8(quorumNumbers[0]), defaultOperator, defaultStake);
 
         cheats.prank(defaultOperator);
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
         
         cheats.expectRevert("BLSRegistryCoordinatorWithIndices.onlyEjector: caller is not the ejector");
         cheats.prank(defaultOperator);
-        registryCoordinator.ejectOperatorFromCoordinator(defaultOperator, quorumNumbers, defaultPubKey);
+        registryCoordinator.ejectOperator(defaultOperator, quorumNumbers, defaultPubKey);
     }
 
     function testUpdateSocket() public {
@@ -912,7 +912,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
     function testUpdateSocket_NotRegistered_Reverts() public {
         cheats.prank(defaultOperator);
-        cheats.expectRevert("BLSRegistryCoordinatorWithIndicies.updateSocket: operator is not registered");
+        cheats.expectRevert("BLSRegistryCoordinatorWithIndices.updateSocket: operator is not registered");
         registryCoordinator.updateSocket("localhost:32004");
     }
 

--- a/test/unit/BLSSignatureCheckerUnit.t.sol
+++ b/test/unit/BLSSignatureCheckerUnit.t.sol
@@ -88,7 +88,7 @@ contract BLSSignatureCheckerUnitTests is BLSMockAVSDeployer {
         // set the nonSignerQuorumBitmapIndices to a different value
         nonSignerStakesAndSignature.nonSignerQuorumBitmapIndices[0] = 1;
 
-        cheats.expectRevert("BLSRegistryCoordinatorWithIndices.getQuorumBitmapByOperatorIdAtBlockNumberByIndex: quorumBitmapUpdate is from after blockNumber");
+        cheats.expectRevert("BLSRegistryCoordinatorWithIndices.getQuorumBitmapAtBlockNumberByIndex: quorumBitmapUpdate is from after blockNumber");
         blsSignatureChecker.checkSignatures(
             msgHash, 
             quorumNumbers,

--- a/test/unit/IndexRegistryUnit.t.sol
+++ b/test/unit/IndexRegistryUnit.t.sol
@@ -71,7 +71,7 @@ contract IndexRegistryUnitTests is Test {
 
         // Check _operatorIdToIndexHistory updates
         IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-            .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 0, quorumNumber: 1, index: 0});
+            .getOperatorUpdateAtIndex({operatorIndex: 0, quorumNumber: 1, index: 0});
         require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: operatorId not operatorId1");
         require(
             operatorUpdate.fromBlockNumber == block.number,
@@ -116,7 +116,7 @@ contract IndexRegistryUnitTests is Test {
 
         // Check _operatorIdToIndexHistory updates
         IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-            .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 0, quorumNumber: 2, index: 0});
+            .getOperatorUpdateAtIndex({operatorIndex: 0, quorumNumber: 2, index: 0});
         require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: operatorId not operatorId1");
         require(
             operatorUpdate.fromBlockNumber == block.number,
@@ -159,7 +159,7 @@ contract IndexRegistryUnitTests is Test {
 
         // Check _operatorIdToIndexHistory updates for quorum 1
         IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-            .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 0, quorumNumber: 1, index: 0});
+            .getOperatorUpdateAtIndex({operatorIndex: 0, quorumNumber: 1, index: 0});
         require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: operatorId not 1operatorId1");
         require(
             operatorUpdate.fromBlockNumber == block.number,
@@ -183,7 +183,7 @@ contract IndexRegistryUnitTests is Test {
         );
 
         // Check _operatorIdToIndexHistory updates for quorum 2
-        operatorUpdate = indexRegistry.getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 0 , quorumNumber: 2, index: 0});
+        operatorUpdate = indexRegistry.getOperatorUpdateAtIndex({operatorIndex: 0 , quorumNumber: 2, index: 0});
         require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: operatorId not operatorId1");
         require(
             operatorUpdate.fromBlockNumber == block.number,
@@ -226,7 +226,7 @@ contract IndexRegistryUnitTests is Test {
 
         // Check _operatorIdToIndexHistory updates
         IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-            .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 1, quorumNumber: 1, index: 0});
+            .getOperatorUpdateAtIndex({operatorIndex: 1, quorumNumber: 1, index: 0});
         require(operatorUpdate.operatorId == operatorId2, "IndexRegistry.registerOperator: operatorId not operatorId2");
         require(
             operatorUpdate.fromBlockNumber == block.number,
@@ -266,7 +266,7 @@ contract IndexRegistryUnitTests is Test {
 
         // Check operator's index
         IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-            .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 0, quorumNumber: defaultQuorumNumber, index: 1});
+            .getOperatorUpdateAtIndex({operatorIndex: 0, quorumNumber: defaultQuorumNumber, index: 1});
         require(operatorUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
         require(operatorUpdate.operatorId == bytes32(0), "incorrect operatorId");
 
@@ -299,7 +299,7 @@ contract IndexRegistryUnitTests is Test {
         // Check operator's index for removed quorums
         for (uint256 i = 0; i < quorumsToRemove.length; i++) {
             IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-                .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 2, quorumNumber: uint8(quorumsToRemove[i]), index: 1}); // 2 indexes -> 1 update and 1 remove
+                .getOperatorUpdateAtIndex({operatorIndex: 2, quorumNumber: uint8(quorumsToRemove[i]), index: 1}); // 2 indexes -> 1 update and 1 remove
             require(operatorUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
             require(operatorUpdate.operatorId == bytes32(0), "incorrect operatorId");
         }
@@ -319,7 +319,7 @@ contract IndexRegistryUnitTests is Test {
         // Check swapped operator's index for removed quorums
         for (uint256 i = 0; i < quorumsToRemove.length; i++) {
             IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-                .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 0, quorumNumber: uint8(quorumsToRemove[i]), index: 1}); // 2 indexes -> 1 update and 1 swap
+                .getOperatorUpdateAtIndex({operatorIndex: 0, quorumNumber: uint8(quorumsToRemove[i]), index: 1}); // 2 indexes -> 1 update and 1 swap
             require(operatorUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
             require(operatorUpdate.operatorId == operatorId3, "incorrect operatorId");
         }
@@ -336,9 +336,9 @@ contract IndexRegistryUnitTests is Test {
         _registerOperator(operatorId1, quorumNumbers);
 
         cheats.expectRevert(
-            "IndexRegistry.getTotalOperatorsForQuorumAtBlockNumberByIndex: provided index is too far in the past for provided block number"
+            "IndexRegistry.getTotalOperatorsForIndexAtBlockNumber: provided index is too far in the past for provided block number"
         );
-        indexRegistry.getTotalOperatorsForQuorumAtBlockNumberByIndex(defaultQuorumNumber, uint32(block.number - 1), 0);
+        indexRegistry.getTotalOperatorsForIndexAtBlockNumber(defaultQuorumNumber, uint32(block.number - 1), 0);
     }
 
     function testGetTotalOperatorsForQuorumAtBlockNumberByIndex_revert_indexBlockMismatch() public {
@@ -350,9 +350,9 @@ contract IndexRegistryUnitTests is Test {
         _registerOperator(operatorId2, quorumNumbers);
 
         cheats.expectRevert(
-            "IndexRegistry.getTotalOperatorsForQuorumAtBlockNumberByIndex: provided index is too far in the future for provided block number"
+            "IndexRegistry.getTotalOperatorsForIndexAtBlockNumber: provided index is too far in the future for provided block number"
         );
-        indexRegistry.getTotalOperatorsForQuorumAtBlockNumberByIndex(defaultQuorumNumber, uint32(block.number), 0);
+        indexRegistry.getTotalOperatorsForIndexAtBlockNumber(defaultQuorumNumber, uint32(block.number), 0);
     }
 
     function testGetTotalOperatorsForQuorumAtBlockNumberByIndex() public {
@@ -364,20 +364,20 @@ contract IndexRegistryUnitTests is Test {
         _registerOperator(operatorId2, quorumNumbers);
 
         // Check that the first total is correct
-        uint32 prevTotal = indexRegistry.getTotalOperatorsForQuorumAtBlockNumberByIndex(
+        uint32 prevTotal = indexRegistry.getTotalOperatorsForIndexAtBlockNumber(
             defaultQuorumNumber,
             uint32(block.number - 10),
             1
         );
-        require(prevTotal == 1, "IndexRegistry.getTotalOperatorsForQuorumAtBlockNumberByIndex: prev total not 1");
+        require(prevTotal == 1, "IndexRegistry.getTotalOperatorsForIndexAtBlockNumber: prev total not 1");
 
         // Check that the total is correct
-        uint32 currentTotal = indexRegistry.getTotalOperatorsForQuorumAtBlockNumberByIndex(
+        uint32 currentTotal = indexRegistry.getTotalOperatorsForIndexAtBlockNumber(
             defaultQuorumNumber,
             uint32(block.number),
             2
         );
-        require(currentTotal == 2, "IndexRegistry.getTotalOperatorsForQuorumAtBlockNumberByIndex: current total not 2");
+        require(currentTotal == 2, "IndexRegistry.getTotalOperatorsForIndexAtBlockNumber: current total not 2");
     }
 
     function testGetOperatorListForQuorumAtBlockNumber() public {
@@ -394,46 +394,46 @@ contract IndexRegistryUnitTests is Test {
         indexRegistry.deregisterOperator(operatorId1, quorumNumbers);
 
         // Check the operator list after first registration
-        bytes32[] memory operatorList = indexRegistry.getOperatorListForQuorumAtBlockNumber(
+        bytes32[] memory operatorList = indexRegistry.getOperatorListAtBlockNumber(
             defaultQuorumNumber,
             uint32(block.number - 20)
         );
         require(
             operatorList.length == 1,
-            "IndexRegistry.getOperatorListForQuorumAtBlockNumber: operator list length not 1"
+            "IndexRegistry.getOperatorListAtBlockNumber: operator list length not 1"
         );
         require(
             operatorList[0] == operatorId1,
-            "IndexRegistry.getOperatorListForQuorumAtBlockNumber: operator list incorrect"
+            "IndexRegistry.getOperatorListAtBlockNumber: operator list incorrect"
         );
 
         // Check the operator list after second registration
-        operatorList = indexRegistry.getOperatorListForQuorumAtBlockNumber(
+        operatorList = indexRegistry.getOperatorListAtBlockNumber(
             defaultQuorumNumber,
             uint32(block.number - 10)
         );
         require(
             operatorList.length == 2,
-            "IndexRegistry.getOperatorListForQuorumAtBlockNumber: operator list length not 2"
+            "IndexRegistry.getOperatorListAtBlockNumber: operator list length not 2"
         );
         require(
             operatorList[0] == operatorId1,
-            "IndexRegistry.getOperatorListForQuorumAtBlockNumber: operator list incorrect"
+            "IndexRegistry.getOperatorListAtBlockNumber: operator list incorrect"
         );
         require(
             operatorList[1] == operatorId2,
-            "IndexRegistry.getOperatorListForQuorumAtBlockNumber: operator list incorrect"
+            "IndexRegistry.getOperatorListAtBlockNumber: operator list incorrect"
         );
 
         // Check the operator list after deregistration
-        operatorList = indexRegistry.getOperatorListForQuorumAtBlockNumber(defaultQuorumNumber, uint32(block.number));
+        operatorList = indexRegistry.getOperatorListAtBlockNumber(defaultQuorumNumber, uint32(block.number));
         require(
             operatorList.length == 1,
-            "IndexRegistry.getOperatorListForQuorumAtBlockNumber: operator list length not 1"
+            "IndexRegistry.getOperatorListAtBlockNumber: operator list length not 1"
         );
         require(
             operatorList[0] == operatorId2,
-            "IndexRegistry.getOperatorListForQuorumAtBlockNumber: operator list incorrect"
+            "IndexRegistry.getOperatorListAtBlockNumber: operator list incorrect"
         );
     }
 
@@ -490,7 +490,7 @@ contract IndexRegistryUnitTests is Test {
         // Check _operatorIdToIndexHistory updates
         IIndexRegistry.OperatorUpdate memory operatorUpdate;
         for (uint256 i = 0; i < quorumNumbers.length; i++) {
-            operatorUpdate = indexRegistry.getOperatorIndexUpdateOfIndexForQuorumAtIndex({
+            operatorUpdate = indexRegistry.getOperatorUpdateAtIndex({
                 operatorIndex: 0,
                 quorumNumber: uint8(quorumNumbers[i]),
                 index: 0
@@ -597,7 +597,7 @@ contract IndexRegistryUnitTests is Test {
         // Check operator's index for removed quorums
         for (uint256 i = 0; i < quorumsToRemove.length; i++) {
             IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-                .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 1, quorumNumber: uint8(quorumsToRemove[i]), index: 1}); // 2 indexes -> 1 update and 1 remove
+                .getOperatorUpdateAtIndex({operatorIndex: 1, quorumNumber: uint8(quorumsToRemove[i]), index: 1}); // 2 indexes -> 1 update and 1 remove
             require(operatorUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
             require(operatorUpdate.operatorId == bytes32(0), "incorrect operatorId");
         }
@@ -617,7 +617,7 @@ contract IndexRegistryUnitTests is Test {
         // Check swapped operator's index for removed quorums
         for (uint256 i = 0; i < quorumsToRemove.length; i++) {
             IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-                .getOperatorIndexUpdateOfIndexForQuorumAtIndex({operatorIndex: 0, quorumNumber: uint8(quorumsToRemove[i]), index: 1}); // 2 indexes -> 1 update and 1 swap
+                .getOperatorUpdateAtIndex({operatorIndex: 0, quorumNumber: uint8(quorumsToRemove[i]), index: 1}); // 2 indexes -> 1 update and 1 swap
             require(operatorUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
             require(operatorUpdate.operatorId == operatorId2, "incorrect operatorId");
         }

--- a/test/unit/IndexRegistryUnit.t.sol
+++ b/test/unit/IndexRegistryUnit.t.sol
@@ -61,6 +61,8 @@ contract IndexRegistryUnitTests is Test {
         cheats.prank(address(registryCoordinatorMock));
         uint32[] memory numOperatorsPerQuorum = indexRegistry.registerOperator(operatorId1, quorumNumbers);
 
+        emit log_named_uint("hi: ", 1);
+
         // Check return value
         require(
             numOperatorsPerQuorum.length == 1,
@@ -68,10 +70,11 @@ contract IndexRegistryUnitTests is Test {
         );
         require(numOperatorsPerQuorum[0] == 1, "IndexRegistry.registerOperator: numOperatorsPerQuorum[0] not 1");
 
+        emit log_named_uint("hi: ", 2);
 
         // Check _operatorIdToIndexHistory updates
         IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-            .getOperatorUpdateAtIndex({operatorIndex: 0, quorumNumber: 1, index: 0});
+            .getOperatorUpdateAtIndex({operatorIndex: 0, quorumNumber: defaultQuorumNumber, index: 0});
         require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: operatorId not operatorId1");
         require(
             operatorUpdate.fromBlockNumber == block.number,
@@ -80,7 +83,8 @@ contract IndexRegistryUnitTests is Test {
 
         // Check _totalOperatorsHistory updates
         IIndexRegistry.QuorumUpdate memory quorumUpdate = indexRegistry
-            .getQuorumUpdateAtIndex(1, 1);
+            .getLatestQuorumUpdate(defaultQuorumNumber);
+        
         require(
             quorumUpdate.numOperators == 1,
             "IndexRegistry.registerOperator: totalOperatorsHistory num operators not 1"
@@ -90,7 +94,7 @@ contract IndexRegistryUnitTests is Test {
             "IndexRegistry.registerOperator: totalOperatorsHistory fromBlockNumber not correct"
         );
         require(
-            indexRegistry.totalOperatorsForQuorum(1) == 1,
+            indexRegistry.totalOperatorsForQuorum(defaultQuorumNumber) == 1,
             "IndexRegistry.registerOperator: total operators for quorum not updated correctly"
         );
     }
@@ -116,7 +120,7 @@ contract IndexRegistryUnitTests is Test {
 
         // Check _operatorIdToIndexHistory updates
         IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-            .getOperatorUpdateAtIndex({operatorIndex: 0, quorumNumber: 2, index: 0});
+            .getOperatorUpdateAtIndex({operatorIndex: 0, quorumNumber: defaultQuorumNumber + 1, index: 0});
         require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: operatorId not operatorId1");
         require(
             operatorUpdate.fromBlockNumber == block.number,
@@ -125,7 +129,7 @@ contract IndexRegistryUnitTests is Test {
 
         // Check _totalOperatorsHistory updates
         IIndexRegistry.QuorumUpdate memory quorumUpdate = indexRegistry
-            .getQuorumUpdateAtIndex(2, 1);
+            .getLatestQuorumUpdate(defaultQuorumNumber + 1);
         require(
             quorumUpdate.numOperators == 1,
             "IndexRegistry.registerOperator: totalOperatorsHistory num operators not 1"
@@ -135,7 +139,7 @@ contract IndexRegistryUnitTests is Test {
             "IndexRegistry.registerOperator: totalOperatorsHistory fromBlockNumber not correct"
         );
         require(
-            indexRegistry.totalOperatorsForQuorum(2) == 1,
+            indexRegistry.totalOperatorsForQuorum(defaultQuorumNumber + 1) == 1,
             "IndexRegistry.registerOperator: total operators for quorum not updated correctly"
         );
     }
@@ -159,7 +163,7 @@ contract IndexRegistryUnitTests is Test {
 
         // Check _operatorIdToIndexHistory updates for quorum 1
         IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-            .getOperatorUpdateAtIndex({operatorIndex: 0, quorumNumber: 1, index: 0});
+            .getOperatorUpdateAtIndex({operatorIndex: 0, quorumNumber: defaultQuorumNumber, index: 0});
         require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: operatorId not 1operatorId1");
         require(
             operatorUpdate.fromBlockNumber == block.number,
@@ -168,7 +172,7 @@ contract IndexRegistryUnitTests is Test {
 
         // Check _totalOperatorsHistory updates for quorum 1
         IIndexRegistry.QuorumUpdate memory quorumUpdate = indexRegistry
-            .getQuorumUpdateAtIndex(1, 1);
+            .getLatestQuorumUpdate(defaultQuorumNumber);
         require(
             quorumUpdate.numOperators == 1,
             "IndexRegistry.registerOperator: totalOperatorsHistory numOperators not 1"
@@ -178,12 +182,12 @@ contract IndexRegistryUnitTests is Test {
             "IndexRegistry.registerOperator: totalOperatorsHistory fromBlockNumber not correct"
         );
         require(
-            indexRegistry.totalOperatorsForQuorum(1) == 1,
+            indexRegistry.totalOperatorsForQuorum(defaultQuorumNumber) == 1,
             "IndexRegistry.registerOperator: total operators for quorum not updated correctly"
         );
 
         // Check _operatorIdToIndexHistory updates for quorum 2
-        operatorUpdate = indexRegistry.getOperatorUpdateAtIndex({operatorIndex: 0 , quorumNumber: 2, index: 0});
+        operatorUpdate = indexRegistry.getOperatorUpdateAtIndex({operatorIndex: 0 , quorumNumber: defaultQuorumNumber + 1, index: 0});
         require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: operatorId not operatorId1");
         require(
             operatorUpdate.fromBlockNumber == block.number,
@@ -191,7 +195,7 @@ contract IndexRegistryUnitTests is Test {
         );
 
         // Check _totalOperatorsHistory updates for quorum 2
-        quorumUpdate = indexRegistry.getQuorumUpdateAtIndex(2, 1);
+        quorumUpdate = indexRegistry.getLatestQuorumUpdate(defaultQuorumNumber + 1);
         require(
             quorumUpdate.numOperators == 1,
             "IndexRegistry.registerOperator: totalOperatorsHistory num operators not 1"
@@ -201,7 +205,7 @@ contract IndexRegistryUnitTests is Test {
             "IndexRegistry.registerOperator: totalOperatorsHistory fromBlockNumber not correct"
         );
         require(
-            indexRegistry.totalOperatorsForQuorum(2) == 1,
+            indexRegistry.totalOperatorsForQuorum(defaultQuorumNumber + 1) == 1,
             "IndexRegistry.registerOperator: total operators for quorum not updated correctly"
         );
     }
@@ -226,7 +230,7 @@ contract IndexRegistryUnitTests is Test {
 
         // Check _operatorIdToIndexHistory updates
         IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-            .getOperatorUpdateAtIndex({operatorIndex: 1, quorumNumber: 1, index: 0});
+            .getLatestOperatorUpdate({quorumNumber: defaultQuorumNumber, index: 1});
         require(operatorUpdate.operatorId == operatorId2, "IndexRegistry.registerOperator: operatorId not operatorId2");
         require(
             operatorUpdate.fromBlockNumber == block.number,
@@ -235,7 +239,7 @@ contract IndexRegistryUnitTests is Test {
 
         // Check _totalOperatorsHistory updates
         IIndexRegistry.QuorumUpdate memory quorumUpdate = indexRegistry
-            .getQuorumUpdateAtIndex(1, 2);
+            .getLatestQuorumUpdate(defaultQuorumNumber);
         require(
             quorumUpdate.numOperators == 2,
             "IndexRegistry.registerOperator: totalOperatorsHistory num operators not 2"
@@ -245,7 +249,7 @@ contract IndexRegistryUnitTests is Test {
             "IndexRegistry.registerOperator: totalOperatorsHistory fromBlockNumber not correct"
         );
         require(
-            indexRegistry.totalOperatorsForQuorum(1) == 2,
+            indexRegistry.totalOperatorsForQuorum(defaultQuorumNumber) == 2,
             "IndexRegistry.registerOperator: total operators for quorum not updated correctly"
         );
     }
@@ -266,16 +270,16 @@ contract IndexRegistryUnitTests is Test {
 
         // Check operator's index
         IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-            .getOperatorUpdateAtIndex({operatorIndex: 0, quorumNumber: defaultQuorumNumber, index: 1});
+            .getLatestOperatorUpdate({quorumNumber: defaultQuorumNumber, index: 0});
         require(operatorUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
         require(operatorUpdate.operatorId == bytes32(0), "incorrect operatorId");
 
         // Check total operators
         IIndexRegistry.QuorumUpdate memory quorumUpdate = indexRegistry
-            .getQuorumUpdateAtIndex(defaultQuorumNumber, 2);
+            .getLatestQuorumUpdate(defaultQuorumNumber);
         require(quorumUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
         require(quorumUpdate.numOperators == 0, "incorrect total number of operators");
-        require(indexRegistry.totalOperatorsForQuorum(1) == 0, "operator not deregistered correctly");
+        require(indexRegistry.totalOperatorsForQuorum(defaultQuorumNumber) == 0, "operator not deregistered correctly");
     }
 
     function testDeregisterOperatorMultipleQuorums() public {
@@ -299,7 +303,7 @@ contract IndexRegistryUnitTests is Test {
         // Check operator's index for removed quorums
         for (uint256 i = 0; i < quorumsToRemove.length; i++) {
             IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-                .getOperatorUpdateAtIndex({operatorIndex: 2, quorumNumber: uint8(quorumsToRemove[i]), index: 1}); // 2 indexes -> 1 update and 1 remove
+                .getLatestOperatorUpdate({quorumNumber: uint8(quorumsToRemove[i]), index: 2});
             require(operatorUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
             require(operatorUpdate.operatorId == bytes32(0), "incorrect operatorId");
         }
@@ -307,7 +311,7 @@ contract IndexRegistryUnitTests is Test {
         // Check total operators for removed quorums
         for (uint256 i = 0; i < quorumsToRemove.length; i++) {
             IIndexRegistry.QuorumUpdate memory quorumUpdate = indexRegistry
-                .getQuorumUpdateAtIndex(uint8(quorumsToRemove[i]), 4); // 5 updates total
+                .getLatestQuorumUpdate(uint8(quorumsToRemove[i])); // 5 updates total
             require(quorumUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
             require(quorumUpdate.numOperators == 2, "incorrect total number of operators");
             require(
@@ -319,7 +323,7 @@ contract IndexRegistryUnitTests is Test {
         // Check swapped operator's index for removed quorums
         for (uint256 i = 0; i < quorumsToRemove.length; i++) {
             IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-                .getOperatorUpdateAtIndex({operatorIndex: 0, quorumNumber: uint8(quorumsToRemove[i]), index: 1}); // 2 indexes -> 1 update and 1 swap
+                .getLatestOperatorUpdate({quorumNumber: uint8(quorumsToRemove[i]), index: 0});
             require(operatorUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
             require(operatorUpdate.operatorId == operatorId3, "incorrect operatorId");
         }
@@ -355,7 +359,7 @@ contract IndexRegistryUnitTests is Test {
         indexRegistry.getTotalOperatorsForIndexAtBlockNumber(defaultQuorumNumber, uint32(block.number), 0);
     }
 
-    function testGetTotalOperatorsForQuorumAtBlockNumberByIndex() public {
+    function testGetTotalOperatorsForIndexAtBlockNumber() public {
         // Add two operators
         bytes memory quorumNumbers = new bytes(1);
         quorumNumbers[0] = bytes1(defaultQuorumNumber);
@@ -367,7 +371,7 @@ contract IndexRegistryUnitTests is Test {
         uint32 prevTotal = indexRegistry.getTotalOperatorsForIndexAtBlockNumber(
             defaultQuorumNumber,
             uint32(block.number - 10),
-            1
+            0
         );
         require(prevTotal == 1, "IndexRegistry.getTotalOperatorsForIndexAtBlockNumber: prev total not 1");
 
@@ -375,7 +379,7 @@ contract IndexRegistryUnitTests is Test {
         uint32 currentTotal = indexRegistry.getTotalOperatorsForIndexAtBlockNumber(
             defaultQuorumNumber,
             uint32(block.number),
-            2
+            1
         );
         require(currentTotal == 2, "IndexRegistry.getTotalOperatorsForIndexAtBlockNumber: current total not 2");
     }
@@ -490,8 +494,7 @@ contract IndexRegistryUnitTests is Test {
         // Check _operatorIdToIndexHistory updates
         IIndexRegistry.OperatorUpdate memory operatorUpdate;
         for (uint256 i = 0; i < quorumNumbers.length; i++) {
-            operatorUpdate = indexRegistry.getOperatorUpdateAtIndex({
-                operatorIndex: 0,
+            operatorUpdate = indexRegistry.getLatestOperatorUpdate({
                 quorumNumber: uint8(quorumNumbers[i]),
                 index: 0
             });
@@ -505,7 +508,7 @@ contract IndexRegistryUnitTests is Test {
         // Check _totalOperatorsHistory updates
         IIndexRegistry.QuorumUpdate memory quorumUpdate;
         for (uint256 i = 0; i < quorumNumbers.length; i++) {
-            quorumUpdate = indexRegistry.getQuorumUpdateAtIndex(uint8(quorumNumbers[i]), 1);
+            quorumUpdate = indexRegistry.getLatestQuorumUpdate(uint8(quorumNumbers[i]));
             require(
                 quorumUpdate.numOperators == 1,
                 "IndexRegistry.registerOperator: totalOperatorsHistory num operators not 1"
@@ -534,23 +537,11 @@ contract IndexRegistryUnitTests is Test {
 
         // Check history of _totalOperatorsHistory updates at each blockNumber
         IIndexRegistry.QuorumUpdate memory quorumUpdate;
-        uint256 numOperators = 1;
-        for (uint256 blockNumber = block.number - 20; blockNumber <= block.number; blockNumber += 10) {
-            for (uint256 i = 0; i < quorumNumbers.length; i++) {
-                quorumUpdate = indexRegistry.getQuorumUpdateAtIndex(
-                    uint8(quorumNumbers[i]),
-                    uint32(numOperators)
-                );
-                require(
-                    quorumUpdate.numOperators == numOperators,
-                    "IndexRegistry.registerOperator: totalOperatorsHistory num operators not correct"
-                );
-                require(
-                    quorumUpdate.fromBlockNumber == blockNumber,
-                    "IndexRegistry.registerOperator: totalOperatorsHistory fromBlockNumber not correct"
-                );
-            }
-            numOperators++;
+        uint256 numOperators = 3;
+        for (uint256 i = 0; i < quorumNumbers.length; i++) {
+            quorumUpdate = indexRegistry.getLatestQuorumUpdate(uint8(quorumNumbers[i]));
+            assertEq(quorumUpdate.numOperators, numOperators, "num operators not correct");
+            assertEq(quorumUpdate.fromBlockNumber, block.number, "latest update should be from current block number");
         }
     }
 
@@ -597,7 +588,7 @@ contract IndexRegistryUnitTests is Test {
         // Check operator's index for removed quorums
         for (uint256 i = 0; i < quorumsToRemove.length; i++) {
             IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-                .getOperatorUpdateAtIndex({operatorIndex: 1, quorumNumber: uint8(quorumsToRemove[i]), index: 1}); // 2 indexes -> 1 update and 1 remove
+                .getLatestOperatorUpdate({quorumNumber: uint8(quorumsToRemove[i]), index: 1});
             require(operatorUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
             require(operatorUpdate.operatorId == bytes32(0), "incorrect operatorId");
         }
@@ -605,7 +596,7 @@ contract IndexRegistryUnitTests is Test {
         // Check total operators for removed quorums
         for (uint256 i = 0; i < quorumsToRemove.length; i++) {
             IIndexRegistry.QuorumUpdate memory quorumUpdate = indexRegistry
-                .getQuorumUpdateAtIndex(uint8(quorumsToRemove[i]), 3); // 4 updates total
+                .getLatestQuorumUpdate(uint8(quorumsToRemove[i]));
             require(quorumUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
             require(quorumUpdate.numOperators == 1, "incorrect total number of operators");
             require(
@@ -617,7 +608,7 @@ contract IndexRegistryUnitTests is Test {
         // Check swapped operator's index for removed quorums
         for (uint256 i = 0; i < quorumsToRemove.length; i++) {
             IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-                .getOperatorUpdateAtIndex({operatorIndex: 0, quorumNumber: uint8(quorumsToRemove[i]), index: 1}); // 2 indexes -> 1 update and 1 swap
+                .getLatestOperatorUpdate({quorumNumber: uint8(quorumsToRemove[i]), index: 0});
             require(operatorUpdate.fromBlockNumber == block.number, "fromBlockNumber not set correctly");
             require(operatorUpdate.operatorId == operatorId2, "incorrect operatorId");
         }

--- a/test/unit/IndexRegistryUnit.t.sol
+++ b/test/unit/IndexRegistryUnit.t.sol
@@ -74,7 +74,7 @@ contract IndexRegistryUnitTests is Test {
 
         // Check _operatorIdToIndexHistory updates
         IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-            .getOperatorUpdateAtIndex({operatorIndex: 0, quorumNumber: defaultQuorumNumber, index: 0});
+            .getOperatorUpdateAtIndex({quorumNumber: defaultQuorumNumber, operatorIndex: 0, index: 0});
         require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: operatorId not operatorId1");
         require(
             operatorUpdate.fromBlockNumber == block.number,
@@ -120,7 +120,7 @@ contract IndexRegistryUnitTests is Test {
 
         // Check _operatorIdToIndexHistory updates
         IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-            .getOperatorUpdateAtIndex({operatorIndex: 0, quorumNumber: defaultQuorumNumber + 1, index: 0});
+            .getOperatorUpdateAtIndex({quorumNumber: defaultQuorumNumber + 1, operatorIndex: 0, index: 0});
         require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: operatorId not operatorId1");
         require(
             operatorUpdate.fromBlockNumber == block.number,
@@ -163,7 +163,7 @@ contract IndexRegistryUnitTests is Test {
 
         // Check _operatorIdToIndexHistory updates for quorum 1
         IIndexRegistry.OperatorUpdate memory operatorUpdate = indexRegistry
-            .getOperatorUpdateAtIndex({operatorIndex: 0, quorumNumber: defaultQuorumNumber, index: 0});
+            .getOperatorUpdateAtIndex({quorumNumber: defaultQuorumNumber, operatorIndex: 0, index: 0});
         require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: operatorId not 1operatorId1");
         require(
             operatorUpdate.fromBlockNumber == block.number,
@@ -187,7 +187,7 @@ contract IndexRegistryUnitTests is Test {
         );
 
         // Check _operatorIdToIndexHistory updates for quorum 2
-        operatorUpdate = indexRegistry.getOperatorUpdateAtIndex({operatorIndex: 0 , quorumNumber: defaultQuorumNumber + 1, index: 0});
+        operatorUpdate = indexRegistry.getOperatorUpdateAtIndex({quorumNumber: defaultQuorumNumber + 1, operatorIndex: 0, index: 0});
         require(operatorUpdate.operatorId == operatorId1, "IndexRegistry.registerOperator: operatorId not operatorId1");
         require(
             operatorUpdate.fromBlockNumber == block.number,

--- a/test/unit/IndexRegistryUnit.t.sol
+++ b/test/unit/IndexRegistryUnit.t.sol
@@ -333,57 +333,6 @@ contract IndexRegistryUnitTests is Test {
                                 UNIT TESTS - GETTERS
     *******************************************************************************/
 
-    function testGetTotalOperatorsForQuorumAtBlockNumberByIndex_revert_indexTooEarly() public {
-        // Add operator
-        bytes memory quorumNumbers = new bytes(1);
-        quorumNumbers[0] = bytes1(defaultQuorumNumber);
-        _registerOperator(operatorId1, quorumNumbers);
-
-        cheats.expectRevert(
-            "IndexRegistry.getTotalOperatorsForIndexAtBlockNumber: provided index is too far in the past for provided block number"
-        );
-        indexRegistry.getTotalOperatorsForIndexAtBlockNumber(defaultQuorumNumber, uint32(block.number - 1), 0);
-    }
-
-    function testGetTotalOperatorsForQuorumAtBlockNumberByIndex_revert_indexBlockMismatch() public {
-        // Add two operators
-        bytes memory quorumNumbers = new bytes(1);
-        quorumNumbers[0] = bytes1(defaultQuorumNumber);
-        _registerOperator(operatorId1, quorumNumbers);
-        vm.roll(block.number + 10);
-        _registerOperator(operatorId2, quorumNumbers);
-
-        cheats.expectRevert(
-            "IndexRegistry.getTotalOperatorsForIndexAtBlockNumber: provided index is too far in the future for provided block number"
-        );
-        indexRegistry.getTotalOperatorsForIndexAtBlockNumber(defaultQuorumNumber, uint32(block.number), 0);
-    }
-
-    function testGetTotalOperatorsForIndexAtBlockNumber() public {
-        // Add two operators
-        bytes memory quorumNumbers = new bytes(1);
-        quorumNumbers[0] = bytes1(defaultQuorumNumber);
-        _registerOperator(operatorId1, quorumNumbers);
-        vm.roll(block.number + 10);
-        _registerOperator(operatorId2, quorumNumbers);
-
-        // Check that the first total is correct
-        uint32 prevTotal = indexRegistry.getTotalOperatorsForIndexAtBlockNumber(
-            defaultQuorumNumber,
-            uint32(block.number - 10),
-            0
-        );
-        require(prevTotal == 1, "IndexRegistry.getTotalOperatorsForIndexAtBlockNumber: prev total not 1");
-
-        // Check that the total is correct
-        uint32 currentTotal = indexRegistry.getTotalOperatorsForIndexAtBlockNumber(
-            defaultQuorumNumber,
-            uint32(block.number),
-            1
-        );
-        require(currentTotal == 2, "IndexRegistry.getTotalOperatorsForIndexAtBlockNumber: current total not 2");
-    }
-
     function testGetOperatorListForQuorumAtBlockNumber() public {
         // Register two operators
         bytes memory quorumNumbers = new bytes(1);

--- a/test/unit/VoteWeigherBaseUnit.t.sol
+++ b/test/unit/VoteWeigherBaseUnit.t.sol
@@ -92,7 +92,7 @@ contract VoteWeigherBaseUnitTests is Test {
     }
 
     /// TODO - migrate tests to registry coordinator
-    // function testCreateQuorum_Valid(IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers) public {
+    // function testCreateQuorum_Valid(IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers) public {
     //     strategiesAndWeightingMultipliers = _convertToValidStrategiesAndWeightingMultipliers(strategiesAndWeightingMultipliers);
     //     // create a quorum from the serviceManagerOwner
     //     // get the quorum count before the quorum is created
@@ -111,7 +111,7 @@ contract VoteWeigherBaseUnitTests is Test {
     //     assertEq(voteWeigher.quorumCount(), quorumCountBefore + 1);
     //     // check that all of the weights are correct
     //     for (uint i = 0; i < strategiesAndWeightingMultipliers.length; i++) {
-    //         IStakeRegistry.StrategyAndWeightingMultiplier memory strategyAndWeightingMultiplier = voteWeigher.strategyAndWeightingMultiplierForQuorumByIndex(quorumCountBefore, i);
+    //         IStakeRegistry.StrategyParams memory strategyAndWeightingMultiplier = voteWeigher.strategyAndWeightingMultiplierForQuorumByIndex(quorumCountBefore, i);
     //         assertEq(address(strategyAndWeightingMultiplier.strategy), address(strategiesAndWeightingMultipliers[i].strategy));
     //         assertEq(strategyAndWeightingMultiplier.multiplier, strategiesAndWeightingMultipliers[i].multiplier);
     //     }
@@ -119,7 +119,7 @@ contract VoteWeigherBaseUnitTests is Test {
 
     // function testCreateQuorum_FromNotServiceManagerOwner_Reverts(
     //     address notServiceManagerOwner,
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers
     // ) public fuzzedAddress(notServiceManagerOwner) {
     //     cheats.assume(notServiceManagerOwner != serviceManagerOwner);
     //     cheats.prank(notServiceManagerOwner);
@@ -128,7 +128,7 @@ contract VoteWeigherBaseUnitTests is Test {
     // }
 
     // function testCreateQuorum_StrategiesAndWeightingMultipliers_LengthGreaterThanMaxAllowed_Reverts(
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers
     // ) public {
     //     strategiesAndWeightingMultipliers = _removeDuplicates(strategiesAndWeightingMultipliers);
     //     strategiesAndWeightingMultipliers = _replaceZeroWeights(strategiesAndWeightingMultipliers);
@@ -140,7 +140,7 @@ contract VoteWeigherBaseUnitTests is Test {
     // }
 
     // function testCreateQuorum_StrategiesAndWeightingMultipliers_WithDuplicateStrategies_Reverts(
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers,
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers,
     //     uint256 indexFromDuplicate,
     //     uint256 indexToDuplicate
     // ) public {
@@ -160,14 +160,14 @@ contract VoteWeigherBaseUnitTests is Test {
     // }
 
     // function testCreateQuorum_EmptyStrategiesAndWeightingMultipliers_Reverts() public {
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers;
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers;
     //     cheats.prank(serviceManagerOwner);
     //     cheats.expectRevert("VoteWeigherBase._addStrategiesConsideredAndMultipliers: no strategies provided");
     //     voteWeigher.createQuorum(strategiesAndWeightingMultipliers);
     // }
 
     // function testCreateQuorum_StrategiesAndWeightingMultipliers_WithZeroWeight(
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers,
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers,
     //     uint256 indexForZeroMultiplier
     // ) public {
     //     strategiesAndWeightingMultipliers = _removeDuplicates(strategiesAndWeightingMultipliers);
@@ -182,7 +182,7 @@ contract VoteWeigherBaseUnitTests is Test {
     // }
 
     // function testCreateQuorum_MoreThanMaxQuorums_Reverts() public {
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers = _defaultStrategiesAndWeightingMultipliers();
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers = _defaultStrategiesAndWeightingMultipliers();
     //     uint256 maxQuorums = voteWeigher.MAX_QUORUM_COUNT();
             
     //     cheats.startPrank(serviceManagerOwner);
@@ -197,7 +197,7 @@ contract VoteWeigherBaseUnitTests is Test {
 
     // function testAddStrategiesConsideredAndMultipliers_Valid(
     //     uint256 randomSplit,
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers
     // ) public {
     //     strategiesAndWeightingMultipliers = _convertToValidStrategiesAndWeightingMultipliers(strategiesAndWeightingMultipliers);
     //     // make sure there is at least 2 strategies
@@ -205,8 +205,8 @@ contract VoteWeigherBaseUnitTests is Test {
     //     // we need at least 1 strategy in each side of the split
     //     randomSplit = randomSplit % (strategiesAndWeightingMultipliers.length - 1) + 1;
     //     // create 2 arrays, 1 with the first randomSplit elements and 1 with the rest
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers1 = new IStakeRegistry.StrategyAndWeightingMultiplier[](randomSplit);
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers2 = new IStakeRegistry.StrategyAndWeightingMultiplier[](strategiesAndWeightingMultipliers.length - randomSplit);
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers1 = new IStakeRegistry.StrategyParams[](randomSplit);
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers2 = new IStakeRegistry.StrategyParams[](strategiesAndWeightingMultipliers.length - randomSplit);
     //     for (uint256 i = 0; i < strategiesAndWeightingMultipliers.length; i++) {
     //         if (i < randomSplit) {
     //             strategiesAndWeightingMultipliers1[i] = strategiesAndWeightingMultipliers[i];
@@ -228,7 +228,7 @@ contract VoteWeigherBaseUnitTests is Test {
 
     //     // check that the quorum was created and strategies were added correctly
     //     for (uint i = 0; i < strategiesAndWeightingMultipliers.length; i++) {
-    //         IStakeRegistry.StrategyAndWeightingMultiplier memory strategyAndWeightingMultiplier = voteWeigher.strategyAndWeightingMultiplierForQuorumByIndex(quorumNumber, i);
+    //         IStakeRegistry.StrategyParams memory strategyAndWeightingMultiplier = voteWeigher.strategyAndWeightingMultiplierForQuorumByIndex(quorumNumber, i);
     //         assertEq(address(strategyAndWeightingMultiplier.strategy), address(strategiesAndWeightingMultipliers[i].strategy));
     //         assertEq(strategyAndWeightingMultiplier.multiplier, strategiesAndWeightingMultipliers[i].multiplier);
     //     }
@@ -238,7 +238,7 @@ contract VoteWeigherBaseUnitTests is Test {
     //     address notServiceManagerOwner
     // ) public fuzzedAddress(notServiceManagerOwner) {
     //     cheats.assume(notServiceManagerOwner != serviceManagerOwner);
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers = _defaultStrategiesAndWeightingMultipliers();
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers = _defaultStrategiesAndWeightingMultipliers();
 
     //     // create quorum with all but the last element
     //     uint8 quorumNumber = uint8(voteWeigher.quorumCount());
@@ -252,7 +252,7 @@ contract VoteWeigherBaseUnitTests is Test {
     // }
 
     // function testAddStrategiesConsideredAndMultipliers_ForNonexistentQuorum_Reverts() public {
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers = _defaultStrategiesAndWeightingMultipliers();
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers = _defaultStrategiesAndWeightingMultipliers();
 
     //     // create quorum with all but the last element
     //     uint8 quorumNumber = uint8(voteWeigher.quorumCount());
@@ -268,7 +268,7 @@ contract VoteWeigherBaseUnitTests is Test {
     // // removes them, and checks that the strategies were removed correctly by computing
     // // a local copy of the strategies when the removal algorithm is applied and comparing
     // function testRemoveStrategiesConsideredAndMultipliers_Valid(
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers,
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers,
     //     uint256 randomness
     // ) public {
     //     strategiesAndWeightingMultipliers = _convertToValidStrategiesAndWeightingMultipliers(strategiesAndWeightingMultipliers);
@@ -290,13 +290,13 @@ contract VoteWeigherBaseUnitTests is Test {
         
     //     // check that the strategies that were not removed are still there
     //     // get all strategies and multipliers form the contracts
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliersFromContract = new IStakeRegistry.StrategyAndWeightingMultiplier[](voteWeigher.strategiesConsideredAndMultipliersLength(quorumNumber));
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliersFromContract = new IStakeRegistry.StrategyParams[](voteWeigher.strategiesConsideredAndMultipliersLength(quorumNumber));
     //     for (uint256 i = 0; i < strategiesAndWeightingMultipliersFromContract.length; i++) {
     //         strategiesAndWeightingMultipliersFromContract[i] = voteWeigher.strategyAndWeightingMultiplierForQuorumByIndex(quorumNumber, i);
     //     }
 
     //     // remove indicesToRemove from local strategiesAndWeightingMultipliers
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliersLocal = new IStakeRegistry.StrategyAndWeightingMultiplier[](strategiesAndWeightingMultipliers.length - indicesToRemove.length);
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliersLocal = new IStakeRegistry.StrategyParams[](strategiesAndWeightingMultipliers.length - indicesToRemove.length);
         
     //     // run the removal algorithm locally
     //     uint256 endIndex = strategiesAndWeightingMultipliers.length - 1;
@@ -323,7 +323,7 @@ contract VoteWeigherBaseUnitTests is Test {
     //     address notServiceManagerOwner
     // ) public fuzzedAddress(notServiceManagerOwner) {
     //     cheats.assume(notServiceManagerOwner != serviceManagerOwner);
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers = _defaultStrategiesAndWeightingMultipliers();
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers = _defaultStrategiesAndWeightingMultipliers();
 
     //     uint256[] memory indicesToRemove = new uint256[](1);
 
@@ -339,7 +339,7 @@ contract VoteWeigherBaseUnitTests is Test {
     // }
 
     // function testRemoveStrategiesConsideredAndMultipliers_ForNonexistentQuorum_Reverts() public {
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers = _defaultStrategiesAndWeightingMultipliers();
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers = _defaultStrategiesAndWeightingMultipliers();
 
     //     uint256[] memory indicesToRemove = new uint256[](1);
 
@@ -354,7 +354,7 @@ contract VoteWeigherBaseUnitTests is Test {
     // }
 
     // function testRemoveStrategiesConsideredAndMultipliers_EmptyIndicesToRemove_Reverts() public {
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers = _defaultStrategiesAndWeightingMultipliers();
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers = _defaultStrategiesAndWeightingMultipliers();
 
     //     // create a valid quorum
     //     uint8 quorumNumber = uint8(voteWeigher.quorumCount());
@@ -370,7 +370,7 @@ contract VoteWeigherBaseUnitTests is Test {
     //     address notServiceManagerOwner
     // ) public fuzzedAddress(notServiceManagerOwner) {
     //     cheats.assume(notServiceManagerOwner != serviceManagerOwner);
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers = _defaultStrategiesAndWeightingMultipliers();
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers = _defaultStrategiesAndWeightingMultipliers();
 
     //     uint256[] memory strategyIndices = new uint256[](1);
     //     uint96[] memory newWeights = new uint96[](1);
@@ -387,7 +387,7 @@ contract VoteWeigherBaseUnitTests is Test {
     // }
 
     // function testModifyStrategyWeights_Valid(
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers,
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers,
     //     uint96[] memory newWeights,
     //     uint256 randomness
     // ) public {
@@ -423,14 +423,14 @@ contract VoteWeigherBaseUnitTests is Test {
     //     }
     //     // make sure the quorum strategies and weights have changed
     //     for (uint i = 0; i < strategiesAndWeightingMultipliers.length; i++) {
-    //         IStakeRegistry.StrategyAndWeightingMultiplier memory strategyAndWeightingMultiplier = voteWeigher.strategyAndWeightingMultiplierForQuorumByIndex(quorumNumber, i);
+    //         IStakeRegistry.StrategyParams memory strategyAndWeightingMultiplier = voteWeigher.strategyAndWeightingMultiplierForQuorumByIndex(quorumNumber, i);
     //         assertEq(address(strategyAndWeightingMultiplier.strategy), address(strategiesAndWeightingMultipliers[i].strategy));
     //         assertEq(strategyAndWeightingMultiplier.multiplier, strategiesAndWeightingMultipliers[i].multiplier);
     //     }
     // }
 
     // function testModifyStrategyWeights_ForNonexistentQuorum_Reverts() public {
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers = _defaultStrategiesAndWeightingMultipliers();
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers = _defaultStrategiesAndWeightingMultipliers();
 
     //     uint256[] memory strategyIndices = new uint256[](1);
     //     uint96[] memory newWeights = new uint96[](1);
@@ -449,7 +449,7 @@ contract VoteWeigherBaseUnitTests is Test {
     //     uint256[] memory strategyIndices,
     //     uint96[] memory newWeights
     // ) public {
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers = _defaultStrategiesAndWeightingMultipliers();
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers = _defaultStrategiesAndWeightingMultipliers();
 
     //     // make sure the arrays are of different lengths
     //     cheats.assume(strategyIndices.length != newWeights.length);
@@ -466,7 +466,7 @@ contract VoteWeigherBaseUnitTests is Test {
     // }
 
     // function testModifyStrategyWeights_EmptyStrategyIndicesAndWeights_Reverts() public {
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers = _defaultStrategiesAndWeightingMultipliers();
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers = _defaultStrategiesAndWeightingMultipliers();
 
     //     // create a valid quorum
     //     uint8 quorumNumber = uint8(voteWeigher.quorumCount());
@@ -480,7 +480,7 @@ contract VoteWeigherBaseUnitTests is Test {
 
     // function testWeightOfOperatorForQuorum(
     //     address operator,
-    //     IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndMultipliers,
+    //     IStakeRegistry.StrategyParams[] memory strategiesAndMultipliers,
     //     uint96[] memory shares
     // ) public {
     //     strategiesAndMultipliers = _convertToValidStrategiesAndWeightingMultipliers(strategiesAndMultipliers);
@@ -510,11 +510,11 @@ contract VoteWeigherBaseUnitTests is Test {
     //     assertEq(voteWeigher.weightOfOperatorForQuorum(quorumNumber, operator), expectedWeight);
     // }
 
-    function _removeDuplicates(IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers) 
+    function _removeDuplicates(IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers) 
         internal 
-        returns(IStakeRegistry.StrategyAndWeightingMultiplier[] memory)
+        returns(IStakeRegistry.StrategyParams[] memory)
     {
-        IStakeRegistry.StrategyAndWeightingMultiplier[] memory deduplicatedStrategiesAndWeightingMultipliers = new IStakeRegistry.StrategyAndWeightingMultiplier[](strategiesAndWeightingMultipliers.length);
+        IStakeRegistry.StrategyParams[] memory deduplicatedStrategiesAndWeightingMultipliers = new IStakeRegistry.StrategyParams[](strategiesAndWeightingMultipliers.length);
         uint256 numUniqueStrategies = 0;
         // check for duplicates
         for (uint i = 0; i < strategiesAndWeightingMultipliers.length; i++) {
@@ -531,14 +531,14 @@ contract VoteWeigherBaseUnitTests is Test {
             strategyInCurrentArray[strategiesAndWeightingMultipliers[i].strategy] = false;
         }
 
-        IStakeRegistry.StrategyAndWeightingMultiplier[] memory trimmedStrategiesAndWeightingMultipliers = new IStakeRegistry.StrategyAndWeightingMultiplier[](numUniqueStrategies);
+        IStakeRegistry.StrategyParams[] memory trimmedStrategiesAndWeightingMultipliers = new IStakeRegistry.StrategyParams[](numUniqueStrategies);
         for (uint i = 0; i < numUniqueStrategies; i++) {
             trimmedStrategiesAndWeightingMultipliers[i] = deduplicatedStrategiesAndWeightingMultipliers[i];
         }
         return trimmedStrategiesAndWeightingMultipliers;
     }
 
-    function _replaceZeroWeights(IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers) internal pure returns(IStakeRegistry.StrategyAndWeightingMultiplier[] memory) {
+    function _replaceZeroWeights(IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers) internal pure returns(IStakeRegistry.StrategyParams[] memory) {
         for (uint256 i = 0; i < strategiesAndWeightingMultipliers.length; i++) {
             if (strategiesAndWeightingMultipliers[i].multiplier == 0) {
                 strategiesAndWeightingMultipliers[i].multiplier = 1;
@@ -572,20 +572,20 @@ contract VoteWeigherBaseUnitTests is Test {
         return trimmedRandomIndices;
     }
 
-    function _convertToValidStrategiesAndWeightingMultipliers(IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers) internal returns (IStakeRegistry.StrategyAndWeightingMultiplier[] memory) {
+    function _convertToValidStrategiesAndWeightingMultipliers(IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers) internal returns (IStakeRegistry.StrategyParams[] memory) {
         strategiesAndWeightingMultipliers = _removeDuplicates(strategiesAndWeightingMultipliers);
         cheats.assume(strategiesAndWeightingMultipliers.length <= voteWeigher.MAX_WEIGHING_FUNCTION_LENGTH());
         cheats.assume(strategiesAndWeightingMultipliers.length > 0);
         return _replaceZeroWeights(strategiesAndWeightingMultipliers);
     }
 
-    function _defaultStrategiesAndWeightingMultipliers() internal pure returns (IStakeRegistry.StrategyAndWeightingMultiplier[] memory) {
-        IStakeRegistry.StrategyAndWeightingMultiplier[] memory strategiesAndWeightingMultipliers = new IStakeRegistry.StrategyAndWeightingMultiplier[](2);
-        strategiesAndWeightingMultipliers[0] = IStakeRegistry.StrategyAndWeightingMultiplier({
+    function _defaultStrategiesAndWeightingMultipliers() internal pure returns (IStakeRegistry.StrategyParams[] memory) {
+        IStakeRegistry.StrategyParams[] memory strategiesAndWeightingMultipliers = new IStakeRegistry.StrategyParams[](2);
+        strategiesAndWeightingMultipliers[0] = IStakeRegistry.StrategyParams({
             strategy: IStrategy(address(uint160(uint256(keccak256("strategy1"))))),
             multiplier: 1.04 ether
         });
-        strategiesAndWeightingMultipliers[1] = IStakeRegistry.StrategyAndWeightingMultiplier({
+        strategiesAndWeightingMultipliers[1] = IStakeRegistry.StrategyParams({
             strategy: IStrategy(address(uint160(uint256(keccak256("strategy2"))))),
             multiplier: 1.69 ether
         });

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -306,7 +306,7 @@ contract MockAVSDeployer is Test {
         }
 
         cheats.prank(operator);
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, pubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, pubKey, defaultSocket);
     }
 
     /**
@@ -324,7 +324,7 @@ contract MockAVSDeployer is Test {
         }
 
         cheats.prank(operator);
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, pubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, pubKey, defaultSocket);
     }
 
     function _registerRandomOperators(uint256 pseudoRandomNumber) internal returns(OperatorMetadata[] memory, uint256[][] memory) {

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -235,11 +235,11 @@ contract MockAVSDeployer is Test {
         }
 
         // setup the dummy quorum strategies
-        IStakeRegistry.StrategyAndWeightingMultiplier[][] memory quorumStrategiesConsideredAndMultipliers =
-            new IStakeRegistry.StrategyAndWeightingMultiplier[][](numQuorumsToAdd);
+        IStakeRegistry.StrategyParams[][] memory quorumStrategiesConsideredAndMultipliers =
+            new IStakeRegistry.StrategyParams[][](numQuorumsToAdd);
         for (uint256 i = 0; i < quorumStrategiesConsideredAndMultipliers.length; i++) {
-            quorumStrategiesConsideredAndMultipliers[i] = new IStakeRegistry.StrategyAndWeightingMultiplier[](1);
-            quorumStrategiesConsideredAndMultipliers[i][0] = IStakeRegistry.StrategyAndWeightingMultiplier(
+            quorumStrategiesConsideredAndMultipliers[i] = new IStakeRegistry.StrategyParams[](1);
+            quorumStrategiesConsideredAndMultipliers[i][0] = IStakeRegistry.StrategyParams(
                 IStrategy(address(uint160(i))),
                 uint96(i+1)
             );


### PR DESCRIPTION
Motivation:
* fix word soup variable and function naming
* take advantage of new quorum existence invariant due to `RegistryCoordinator.createQuorum` and its associated `initializeQuorum` methods in each registry
* registries each keep "histories" of updates. The status quo is that every time anything changes, we push a new history update. this means that when updates happen multiple times in the same block, the history contains multiple updates from the same block number, making it harder to determine what the canonical state at a given block number is.

This PR:
* Replaces logic that handles "0-length histories" with simple checks, since we now have an invariant that initialized quorums have nonzero histories (see any registry's `initializeQuorum` method)
* changes registry histories to update their "most recent entry" rather than pushing a new entry, if the entry was made in the current block
* Renames state variables in the registry coordinator and registry contracts to be less wordy

**For reviewers, this order may work best:**
1. Review `IndexRegistry` changes in the first commit, which contains the functional changes mentioned above, as well as readability/logical simplification. This is the worst commit to review, sorry! The diff looks intimidating, so I'd recommend opening the new/old IndexRegistry files side by side and comparing like that. :pray: 
2. The rest of the commits are style/refactor commits. I'd recommend skimming the renaming changes below and only dipping into the commits themselves if you feel like it.

Renaming changes:
* `IndexRegistry` state vars:
  * `operatorIdToIndex` -> `currentOperatorIndex`
  * `_totalOperatorsHistory` -> `_operatorCountHistory`
  * `_indexToOperatorIdHistory` -> `_indexHistory`
* `IndexRegistry` functions:
  * `_getTotalOperatorsForQuorumAtBlockNumber` -> `_operatorCountAtBlockNumber`
  * `_getOperatorIdAtIndexForQuorumAtBlockNumber` -> `_operatorIdForIndexAtBlockNumber`
  * `getOperatorIndexUpdateOfIndexForQuorumAtIndex` -> `getOperatorUpdateAtIndex`
  * `getTotalOperatorsForQuorumAtBlockNumberByIndex` -> `getTotalOperatorsForIndexAtBlockNumber`
  * `getOperatorListForQuorumAtBlockNumber` -> `getOperatorListAtBlockNumber`
* `StakeRegistry` state vars:
  * `operatorIdToStakeHistory` -> `operatorStakeHistory`
  * `strategiesConsideredAndMultipliers` -> `strategyParams`
* `StakeRegistry` structs:
  * `StrategyAndWeightingMultiplier` -> `StrategyParams`
* `StakeRegistry` functions:
  * `strategiesConsideredAndMultipliersLength` -> `strategyParamsLength`
  * `strategyAndWeightingMultiplierForQuorumByIndex` -> `strategyParamsByIndex`
  * `getOperatorIdToStakeHistory` -> `getOperatorStakeHistory`
  * `getLengthOfTotalStakeHistoryForQuorum` -> `getTotalStakeHistoryLength`
  * `getTotalStakeUpdateForQuorumFromIndex` -> `getTotalStakeUpdateAtIndex`
  * `getStakeUpdateIndexForOperatorIdForQuorumAtBlockNumber` -> `getStakeUpdateIndexForOperatorAtBlockNumber`
  * `getTotalStakeIndicesByQuorumNumbersAtBlockNumber` -> `getTotalStakeIndicesAtBlockNumber`
  * `getStakeUpdateForQuorumFromOperatorIdAndIndex` -> `getStakeUpdateForOperatorAtIndex`
  * `getStakeForQuorumAtBlockNumberFromOperatorIdAndIndex` -> `getOperatorStakeAtBlockNumberAndIndex`
  * `getStakeForOperatorIdForQuorumAtBlockNumber` -> `getOperatorStakeAtBlockNumber`
  * `getLengthOfOperatorIdStakeHistoryForQuorum` -> `getOperatorStakeHistoryLength`
* `BLSRegistryCoordinatorWithIndices` state vars:
  * `_quorumOperatorSetParams` -> `_quorumParams`
  * `_operatorIdToQuorumBitmapHistory` -> `_operatorBitmapHistory`
  * `_operators` -> `_operatorInfo`
* `BLSRegistryCoordinatorWithIndices` state modifying functions:
  * `registerOperatorWithCoordinator` -> `registerOperator`
  * `registerOperatorWithCoordinator` -> `registerOperatorWithChurn`
  * `deregisterOperatorWithCoordinator` -> `deregisterOperator`
  * `ejectOperatorFromCoordinator` -> `ejectOperator`
* `BLSRegistryCoordinatorWithIndices` view functions:
  * `getQuorumBitmapIndicesByOperatorIdsAtBlockNumber` -> `getQuorumBitmapIndicesAtBlockNumber`
  * `getQuorumBitmapByOperatorIdAtBlockNumberByIndex` -> `getQuorumBitmapAtBlockNumberByIndex`
  * `getQuorumBitmapUpdateByOperatorIdByIndex` -> `getQuorumBitmapUpdateByIndex`
  * `getCurrentQuorumBitmapByOperatorId` -> `getCurrentQuorumBitmap`
  * `getQuorumBitmapUpdateByOperatorIdLength` -> `getQuorumBitmapHistoryLength`

`IndexRegistry` changes:
* Refactored index registry history updates to have a more readable register/deregister flow:
  * `registerOperator` is now `_increaseOperatorCount` + `_assignOperatorToIndex`. Functional changes:
    * If the most recent `QuorumUpdate/OperatorUpdate` is from this block, we update the last entry rather than pushing a new one.
  * `deregisterOperator` is now `_decreaseOperatorCount` + `_popLastOperator` + `_assignOperatorToIndex`. Functional changes:
    * As above, histories are updated rather than pushed if the last entry was from the current block.
    * Previously, we assigned `currentOperatorIndex[quorum][OPERATOR_DOES_NOT_EXIST_ID]` to the removed index, and emitted an event for this update. This logic has been removed, since the `currentOperatorIndex` of the null id doesn't matter. See [previous logic](https://github.com/Layr-Labs/eigenlayer-middleware/blob/alex/refactor-quorums/src/IndexRegistry.sol#L169-L174) vs [new logic](https://github.com/Layr-Labs/eigenlayer-middleware/blob/aa1d513253c5a032d68e398a05b86479812bc68b/src/IndexRegistry.sol#L175)