### PR TITLE
Feat: updateStakesAllOperators() for StakeRegistry pull-updates

### DIFF
--- a/src/StakeRegistry.sol
+++ b/src/StakeRegistry.sol
@@ -207,7 +207,7 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
             // Check that number of operators matches quorum total
             require(
                 currQuorumOperators.length == indexRegistry.totalOperatorsForQuorum(quorumNumber),
-                "StakeRegistry.updateStakesAllOperators: number of updated operators doesn't match quorum total"
+                "StakeRegistry.updateStakesAllOperators: number of updated operators does not match quorum total"
             );
 
             bytes32 prevOperatorId = bytes32(0);

--- a/src/StakeRegistry.sol
+++ b/src/StakeRegistry.sol
@@ -149,7 +149,7 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
             bytes32 prevOperatorId = bytes32(0);
             // Update stakes for each operator in the quorum
             // If the operator is not part of the quorum then revert. Checks this via quorum bitmap
-            for (uint256 i = 0; i < currQuorumOperators.length; ++i) {
+            for (uint256 i = 0; i < currQuorumOperators.length;) {
                 bytes32 operatorId = registryCoordinator.getOperatorId(currQuorumOperators[i]);
                 uint192 quorumBitmap = registryCoordinator.getCurrentQuorumBitmapByOperatorId(operatorId);
 

--- a/src/StakeRegistry.sol
+++ b/src/StakeRegistry.sol
@@ -135,7 +135,7 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
      *      we aren't updating duplicate operators. This is because we want to check at the end that we updated all registered
      *      operators in the quorum and we verify this with indexRegistry.totalOperatorsForQuorum(quorumNumber)
      */
-    function updateStakesAllOperators(address[] calldata operators) external {
+    function updateStakesAllOperators(address[] memory operators) external {
         // for each quorum, loop through operators and see if they are a part of the quorum
         // if they are, get their new weight and update their individual stake history and the
         // quorum's total stake history accordingly
@@ -198,7 +198,7 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
      * @param operatorsPerQuorum is an array of quorums where each quorum is an array of operators
      * operators in the nested array must be sorted in ascending operatorId order.
      */
-    function updateStakesAllOperators(address[][] calldata operatorsPerQuorum) external {
+    function updateStakesAllOperators(address[][] memory operatorsPerQuorum) external {
         for (uint8 quorumNumber = 0; quorumNumber < operatorsPerQuorum.length; quorumNumber) {
             OperatorStakeUpdate memory totalStakeUpdate = _totalStakeHistory[quorumNumber][
                 _totalStakeHistory[quorumNumber].length - 1
@@ -213,7 +213,7 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
             bytes32 prevOperatorId = bytes32(0);
             // Update stakes for each operator in the quorum
             // If the operator is not part of the quorum then revert. Checks this via quorum bitmap
-            for (uint8 i = 0; i < currQuorumOperators.length; ++i) {
+            for (uint256 i = 0; i < currQuorumOperators.length; ++i) {
                 bytes32 operatorId = registryCoordinator.getOperatorId(currQuorumOperators[i]);
                 uint192 quorumBitmap = registryCoordinator.getCurrentQuorumBitmapByOperatorId(operatorId);
 
@@ -237,6 +237,7 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
                 // calculate the new total stake for the quorum
                 totalStakeUpdate.stake = totalStakeUpdate.stake - stakeBeforeUpdate + stakeAfterUpdate;
 
+                prevOperatorId = operatorId;
                 unchecked {
                     ++i;
                 }

--- a/src/StakeRegistry.sol
+++ b/src/StakeRegistry.sol
@@ -178,7 +178,7 @@ contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
 
             require(
                 numOperatorsUpdatedInQuorum == indexRegistry.totalOperatorsForQuorum(quorumNumber),
-                "StakeRegistry.updateStakesAllOperators: number of updated operators doesn't match quorum total"
+                "StakeRegistry.updateStakesAllOperators: number of updated operators does not match quorum total"
             );
 
             // if the total stake for this quorum was updated, record it in storage

--- a/src/StakeRegistryStorage.sol
+++ b/src/StakeRegistryStorage.sol
@@ -5,6 +5,7 @@ import {IStrategyManager} from "eigenlayer-contracts/src/contracts/interfaces/IS
 import {IServiceManager} from "src/interfaces/IServiceManager.sol";
 import {IStakeRegistry} from  "src/interfaces/IStakeRegistry.sol";
 import {IRegistryCoordinator} from "src/interfaces/IRegistryCoordinator.sol";
+import {IIndexRegistry} from  "src/interfaces/IIndexRegistry.sol";
 
 /**
  * @title Storage variables for the `StakeRegistry` contract.
@@ -14,6 +15,8 @@ import {IRegistryCoordinator} from "src/interfaces/IRegistryCoordinator.sol";
 abstract contract StakeRegistryStorage is IStakeRegistry {
     /// @notice the coordinator contract that this registry is associated with
     IRegistryCoordinator public immutable registryCoordinator;
+
+    IIndexRegistry public immutable indexRegistry;
 
     /// @notice In order to register for a quorum i, an operator must have at least `minimumStakeForQuorum[i]`
     /// evaluated by this contract's 'VoteWeigher' logic.
@@ -25,8 +28,9 @@ abstract contract StakeRegistryStorage is IStakeRegistry {
     /// @notice mapping from operator's operatorId to the history of their stake updates
     mapping(bytes32 => mapping(uint8 => OperatorStakeUpdate[])) internal operatorIdToStakeHistory;
 
-    constructor(IRegistryCoordinator _registryCoordinator) {
+    constructor(IRegistryCoordinator _registryCoordinator, IIndexRegistry _indexRegistry) {
         registryCoordinator = _registryCoordinator;
+        indexRegistry = _indexRegistry;
     }
 
     // storage gap for upgradeability

--- a/src/interfaces/IStakeRegistry.sol
+++ b/src/interfaces/IStakeRegistry.sol
@@ -160,8 +160,9 @@ interface IStakeRegistry is IRegistry {
 
     /**
      * @notice Used for updating information on deposits of nodes for all registered operators.
-     * @param operators are the addresses of the operators whose stake information is getting updated
-     * note: operators array must be sorted in ascending order based on their corresponding operatorId
+     * @param operatorsPerQuorum are the addresses of the operators whose stake information is getting updated
+     * Each array index corresponds the quorum number of the operators being updated.
+     * note: Each nested operators array must be sorted in ascending order based on their corresponding operatorId
      */
-    function updateStakesAllOperators(address[] calldata operators) external;
+    function updateStakesAllOperators(address[][] memory operatorsPerQuorum) external;
 }

--- a/src/interfaces/IStakeRegistry.sol
+++ b/src/interfaces/IStakeRegistry.sol
@@ -157,4 +157,11 @@ interface IStakeRegistry is IRegistry {
      * @param operators are the addresses of the operators whose stake information is getting updated
      */
     function updateStakes(address[] memory operators) external;
+
+    /**
+     * @notice Used for updating information on deposits of nodes for all registered operators.
+     * @param operators are the addresses of the operators whose stake information is getting updated
+     * note: operators array must be sorted in ascending order based on their corresponding operatorId
+     */
+    function updateStakesAllOperators(address[] calldata operators) external;
 }

--- a/test/harnesses/StakeRegistryHarness.sol
+++ b/test/harnesses/StakeRegistryHarness.sol
@@ -9,9 +9,10 @@ contract StakeRegistryHarness is StakeRegistry {
 
     constructor(
         IRegistryCoordinator _registryCoordinator,
+        IIndexRegistry _indexRegistry,
         IStrategyManager _strategyManager,
         IServiceManager _serviceManager
-    ) StakeRegistry(_registryCoordinator, _strategyManager, _serviceManager) {
+    ) StakeRegistry(_registryCoordinator, _indexRegistry, _strategyManager, _serviceManager) {
     }
 
     function recordOperatorStakeUpdate(bytes32 operatorId, uint8 quorumNumber, OperatorStakeUpdate memory operatorStakeUpdate) external returns(uint96) {

--- a/test/mocks/IndexRegistryMock.sol
+++ b/test/mocks/IndexRegistryMock.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import {IIndexRegistry} from "src/interfaces/IIndexRegistry.sol";
+import {IRegistryCoordinator} from "src/interfaces/IRegistryCoordinator.sol";
+
+// Mock contract for IndexRegistry that allows setting totalOperatorsForQuorum and implements IIndexRegistry interface
+contract IndexRegistryMock is IIndexRegistry {
+    uint32[256] _totalOperatorsForQuorum;
+
+    function registryCoordinator() external view returns (IRegistryCoordinator) {}
+
+    function registerOperator(bytes32 operatorId, bytes calldata quorumNumbers) external returns(uint32[] memory) {}
+
+    function deregisterOperator(bytes32 operatorId, bytes calldata quorumNumbers) external {}
+
+    function getOperatorIndexUpdateOfIndexForQuorumAtIndex(uint32 operatorIndex, uint8 quorumNumber, uint32 index) external view returns (OperatorUpdate memory) {}
+
+    function getQuorumUpdateAtIndex(uint8 quorumNumber, uint32 index) external view returns (QuorumUpdate memory) {}
+
+    function getTotalOperatorsForQuorumAtBlockNumberByIndex(uint8 quorumNumber, uint32 blockNumber, uint32 index) external view returns (uint32) {}
+
+    function totalOperatorsForQuorum(uint8 quorumNumber) external view returns (uint32) {
+        return _totalOperatorsForQuorum[quorumNumber];
+    }
+
+    function getOperatorListForQuorumAtBlockNumber(uint8 quorumNumber, uint32 blockNumber) external view returns (bytes32[] memory) {}
+
+    function setTotalOperatorsForQuorum(uint256 quorumNumber, uint32 numOperators) external {
+        _totalOperatorsForQuorum[quorumNumber] = numOperators;
+    }
+}

--- a/test/mocks/StakeRegistryMock.sol
+++ b/test/mocks/StakeRegistryMock.sol
@@ -146,6 +146,20 @@ contract StakeRegistryMock is IStakeRegistry {
         }
     }
 
+    /**
+     * @notice Used for updating information on deposits of all registered nodes.
+     * @param operators are the addresses of the operators whose stake information is getting updated
+     */
+    function updateStakesAllOperators(address[] memory operators) external {
+        for (uint256 i = 0; i < operators.length; i++) {
+            emit StakeUpdate(
+                bytes32(uint256(keccak256(abi.encodePacked(operators[i], "operatorId")))),
+                uint8(uint256(keccak256(abi.encodePacked(operators[i], i, "quorumNumber")))),
+                uint96(uint256(keccak256(abi.encodePacked(operators[i], i, "stake"))))
+            );
+        }
+    }
+
     function getMockOperatorId(address operator) external returns(bytes32) {
         return bytes32(uint256(keccak256(abi.encodePacked(operator, "operatorId"))));
     }

--- a/test/mocks/StakeRegistryMock.sol
+++ b/test/mocks/StakeRegistryMock.sol
@@ -150,13 +150,15 @@ contract StakeRegistryMock is IStakeRegistry {
      * @notice Used for updating information on deposits of all registered nodes.
      * @param operators are the addresses of the operators whose stake information is getting updated
      */
-    function updateStakesAllOperators(address[] memory operators) external {
-        for (uint256 i = 0; i < operators.length; i++) {
-            emit StakeUpdate(
-                bytes32(uint256(keccak256(abi.encodePacked(operators[i], "operatorId")))),
-                uint8(uint256(keccak256(abi.encodePacked(operators[i], i, "quorumNumber")))),
-                uint96(uint256(keccak256(abi.encodePacked(operators[i], i, "stake"))))
-            );
+    function updateStakesAllOperators(address[][] memory operators) external {
+        for (uint256 quorumNum = 0; quorumNum < operators.length; ++quorumNum) {
+            for (uint256 i = 0; i < operators.length; i++) {
+                emit StakeUpdate(
+                    bytes32(uint256(keccak256(abi.encodePacked(operators[i], "operatorId")))),
+                    uint8(uint256(keccak256(abi.encodePacked(operators[i], i, "quorumNumber")))),
+                    uint96(uint256(keccak256(abi.encodePacked(operators[i], i, "stake"))))
+                );
+            }
         }
     }
 

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -111,6 +111,7 @@ contract StakeRegistryUnitTests is Test {
         serviceManagerMock = new ServiceManagerMock(slasher);
         stakeRegistryImplementation = new StakeRegistryHarness(
             IRegistryCoordinator(address(registryCoordinator)),
+            IIndexRegistry(indexRegistry),
             strategyManagerMock,
             IServiceManager(address(serviceManagerMock))
         );

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -772,13 +772,13 @@ contract StakeRegistryUnitTests_updateStakesAllOperators is Test {
             defaultOperator = operators[i];
             bytes32 operatorId = bytes32(i + 1);
 
-            (uint256 quorumBitmap, uint96[] memory stakesForQuorum) = _registerOperatorSpecificQuorum(defaultOperator, operatorId, /*quorumNumber*/ 0);
+            (uint256 quorumBitmap, uint96 stakeForQuorum) = _registerOperatorSpecificQuorum(defaultOperator, operatorId, /*quorumNumber*/ 0);
             require(quorumBitmap == 1, "quorumBitmap should be 1");
             registryCoordinator.setOperatorId(defaultOperator, operatorId);
             registryCoordinator.recordOperatorQuorumBitmapUpdate(operatorId, uint192(quorumBitmap));
 
             bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(quorumBitmap);
-            _setOperatorQuorumWeight(uint8(quorumNumbers[0]), defaultOperator, stakesForQuorum[0] + 1);
+            _setOperatorQuorumWeight(uint8(quorumNumbers[0]), defaultOperator, stakeForQuorum + 1);
             updateOperators[0][i] = operators[i];
         }
         // For each of the quorums 1-9, register 50 operators
@@ -789,11 +789,11 @@ contract StakeRegistryUnitTests_updateStakesAllOperators is Test {
             uint256 newBitmap;
             for (uint256 j = 1; j < 10; j++) {
                 // stakesForQuorum has 1 element for quorum j
-                (uint256 quorumBitmap, uint96[] memory stakesForQuorum) = _registerOperatorSpecificQuorum(defaultOperator, operatorId, /*quorumNumber*/ j);
+                (uint256 quorumBitmap, uint96 stakeForQuorum) = _registerOperatorSpecificQuorum(defaultOperator, operatorId, /*quorumNumber*/ j);
                 uint256 currentOperatorBitmap = registryCoordinator.getCurrentQuorumBitmapByOperatorId(operatorId);
                 newBitmap = currentOperatorBitmap | quorumBitmap;
                 registryCoordinator.recordOperatorQuorumBitmapUpdate(operatorId, uint192(newBitmap));
-                _setOperatorQuorumWeight(uint8(j), defaultOperator, stakesForQuorum[0] + 1);
+                _setOperatorQuorumWeight(uint8(j), defaultOperator, stakeForQuorum + 1);
             }
             require(newBitmap == (1<<maxQuorumsToRegisterFor)-1, "Should be registered all quorums");
         }
@@ -857,13 +857,13 @@ contract StakeRegistryUnitTests_updateStakesAllOperators is Test {
             defaultOperator = operators[i];
             bytes32 operatorId = bytes32(i + 1);
 
-            (uint256 quorumBitmap, uint96[] memory stakesForQuorum) = _registerOperatorSpecificQuorum(defaultOperator, operatorId, /*quorumNumber*/ 0);
+            (uint256 quorumBitmap, uint96 stakeForQuorum) = _registerOperatorSpecificQuorum(defaultOperator, operatorId, /*quorumNumber*/ 0);
             require(quorumBitmap == 1, "quorumBitmap should be 1");
             registryCoordinator.setOperatorId(defaultOperator, operatorId);
             registryCoordinator.recordOperatorQuorumBitmapUpdate(operatorId, uint192(quorumBitmap));
 
             bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(quorumBitmap);
-            _setOperatorQuorumWeight(uint8(quorumNumbers[0]), defaultOperator, stakesForQuorum[0] + 1);
+            _setOperatorQuorumWeight(uint8(quorumNumbers[0]), defaultOperator, stakeForQuorum + 1);
             updateOperators[0][i] = operators[i];
         }
         // For each of the quorums 1-9, register 30 operators
@@ -874,11 +874,11 @@ contract StakeRegistryUnitTests_updateStakesAllOperators is Test {
             uint256 newBitmap;
             for (uint256 j = 1; j < 10; j++) {
                 // stakesForQuorum has 1 element for quorum j
-                (uint256 quorumBitmap, uint96[] memory stakesForQuorum) = _registerOperatorSpecificQuorum(defaultOperator, operatorId, /*quorumNumber*/ j);
+                (uint256 quorumBitmap, uint96 stakeForQuorum) = _registerOperatorSpecificQuorum(defaultOperator, operatorId, /*quorumNumber*/ j);
                 uint256 currentOperatorBitmap = registryCoordinator.getCurrentQuorumBitmapByOperatorId(operatorId);
                 newBitmap = currentOperatorBitmap | quorumBitmap;
                 registryCoordinator.recordOperatorQuorumBitmapUpdate(operatorId, uint192(newBitmap));
-                _setOperatorQuorumWeight(uint8(j), defaultOperator, stakesForQuorum[0] + 1);
+                _setOperatorQuorumWeight(uint8(j), defaultOperator, stakeForQuorum + 1);
             }
             require(newBitmap == (1<<maxQuorumsToRegisterFor)-1, "Should be registered all quorums");
         }
@@ -926,13 +926,13 @@ contract StakeRegistryUnitTests_updateStakesAllOperators is Test {
         for (uint256 i = 0; i < 5; ++i) {
             defaultOperator = operators[i];
             bytes32 operatorId = bytes32(i + 1);
-            (uint256 quorumBitmap, uint96[] memory stakesForQuorum) = _registerOperatorSpecificQuorum(defaultOperator, operatorId, /*quorumNumber*/ 0);
+            (uint256 quorumBitmap, uint96 stakeForQuorum) = _registerOperatorSpecificQuorum(defaultOperator, operatorId, /*quorumNumber*/ 0);
             require(quorumBitmap == 1, "quorumBitmap should be 1");
             registryCoordinator.setOperatorId(defaultOperator, operatorId);
             registryCoordinator.recordOperatorQuorumBitmapUpdate(operatorId, uint192(quorumBitmap));
 
             bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(quorumBitmap);
-            _setOperatorQuorumWeight(uint8(quorumNumbers[0]), defaultOperator, stakesForQuorum[0] + 1);
+            _setOperatorQuorumWeight(uint8(quorumNumbers[0]), defaultOperator, stakeForQuorum + 1);
             updateOperators[0][i] = operators[i];
         }
 
@@ -942,16 +942,104 @@ contract StakeRegistryUnitTests_updateStakesAllOperators is Test {
         stakeRegistry.updateStakesAllOperators(updateOperators);
     }
 
-    function testUpdateStakesAllOperators_Reverts_NonIncreasingOperatorIds(uint256[10] memory psuedoRandomNumbers) external {}
+    function testUpdateStakesAllOperators_Reverts_NonIncreasingOperatorIds(uint256[10] memory psuedoRandomNumbers) external {
+        // Set 5 operator addresses
+        address[] memory operators = new address[](5);
+        for (uint256 i = 0; i < 5; ++i) {
+            operators[i] = address(uint160(i + 1000));
+        }
+        // OperatorsPerQuorum input param
+        address[][] memory updateOperators = new address[][](maxQuorumsToRegisterFor);
+        // Register 5 operators for quorum0
+        updateOperators[0] = new address[](5);
+        indexRegistryMock.setTotalOperatorsForQuorum(0, 5);
+        // Order by descending order although doesn't run for operaters[0], should revert because operatorIds are not increasing
+        for (uint256 i = 4; i > 0; --i) {
+            defaultOperator = operators[i];
+            bytes32 operatorId = bytes32(i + 1);
+            (uint256 quorumBitmap, uint96 stakeForQuorum) = _registerOperatorSpecificQuorum(defaultOperator, operatorId, /*quorumNumber*/ 0);
+            require(quorumBitmap == 1, "quorumBitmap should be 1");
+            registryCoordinator.setOperatorId(defaultOperator, operatorId);
+            registryCoordinator.recordOperatorQuorumBitmapUpdate(operatorId, uint192(quorumBitmap));
 
-    function testUpdateStakesAllOperators_Reverts_InsufficientQuorumOperatorCount(uint256[10] memory psuedoRandomNumbers) external {}
+            bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(quorumBitmap);
+            _setOperatorQuorumWeight(uint8(quorumNumbers[0]), defaultOperator, stakeForQuorum + 1);
+            updateOperators[0][i] = operators[i];
+        }
+        cheats.expectRevert("StakeRegistry.updateStakesAllOperators: operators array must be sorted in ascending operatorId order");
+        stakeRegistry.updateStakesAllOperators(updateOperators);
+    }
+
+    function testUpdateStakesAllOperators_Reverts_OperatorNotInQuorum() external {
+        // Set 5 operator addresses
+        address[] memory operators = new address[](5);
+        for (uint256 i = 0; i < 5; ++i) {
+            operators[i] = address(uint160(i + 1000));
+        }
+        // OperatorsPerQuorum input param
+        address[][] memory updateOperators = new address[][](maxQuorumsToRegisterFor);
+        // Register 5 operators for quorum0
+        updateOperators[0] = new address[](5);
+        indexRegistryMock.setTotalOperatorsForQuorum(0, 5);
+        // updateOperators in ascending order but 0th index operator is not registered for the quorum
+        for (uint256 i = 0; i < 5; ++i) {
+            defaultOperator = operators[i];
+            bytes32 operatorId = bytes32(i + 1);
+            (uint256 quorumBitmap, uint96 stakeForQuorum) = _registerOperatorSpecificQuorum(defaultOperator, operatorId, /*quorumNumber*/ 0);
+            require(quorumBitmap == 1, "quorumBitmap should be 1");
+            registryCoordinator.setOperatorId(defaultOperator, operatorId);
+            registryCoordinator.recordOperatorQuorumBitmapUpdate(operatorId, uint192(quorumBitmap));
+
+            bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(quorumBitmap);
+            _setOperatorQuorumWeight(uint8(quorumNumbers[0]), defaultOperator, stakeForQuorum + 1);
+            updateOperators[0][i] = operators[i];
+        }
+        // Deregister updatedOperators[0]
+        bytes32 operatorId = bytes32(uint256(1));
+        bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(1);
+        registryCoordinator.recordOperatorQuorumBitmapUpdate(operatorId, uint192(0));
+        cheats.prank(address(registryCoordinator));
+        stakeRegistry.deregisterOperator(operatorId, quorumNumbers);
+        assertEq(registryCoordinator.getCurrentQuorumBitmapByOperatorId(operatorId), 0);
+
+        cheats.expectRevert("StakeRegistry.updateStakesAllOperators: operator not in quorum");
+        stakeRegistry.updateStakesAllOperators(updateOperators);
+    }
+
+    function testUpdateStakesAllOperators_Reverts_InsufficientQuorumOperatorCount(uint256[10] memory psuedoRandomNumbers) external {
+        // Set 5 operator addresses
+        address[] memory operators = new address[](5);
+        for (uint256 i = 0; i < 5; ++i) {
+            operators[i] = address(uint160(i + 1000));
+        }
+        // OperatorsPerQuorum input param
+        address[][] memory updateOperators = new address[][](maxQuorumsToRegisterFor);
+        // Register 5 operators for quorum0 but with totals actually being 10
+        updateOperators[0] = new address[](5);
+        indexRegistryMock.setTotalOperatorsForQuorum(0, 10);
+        for (uint256 i = 0; i < 5; ++i) {
+            defaultOperator = operators[i];
+            bytes32 operatorId = bytes32(i + 1);
+            (uint256 quorumBitmap, uint96 stakeForQuorum) = _registerOperatorSpecificQuorum(defaultOperator, operatorId, /*quorumNumber*/ 0);
+            require(quorumBitmap == 1, "quorumBitmap should be 1");
+            registryCoordinator.setOperatorId(defaultOperator, operatorId);
+            registryCoordinator.recordOperatorQuorumBitmapUpdate(operatorId, uint192(quorumBitmap));
+
+            bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(quorumBitmap);
+            _setOperatorQuorumWeight(uint8(quorumNumbers[0]), defaultOperator, stakeForQuorum + 1);
+            updateOperators[0][i] = operators[i];
+        }
+
+        cheats.expectRevert("StakeRegistry.updateStakesAllOperators: number of updated operators does not match quorum total");
+        stakeRegistry.updateStakesAllOperators(updateOperators);
+    }
 
     // utility function for registering an operator with a valid quorumBitmap and stakesForQuorum using provided randomness
     function _registerOperatorSpecificQuorum(
         address operator,
         bytes32 operatorId,
         uint256 quorumNumber
-    ) internal returns(uint256, uint96[] memory) {
+    ) internal returns(uint256, uint96) {
         // Register for quorumNumber
         uint256 quorumBitmap = 1 << quorumNumber;
         // uint256 quorumBitmap = bound(psuedoRandomNumber, 0, (1<<maxQuorumsToRegisterFor)-1) | 1;
@@ -960,8 +1048,9 @@ contract StakeRegistryUnitTests_updateStakesAllOperators is Test {
         for(uint i = 0; i < stakesForQuorum.length; i++) {
             stakesForQuorum[i] = uint80(uint256(keccak256(abi.encodePacked(quorumNumber, i, "stakesForQuorum"))));
         }
-
-        return (quorumBitmap, _registerOperatorValid(operator, operatorId, quorumBitmap, stakesForQuorum));
+        // Only registered single quorum, only need 0th index
+        uint96[] memory quorumStake = _registerOperatorValid(operator, operatorId, quorumBitmap, stakesForQuorum);
+        return (quorumBitmap, quorumStake[0]);
     }
 
     // utility function for registering an operator

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -197,6 +197,7 @@ contract MockAVSDeployer is Test {
 
         stakeRegistryImplementation = new StakeRegistryHarness(
             IRegistryCoordinator(registryCoordinator),
+            indexRegistry,
             strategyManagerMock,
             IServiceManager(address(serviceManagerMock))
         );


### PR DESCRIPTION
Description: 
The idea is to add a method to enforce updates of all registered operators across all quorums. StakeRegistry now has `updateStakesAllOperators()` function which is the same as `updateStakes` but keeps track of the previous operatorId to ensure no duplicates and the number of updated operators matches `IndexRegistry.totalOperatorsForQuorum()`. 

Changes:
StakeRegistry.sol: added `updateStakesAllOperators` and now passing in IndexRegistry to the constructor
IStakeRegistry.sol: added `updateStakesAllOperators`