### PR TITLE
refactor: pubkey compendium stores pubkeys

### DIFF
--- a/src/BLSOperatorStateRetriever.sol
+++ b/src/BLSOperatorStateRetriever.sol
@@ -149,7 +149,7 @@ contract BLSOperatorStateRetriever {
 
         IBLSPubkeyRegistry blsPubkeyRegistry = registryCoordinator.blsPubkeyRegistry();
         // get the indices of the quorum apks for each of the provided quorums at the given blocknumber
-        checkSignaturesIndices.quorumApkIndices = blsPubkeyRegistry.getApkIndicesForQuorumsAtBlockNumber(quorumNumbers, referenceBlockNumber);
+        checkSignaturesIndices.quorumApkIndices = blsPubkeyRegistry.getApkIndicesAtBlockNumber(quorumNumbers, referenceBlockNumber);
 
         return checkSignaturesIndices;
     }

--- a/src/BLSPubkeyRegistry.sol
+++ b/src/BLSPubkeyRegistry.sol
@@ -82,9 +82,9 @@ contract BLSPubkeyRegistry is BLSPubkeyRegistryStorage {
      * @param quorumNumber The number of the new quorum
      */
     function initializeQuorum(uint8 quorumNumber) public virtual onlyRegistryCoordinator {
-        require(quorumApkUpdates[quorumNumber].length == 0, "BLSPubkeyRegistry.createQuorum: quorum already exists");
+        require(apkHistory[quorumNumber].length == 0, "BLSPubkeyRegistry.initializeQuorum: quorum already exists");
 
-        quorumApkUpdates[quorumNumber].push(ApkUpdate({
+        apkHistory[quorumNumber].push(ApkUpdate({
             apkHash: bytes24(0),
             updateBlockNumber: uint32(block.number),
             nextUpdateBlockNumber: 0
@@ -101,22 +101,22 @@ contract BLSPubkeyRegistry is BLSPubkeyRegistryStorage {
         for (uint256 i = 0; i < quorumNumbers.length; i++) {
             // Validate quorum exists and get history length
             uint8 quorumNumber = uint8(quorumNumbers[i]);
-            uint256 historyLength = quorumApkUpdates[quorumNumber].length;
+            uint256 historyLength = apkHistory[quorumNumber].length;
             require(historyLength != 0, "BLSPubkeyRegistry._processQuorumApkUpdate: quorum does not exist");
 
             // Update aggregate public key for this quorum
-            newApk = quorumApk[quorumNumber].plus(point);
-            quorumApk[quorumNumber] = newApk;
+            newApk = currentApk[quorumNumber].plus(point);
+            currentApk[quorumNumber] = newApk;
             bytes24 newApkHash = bytes24(BN254.hashG1Point(newApk));
 
             // Update apk history. If the last update was made in this block, update the entry
             // Otherwise, push a new historical entry and update the prev->next pointer
-            ApkUpdate storage lastUpdate = quorumApkUpdates[quorumNumber][historyLength - 1];
+            ApkUpdate storage lastUpdate = apkHistory[quorumNumber][historyLength - 1];
             if (lastUpdate.updateBlockNumber == uint32(block.number)) {
                 lastUpdate.apkHash = newApkHash;
             } else {
                 lastUpdate.nextUpdateBlockNumber = uint32(block.number);
-                quorumApkUpdates[quorumNumber].push(ApkUpdate({
+                apkHistory[quorumNumber].push(ApkUpdate({
                     apkHash: newApkHash,
                     updateBlockNumber: uint32(block.number),
                     nextUpdateBlockNumber: 0
@@ -126,10 +126,10 @@ contract BLSPubkeyRegistry is BLSPubkeyRegistryStorage {
     }
 
     // TODO - should this fail if apkUpdate.apkHash == 0? This will be the case for the first entry in each quorum
-    function _validateApkHashForQuorumAtBlockNumber(ApkUpdate memory apkUpdate, uint32 blockNumber) internal pure {
+    function _validateApkHashAtBlockNumber(ApkUpdate memory apkUpdate, uint32 blockNumber) internal pure {
         require(
             blockNumber >= apkUpdate.updateBlockNumber,
-            "BLSPubkeyRegistry._validateApkHashForQuorumAtBlockNumber: index too recent"
+            "BLSPubkeyRegistry._validateApkHashAtBlockNumber: index too recent"
         );
         /**
          * if there is a next update, check that the blockNumber is before the next update or if
@@ -137,7 +137,7 @@ contract BLSPubkeyRegistry is BLSPubkeyRegistryStorage {
          */
         require(
             apkUpdate.nextUpdateBlockNumber == 0 || blockNumber < apkUpdate.nextUpdateBlockNumber,
-            "BLSPubkeyRegistry._validateApkHashForQuorumAtBlockNumber: not latest apk update"
+            "BLSPubkeyRegistry._validateApkHashAtBlockNumber: not latest apk update"
         );
     }
 
@@ -149,23 +149,23 @@ contract BLSPubkeyRegistry is BLSPubkeyRegistryStorage {
      * @notice Returns the indices of the quorumApks index at `blockNumber` for the provided `quorumNumbers`
      * @dev Returns the current indices if `blockNumber >= block.number`
      */
-     function getApkIndicesForQuorumsAtBlockNumber(
+     function getApkIndicesAtBlockNumber(
         bytes calldata quorumNumbers,
         uint256 blockNumber
     ) external view returns (uint32[] memory) {
         uint32[] memory indices = new uint32[](quorumNumbers.length);
         for (uint i = 0; i < quorumNumbers.length; i++) {
             uint8 quorumNumber = uint8(quorumNumbers[i]);
-            uint32 quorumApkUpdatesLength = uint32(quorumApkUpdates[quorumNumber].length);
+            uint32 quorumApkUpdatesLength = uint32(apkHistory[quorumNumber].length);
 
-            if (quorumApkUpdatesLength == 0 || blockNumber < quorumApkUpdates[quorumNumber][0].updateBlockNumber) {
+            if (quorumApkUpdatesLength == 0 || blockNumber < apkHistory[quorumNumber][0].updateBlockNumber) {
                 revert(
-                    "BLSPubkeyRegistry.getApkIndicesForQuorumsAtBlockNumber: blockNumber is before the first update"
+                    "BLSPubkeyRegistry.getApkIndicesAtBlockNumber: blockNumber is before the first update"
                 );
             }
 
             for (uint32 j = 0; j < quorumApkUpdatesLength; j++) {
-                if (quorumApkUpdates[quorumNumber][quorumApkUpdatesLength - j - 1].updateBlockNumber <= blockNumber) {
+                if (apkHistory[quorumNumber][quorumApkUpdatesLength - j - 1].updateBlockNumber <= blockNumber) {
                     indices[i] = quorumApkUpdatesLength - j - 1;
                     break;
                 }
@@ -175,13 +175,13 @@ contract BLSPubkeyRegistry is BLSPubkeyRegistryStorage {
     }
 
     /// @notice Returns the current APK for the provided `quorumNumber `
-    function getApkForQuorum(uint8 quorumNumber) external view returns (BN254.G1Point memory) {
-        return quorumApk[quorumNumber];
+    function getApk(uint8 quorumNumber) external view returns (BN254.G1Point memory) {
+        return currentApk[quorumNumber];
     }
 
     /// @notice Returns the `ApkUpdate` struct at `index` in the list of APK updates for the `quorumNumber`
-    function getApkUpdateForQuorumByIndex(uint8 quorumNumber, uint256 index) external view returns (ApkUpdate memory) {
-        return quorumApkUpdates[quorumNumber][index];
+    function getApkUpdateAtIndex(uint8 quorumNumber, uint256 index) external view returns (ApkUpdate memory) {
+        return apkHistory[quorumNumber][index];
     }
 
     /**
@@ -191,19 +191,19 @@ contract BLSPubkeyRegistry is BLSPubkeyRegistryStorage {
      * @param blockNumber is the number of the block for which the latest ApkHash will be retrieved
      * @param index is the index of the apkUpdate being retrieved from the list of quorum apkUpdates in storage
      */
-    function getApkHashForQuorumAtBlockNumberFromIndex(
+    function getApkHashAtBlockNumberAndIndex(
         uint8 quorumNumber,
         uint32 blockNumber,
         uint256 index
     ) external view returns (bytes24) {
-        ApkUpdate memory quorumApkUpdate = quorumApkUpdates[quorumNumber][index];
-        _validateApkHashForQuorumAtBlockNumber(quorumApkUpdate, blockNumber);
+        ApkUpdate memory quorumApkUpdate = apkHistory[quorumNumber][index];
+        _validateApkHashAtBlockNumber(quorumApkUpdate, blockNumber);
         return quorumApkUpdate.apkHash;
     }
 
     /// @notice Returns the length of ApkUpdates for the provided `quorumNumber`
-    function getQuorumApkHistoryLength(uint8 quorumNumber) external view returns (uint32) {
-        return uint32(quorumApkUpdates[quorumNumber].length);
+    function getApkHistoryLength(uint8 quorumNumber) external view returns (uint32) {
+        return uint32(apkHistory[quorumNumber].length);
     }
 
     /// @notice Returns the operator address for the given `pubkeyHash`

--- a/src/BLSPubkeyRegistry.sol
+++ b/src/BLSPubkeyRegistry.sol
@@ -30,7 +30,6 @@ contract BLSPubkeyRegistry is BLSPubkeyRegistryStorage {
      * @notice Registers the `operator`'s pubkey for the specified `quorumNumbers`.
      * @param operator The address of the operator to register.
      * @param quorumNumbers The quorum numbers the operator is registering for, where each byte is an 8 bit integer quorumNumber.
-     * @param pubkey The operator's BLS public key.
      * @return pubkeyHash of the operator's pubkey
      * @dev access restricted to the RegistryCoordinator
      * @dev Preconditions (these are assumed, not validated in this contract):
@@ -41,31 +40,23 @@ contract BLSPubkeyRegistry is BLSPubkeyRegistryStorage {
      */
     function registerOperator(
         address operator,
-        bytes memory quorumNumbers,
-        BN254.G1Point memory pubkey
+        bytes memory quorumNumbers
     ) public virtual onlyRegistryCoordinator returns (bytes32) {
-        //calculate hash of the operator's pubkey
-        bytes32 pubkeyHash = BN254.hashG1Point(pubkey);
+        // Get the operator's pubkey from the compendium. Reverts if they have not registered a key
+        BN254.G1Point memory pubkey = pubkeyCompendium.getRegisteredPubkey(operator);
 
-        require(pubkeyHash != ZERO_PK_HASH, "BLSPubkeyRegistry.registerOperator: cannot register zero pubkey");
-        //ensure that the operator owns their public key by referencing the BLSPubkeyCompendium
-        require(
-            getOperatorFromPubkeyHash(pubkeyHash) == operator,
-            "BLSPubkeyRegistry.registerOperator: operator does not own pubkey"
-        );
-        // update each quorum's aggregate pubkey
+        // Update each quorum's aggregate pubkey
         _processQuorumApkUpdate(quorumNumbers, pubkey);
 
-        // emit event so offchain actors can update their state
+        // Return pubkeyHash, which will become the operator's unique id
         emit OperatorAddedToQuorums(operator, quorumNumbers);
-        return pubkeyHash;
+        return BN254.hashG1Point(pubkey);
     }
 
     /**
      * @notice Deregisters the `operator`'s pubkey for the specified `quorumNumbers`.
      * @param operator The address of the operator to deregister.
      * @param quorumNumbers The quorum numbers the operator is deregistering from, where each byte is an 8 bit integer quorumNumber.
-     * @param pubkey The public key of the operator.
      * @dev access restricted to the RegistryCoordinator
      * @dev Preconditions (these are assumed, not validated in this contract):
      *         1) `quorumNumbers` has no duplicates
@@ -73,23 +64,16 @@ contract BLSPubkeyRegistry is BLSPubkeyRegistryStorage {
      *         3) `quorumNumbers` is ordered in ascending order
      *         4) the operator is not already deregistered
      *         5) `quorumNumbers` is a subset of the quorumNumbers that the operator is registered for
-     *         6) `pubkey` is the same as the parameter used when registering
      */
     function deregisterOperator(
         address operator,
-        bytes memory quorumNumbers,
-        BN254.G1Point memory pubkey
+        bytes memory quorumNumbers
     ) public virtual onlyRegistryCoordinator {
-        bytes32 pubkeyHash = BN254.hashG1Point(pubkey);
+        // Get the operator's pubkey from the compendium. Reverts if they have not registered a key
+        BN254.G1Point memory pubkey = pubkeyCompendium.getRegisteredPubkey(operator);
 
-        require(
-            getOperatorFromPubkeyHash(pubkeyHash) == operator,
-            "BLSPubkeyRegistry.registerOperator: operator does not own pubkey"
-        );
-
-        // update each quorum's aggregate pubkey
+        // Update each quorum's aggregate pubkey
         _processQuorumApkUpdate(quorumNumbers, pubkey.negate());
-
         emit OperatorRemovedFromQuorums(operator, quorumNumbers);
     }
 

--- a/src/BLSPubkeyRegistryStorage.sol
+++ b/src/BLSPubkeyRegistryStorage.sol
@@ -9,8 +9,6 @@ import "eigenlayer-contracts/src/contracts/libraries/BN254.sol";
 import "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";
 
 abstract contract BLSPubkeyRegistryStorage is Initializable, IBLSPubkeyRegistry {
-    /// @notice the hash of the zero pubkey aka BN254.G1Point(0,0)
-    bytes32 internal constant ZERO_PK_HASH = hex"ad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5";
     /// @notice the registry coordinator contract
     IRegistryCoordinator public immutable registryCoordinator;
     /// @notice the BLSPublicKeyCompendium contract against which pubkey ownership is checked

--- a/src/BLSPubkeyRegistryStorage.sol
+++ b/src/BLSPubkeyRegistryStorage.sol
@@ -14,10 +14,10 @@ abstract contract BLSPubkeyRegistryStorage is Initializable, IBLSPubkeyRegistry 
     /// @notice the BLSPublicKeyCompendium contract against which pubkey ownership is checked
     IBLSPublicKeyCompendium public immutable pubkeyCompendium;
 
-    /// @notice mapping of quorumNumber => ApkUpdate[], tracking the aggregate pubkey updates of every quorum
-    mapping(uint8 => ApkUpdate[]) public quorumApkUpdates;
-    /// @notice mapping of quorumNumber => current aggregate pubkey of quorum
-    mapping(uint8 => BN254.G1Point) public quorumApk;
+    /// @notice maps quorumNumber => historical aggregate pubkey updates
+    mapping(uint8 => ApkUpdate[]) public apkHistory;
+    /// @notice maps quorumNumber => current aggregate pubkey of quorum
+    mapping(uint8 => BN254.G1Point) public currentApk;
 
     constructor(IRegistryCoordinator _registryCoordinator, IBLSPublicKeyCompendium _pubkeyCompendium) {
         registryCoordinator = _registryCoordinator;

--- a/src/BLSPublicKeyCompendium.sol
+++ b/src/BLSPublicKeyCompendium.sol
@@ -12,10 +12,15 @@ import "eigenlayer-contracts/src/contracts/libraries/BN254.sol";
 contract BLSPublicKeyCompendium is IBLSPublicKeyCompendium {
     using BN254 for BN254.G1Point;
 
-    /// @notice mapping from operator address to pubkey hash
+    /// @notice the hash of the zero pubkey aka BN254.G1Point(0,0)
+    bytes32 internal constant ZERO_PK_HASH = hex"ad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5";
+
+    /// @notice maps operator address to pubkey hash
     mapping(address => bytes32) public operatorToPubkeyHash;
-    /// @notice mapping from pubkey hash to operator address
+    /// @notice maps pubkey hash to operator address
     mapping(bytes32 => address) public pubkeyHashToOperator;
+    /// @notice maps operator address to pubkeyG1
+    mapping(address => BN254.G1Point) public operatorToPubkey;
 
     /*******************************************************************************
                             EXTERNAL FUNCTIONS 
@@ -33,6 +38,9 @@ contract BLSPublicKeyCompendium is IBLSPublicKeyCompendium {
         BN254.G2Point memory pubkeyG2
     ) external {
         bytes32 pubkeyHash = BN254.hashG1Point(pubkeyG1);
+        require(
+            pubkeyHash != ZERO_PK_HASH, "BLSPublicKeyCompendium.registerBLSPublicKey: cannot register zero pubkey"
+        );
         require(
             operatorToPubkeyHash[msg.sender] == bytes32(0),
             "BLSPublicKeyCompendium.registerBLSPublicKey: operator already registered pubkey"
@@ -65,6 +73,7 @@ contract BLSPublicKeyCompendium is IBLSPublicKeyCompendium {
             pubkeyG2
         ), "BLSPublicKeyCompendium.registerBLSPublicKey: either the G1 signature is wrong, or G1 and G2 private key do not match");
 
+        operatorToPubkey[msg.sender] = pubkeyG1;
         operatorToPubkeyHash[msg.sender] = pubkeyHash;
         pubkeyHashToOperator[pubkeyHash] = msg.sender;
 
@@ -74,6 +83,24 @@ contract BLSPublicKeyCompendium is IBLSPublicKeyCompendium {
     /*******************************************************************************
                             VIEW FUNCTIONS
     *******************************************************************************/
+
+    /**
+     * @notice Returns the pubkey of an operator, verifying that the pubkey and its hash are valid
+     * @dev Reverts if the operator has not registered a valid pubkey
+     */
+    function getRegisteredPubkey(address operator) public view returns (BN254.G1Point memory) {
+        BN254.G1Point memory pubkey = operatorToPubkey[operator];
+        bytes32 pubkeyHash = operatorToPubkeyHash[operator];
+
+        require(
+            pubkeyHash != bytes32(0) && BN254.hashG1Point(pubkey) == pubkeyHash, 
+            "BLSPublicKeyCompendium.getRegisteredPubkey: operator is not registered"
+        );
+
+        require(pubkeyHash != ZERO_PK_HASH, "BLSPublicKeyCompendium.getRegisteredPubkey: invalid pubkey");
+        
+        return pubkey;
+    }
 
     /**
      * @notice Returns the message hash that an operator must sign to register their BLS public key.

--- a/src/BLSPublicKeyCompendium.sol
+++ b/src/BLSPublicKeyCompendium.sol
@@ -93,11 +93,9 @@ contract BLSPublicKeyCompendium is IBLSPublicKeyCompendium {
         bytes32 pubkeyHash = operatorToPubkeyHash[operator];
 
         require(
-            pubkeyHash != bytes32(0) && BN254.hashG1Point(pubkey) == pubkeyHash, 
+            pubkeyHash != bytes32(0),
             "BLSPublicKeyCompendium.getRegisteredPubkey: operator is not registered"
         );
-
-        require(pubkeyHash != ZERO_PK_HASH, "BLSPublicKeyCompendium.getRegisteredPubkey: invalid pubkey");
         
         return pubkey;
     }

--- a/src/BLSSignatureChecker.sol
+++ b/src/BLSSignatureChecker.sol
@@ -74,7 +74,7 @@ contract BLSSignatureChecker is IBLSSignatureChecker {
         for (uint i = 0; i < quorumNumbers.length; i++) {
             require(
                 bytes24(nonSignerStakesAndSignature.quorumApks[i].hashG1Point()) == 
-                    IBLSPubkeyRegistry(blsPubkeyRegistry).getApkHashForQuorumAtBlockNumberFromIndex(
+                    IBLSPubkeyRegistry(blsPubkeyRegistry).getApkHashAtBlockNumberAndIndex(
                         uint8(quorumNumbers[i]), 
                         referenceBlockNumber, 
                         nonSignerStakesAndSignature.quorumApkIndices[i]

--- a/src/interfaces/IBLSPubkeyRegistry.sol
+++ b/src/interfaces/IBLSPubkeyRegistry.sol
@@ -66,13 +66,13 @@ interface IBLSPubkeyRegistry is IRegistry {
     function initializeQuorum(uint8 quorumNumber) external;
 
     /// @notice Returns the current APK for the provided `quorumNumber `
-    function getApkForQuorum(uint8 quorumNumber) external view returns (BN254.G1Point memory);
+    function getApk(uint8 quorumNumber) external view returns (BN254.G1Point memory);
 
     /// @notice Returns the index of the quorumApk index at `blockNumber` for the provided `quorumNumber`
-    function getApkIndicesForQuorumsAtBlockNumber(bytes calldata quorumNumbers, uint256 blockNumber) external view returns(uint32[] memory);
+    function getApkIndicesAtBlockNumber(bytes calldata quorumNumbers, uint256 blockNumber) external view returns(uint32[] memory);
 
     /// @notice Returns the `ApkUpdate` struct at `index` in the list of APK updates for the `quorumNumber`
-    function getApkUpdateForQuorumByIndex(uint8 quorumNumber, uint256 index) external view returns (ApkUpdate memory);
+    function getApkUpdateAtIndex(uint8 quorumNumber, uint256 index) external view returns (ApkUpdate memory);
 
     /// @notice Returns the operator address for the given `pubkeyHash`
     function getOperatorFromPubkeyHash(bytes32 pubkeyHash) external view returns (address);
@@ -84,5 +84,5 @@ interface IBLSPubkeyRegistry is IRegistry {
      * @param blockNumber is the number of the block for which the latest ApkHash will be retrieved
      * @param index is the index of the apkUpdate being retrieved from the list of quorum apkUpdates in storage
      */
-    function getApkHashForQuorumAtBlockNumberFromIndex(uint8 quorumNumber, uint32 blockNumber, uint256 index) external view returns (bytes24);
+    function getApkHashAtBlockNumberAndIndex(uint8 quorumNumber, uint32 blockNumber, uint256 index) external view returns (bytes24);
 }

--- a/src/interfaces/IBLSPubkeyRegistry.sol
+++ b/src/interfaces/IBLSPubkeyRegistry.sol
@@ -36,7 +36,6 @@ interface IBLSPubkeyRegistry is IRegistry {
      * @notice Registers the `operator`'s pubkey for the specified `quorumNumbers`.
      * @param operator The address of the operator to register.
      * @param quorumNumbers The quorum numbers the operator is registering for, where each byte is an 8 bit integer quorumNumber.
-     * @param pubkey The operator's BLS public key.
      * @dev access restricted to the RegistryCoordinator
      * @dev Preconditions (these are assumed, not validated in this contract):
      *         1) `quorumNumbers` has no duplicates
@@ -44,13 +43,12 @@ interface IBLSPubkeyRegistry is IRegistry {
      *         3) `quorumNumbers` is ordered in ascending order
      *         4) the operator is not already registered
      */
-    function registerOperator(address operator, bytes calldata quorumNumbers, BN254.G1Point memory pubkey) external returns(bytes32);
+    function registerOperator(address operator, bytes calldata quorumNumbers) external returns(bytes32);
 
     /**
      * @notice Deregisters the `operator`'s pubkey for the specified `quorumNumbers`.
      * @param operator The address of the operator to deregister.
      * @param quorumNumbers The quorum numbers the operator is deregistering from, where each byte is an 8 bit integer quorumNumber.
-     * @param pubkey The public key of the operator.
      * @dev access restricted to the RegistryCoordinator
      * @dev Preconditions (these are assumed, not validated in this contract):
      *         1) `quorumNumbers` has no duplicates
@@ -58,9 +56,8 @@ interface IBLSPubkeyRegistry is IRegistry {
      *         3) `quorumNumbers` is ordered in ascending order
      *         4) the operator is not already deregistered
      *         5) `quorumNumbers` is a subset of the quorumNumbers that the operator is registered for
-     *         6) `pubkey` is the same as the parameter used when registering
      */ 
-    function deregisterOperator(address operator, bytes calldata quorumNumbers, BN254.G1Point memory pubkey) external;
+    function deregisterOperator(address operator, bytes calldata quorumNumbers) external;
     
     /**
      * @notice Initializes a new quorum by pushing its first apk update

--- a/src/interfaces/IBLSPublicKeyCompendium.sol
+++ b/src/interfaces/IBLSPublicKeyCompendium.sol
@@ -36,6 +36,12 @@ interface IBLSPublicKeyCompendium {
     function registerBLSPublicKey(BN254.G1Point memory signedMessageHash, BN254.G1Point memory pubkeyG1, BN254.G2Point memory pubkeyG2) external;
 
     /**
+     * @notice Returns the pubkey of an operator, verifying that the pubkey and its hash are valid
+     * @dev Reverts if the operator has not registered a valid pubkey
+     */
+    function getRegisteredPubkey(address operator) external view returns (BN254.G1Point memory);
+
+    /**
      * @notice Returns the message hash that an operator must sign to register their BLS public key.
      * @param operator is the address of the operator registering their BLS public key
      */

--- a/src/interfaces/IBLSRegistryCoordinatorWithIndices.sol
+++ b/src/interfaces/IBLSRegistryCoordinatorWithIndices.sol
@@ -29,12 +29,11 @@ interface IBLSRegistryCoordinatorWithIndices is ISignatureUtils, IRegistryCoordi
 
     /**
      * @notice Data structure for the parameters needed to kick an operator from a quorum with number `quorumNumber`, used during registration churn.
-     * Specifically the `operator` is the address of the operator to kick, `pubkey` is the BLS public key of the operator,
+     * `operator` is the address of the operator to kick
      */
     struct OperatorKickParam {
         uint8 quorumNumber;
         address operator;
-        BN254.G1Point pubkey; 
     }
 
     // EVENTS
@@ -58,11 +57,9 @@ interface IBLSRegistryCoordinatorWithIndices is ISignatureUtils, IRegistryCoordi
      * @notice Ejects the provided operator from the provided quorums from the AVS
      * @param operator is the operator to eject
      * @param quorumNumbers are the quorum numbers to eject the operator from
-     * @param pubkey is the BLS public key of the operator
      */
     function ejectOperator(
         address operator, 
-        bytes calldata quorumNumbers, 
-        BN254.G1Point memory pubkey 
+        bytes calldata quorumNumbers
     ) external;
 }

--- a/test/ffi/BLSPubKeyCompendiumFFI.t.sol
+++ b/test/ffi/BLSPubKeyCompendiumFFI.t.sol
@@ -8,6 +8,8 @@ contract BLSPublicKeyCompendiumFFITests is G2Operations {
     using BN254 for BN254.G1Point;
     using Strings for uint256;
 
+    Vm cheats = Vm(HEVM_ADDRESS);
+
     BLSPublicKeyCompendium compendium;
 
     uint256 privKey;
@@ -22,6 +24,7 @@ contract BLSPublicKeyCompendiumFFITests is G2Operations {
     }
 
     function testRegisterBLSPublicKey(uint256 _privKey) public {
+        cheats.assume(_privKey != 0);
         _setKeys(_privKey);
 
         signedMessageHash = _signMessage(alice);

--- a/test/mocks/BLSPublicKeyCompendiumMock.sol
+++ b/test/mocks/BLSPublicKeyCompendiumMock.sol
@@ -10,10 +10,15 @@ import "eigenlayer-contracts/src/contracts/libraries/BN254.sol";
  */
 contract BLSPublicKeyCompendiumMock is IBLSPublicKeyCompendium{
 
-    /// @notice mapping from operator address to pubkey hash
+    /// @notice the hash of the zero pubkey aka BN254.G1Point(0,0)
+    bytes32 internal constant ZERO_PK_HASH = hex"ad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5";
+
+    /// @notice maps operator address to pubkey hash
     mapping(address => bytes32) public operatorToPubkeyHash;
-    /// @notice mapping from pubkey hash to operator address
+    /// @notice maps pubkey hash to operator address
     mapping(bytes32 => address) public pubkeyHashToOperator;
+    /// @notice maps operator address to pubkeyG1
+    mapping(address => BN254.G1Point) public operatorToPubkey;
 
     /**
      * @notice Called by an operator to register themselves as the owner of a BLS public key and reveal their G1 and G2 public key.
@@ -30,6 +35,7 @@ contract BLSPublicKeyCompendiumMock is IBLSPublicKeyCompendium{
         // store updates
         operatorToPubkeyHash[msg.sender] = pubkeyHash;
         pubkeyHashToOperator[pubkeyHash] = msg.sender;
+        operatorToPubkey[msg.sender] = pk;
     }
 
     function setBLSPublicKey(address account, BN254.G1Point memory pk) external {
@@ -38,6 +44,21 @@ contract BLSPublicKeyCompendiumMock is IBLSPublicKeyCompendium{
         // store updates
         operatorToPubkeyHash[account] = pubkeyHash;
         pubkeyHashToOperator[pubkeyHash] = account;
+        operatorToPubkey[account] = pk;
+    }
+
+    function getRegisteredPubkey(address operator) public view returns (BN254.G1Point memory) {
+        BN254.G1Point memory pubkey = operatorToPubkey[operator];
+        bytes32 pubkeyHash = operatorToPubkeyHash[operator];
+
+        require(
+            pubkeyHash != bytes32(0) && BN254.hashG1Point(pubkey) == pubkeyHash, 
+            "BLSPublicKeyCompendium.getRegisteredPubkey: operator is not registered"
+        );
+
+        require(pubkeyHash != ZERO_PK_HASH, "BLSPublicKeyCompendium.getRegisteredPubkey: invalid pubkey");
+        
+        return pubkey;
     }
 
     function getMessageHash(address operator) external view returns (BN254.G1Point memory) {}

--- a/test/unit/BLSOperatorStateRetrieverUnit.t.sol
+++ b/test/unit/BLSOperatorStateRetrieverUnit.t.sol
@@ -47,7 +47,7 @@ contract BLSOperatorStateRetrieverUnitTests is MockAVSDeployer {
         cheats.roll(deregistrationBlockNumber);
 
         cheats.prank(_incrementAddress(defaultOperator, operatorIndexToDeregister));
-        registryCoordinator.deregisterOperator(quorumNumbersToDeregister, operatorMetadatas[operatorIndexToDeregister].pubkey);
+        registryCoordinator.deregisterOperator(quorumNumbersToDeregister);
         // modify expectedOperatorOverallIndices by moving th operatorIdsToSwap to the index where the operatorIndexToDeregister was
         for (uint i = 0; i < quorumNumbersToDeregister.length; i++) {
             uint8 quorumNumber = uint8(quorumNumbersToDeregister[i]);

--- a/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
+++ b/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
@@ -121,21 +121,21 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
         cheats.startPrank(defaultOperator);
         cheats.expectRevert(bytes("Pausable: index is paused"));
-        registryCoordinator.registerOperator(emptyQuorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(emptyQuorumNumbers, defaultSocket);
     }
 
     function testRegisterOperatorWithCoordinator_EmptyQuorumNumbers_Reverts() public {
         bytes memory emptyQuorumNumbers = new bytes(0);
         cheats.expectRevert("BLSRegistryCoordinatorWithIndices._registerOperator: bitmap cannot be 0");
         cheats.prank(defaultOperator);
-        registryCoordinator.registerOperator(emptyQuorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(emptyQuorumNumbers, defaultSocket);
     }
 
     function testRegisterOperatorWithCoordinator_QuorumNumbersTooLarge_Reverts() public {
         bytes memory quorumNumbersTooLarge = new bytes(1);
         quorumNumbersTooLarge[0] = 0xC0;
         cheats.expectRevert("BLSRegistryCoordinatorWithIndices._registerOperator: bitmap exceeds max bitmap size");
-        registryCoordinator.registerOperator(quorumNumbersTooLarge, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbersTooLarge, defaultSocket);
     }
 
     function testRegisterOperatorWithCoordinator_QuorumNotCreated_Reverts() public {
@@ -144,7 +144,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         quorumNumbersNotCreated[0] = 0x0B;
         cheats.prank(defaultOperator);
         cheats.expectRevert("BLSPubkeyRegistry._processQuorumApkUpdate: quorum does not exist");
-        registryCoordinator.registerOperator(quorumNumbersNotCreated, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbersNotCreated, defaultSocket);
     }
 
     function testRegisterOperatorWithCoordinatorForSingleQuorum_Valid() public {
@@ -164,7 +164,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         emit OperatorSocketUpdate(defaultOperatorId, defaultSocket);
 
         uint256 gasBefore = gasleft();
-        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultSocket);
         uint256 gasAfter = gasleft();
         emit log_named_uint("gasUsed", gasBefore - gasAfter);
 
@@ -215,7 +215,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         emit OperatorSocketUpdate(defaultOperatorId, defaultSocket);
 
         uint256 gasBefore = gasleft();
-        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultSocket);
         uint256 gasAfter = gasleft();
         emit log_named_uint("gasUsed", gasBefore - gasAfter);
         emit log_named_uint("numQuorums", quorumNumbers.length);
@@ -249,7 +249,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         stakeRegistry.setOperatorWeight(uint8(quorumNumbers[0]), defaultOperator, defaultStake);
         cheats.prank(defaultOperator);
         cheats.roll(registrationBlockNumber);
-        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultSocket);
 
         bytes memory newQuorumNumbers = new bytes(1);
         newQuorumNumbers[0] = bytes1(defaultQuorumNumber+1);
@@ -265,7 +265,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         cheats.expectEmit(true, true, true, true, address(registryCoordinator));
         emit OperatorSocketUpdate(defaultOperatorId, defaultSocket);
         cheats.roll(nextRegistrationBlockNumber);
-        registryCoordinator.registerOperator(newQuorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(newQuorumNumbers, defaultSocket);
 
         uint256 quorumBitmap = BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers) | BitmapUtils.orderedBytesArrayToBitmap(newQuorumNumbers);
 
@@ -323,7 +323,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
         cheats.prank(operatorToRegister);
         cheats.expectRevert("BLSRegistryCoordinatorWithIndices.registerOperator: quorum is overfilled");
-        registryCoordinator.registerOperator(quorumNumbers, operatorToRegisterPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultSocket);
     }
 
     function testRegisterOperatorWithCoordinator_RegisteredOperatorForSameQuorums_Reverts() public {
@@ -336,12 +336,12 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         stakeRegistry.setOperatorWeight(uint8(quorumNumbers[0]), defaultOperator, defaultStake);
         cheats.prank(defaultOperator);
         cheats.roll(registrationBlockNumber);
-        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultSocket);
 
         cheats.prank(defaultOperator);
         cheats.roll(nextRegistrationBlockNumber);
         cheats.expectRevert("BLSRegistryCoordinatorWithIndices._registerOperator: operator already registered for some quorums being registered for");
-        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultSocket);
     }
 
     function testDeregisterOperatorWithCoordinator_WhenPaused_Reverts() public {
@@ -357,7 +357,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
         cheats.expectRevert(bytes("Pausable: index is paused"));
         cheats.prank(defaultOperator);
-        registryCoordinator.deregisterOperator(quorumNumbers, defaultPubKey);
+        registryCoordinator.deregisterOperator(quorumNumbers);
     }
 
     function testDeregisterOperatorWithCoordinator_NotRegistered_Reverts() public {
@@ -366,21 +366,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
         cheats.expectRevert("BLSRegistryCoordinatorWithIndices._deregisterOperator: operator is not registered");
         cheats.prank(defaultOperator);
-        registryCoordinator.deregisterOperator(quorumNumbers, defaultPubKey);
-    }
-
-    function testDeregisterOperatorWithCoordinator_IncorrectPubkey_Reverts() public {
-        bytes memory quorumNumbers = new bytes(1);
-        quorumNumbers[0] = bytes1(defaultQuorumNumber);
-        uint256 quorumBitmap = BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers);
-
-        _registerOperatorWithCoordinator(defaultOperator, quorumBitmap, defaultPubKey);
-
-        BN254.G1Point memory incorrectPubKey = BN254.hashToG1(bytes32(uint256(123)));
-
-        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._deregisterOperator: operatorId does not match pubkey hash");
-        cheats.prank(defaultOperator);
-        registryCoordinator.deregisterOperator(quorumNumbers, incorrectPubKey);
+        registryCoordinator.deregisterOperator(quorumNumbers);
     }
 
     function testDeregisterOperatorWithCoordinator_IncorrectQuorums_Reverts() public {
@@ -396,7 +382,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
         cheats.expectRevert("BLSRegistryCoordinatorWithIndices._deregisterOperator: operator is not registered for any of the provided quorums");
         cheats.prank(defaultOperator);
-        registryCoordinator.deregisterOperator(quorumNumbers, defaultPubKey);
+        registryCoordinator.deregisterOperator(quorumNumbers);
     }
 
     function testDeregisterOperatorWithCoordinatorForSingleQuorumAndSingleOperator_Valid() public {
@@ -412,7 +398,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         
         cheats.roll(registrationBlockNumber);
         
-        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultSocket);
 
         uint256 quorumBitmap = BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers);
 
@@ -424,7 +410,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         cheats.roll(deregistrationBlockNumber);
 
         uint256 gasBefore = gasleft();
-        registryCoordinator.deregisterOperator(quorumNumbers, defaultPubKey);
+        registryCoordinator.deregisterOperator(quorumNumbers);
         uint256 gasAfter = gasleft();
         emit log_named_uint("gasUsed", gasBefore - gasAfter);
 
@@ -462,7 +448,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         
         cheats.roll(registrationBlockNumber);
         
-        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultSocket);
 
         cheats.expectEmit(true, true, true, true, address(blsPubkeyRegistry));
         emit OperatorRemovedFromQuorums(defaultOperator, quorumNumbers);
@@ -474,7 +460,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         cheats.roll(deregistrationBlockNumber);
 
         uint256 gasBefore = gasleft();
-        registryCoordinator.deregisterOperator(quorumNumbers, defaultPubKey);
+        registryCoordinator.deregisterOperator(quorumNumbers);
         uint256 gasAfter = gasleft();
         emit log_named_uint("gasUsed", gasBefore - gasAfter);
         emit log_named_uint("numQuorums", quorumNumbers.length);
@@ -551,7 +537,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         cheats.roll(deregistrationBlockNumber);
 
         cheats.prank(operatorToDerigister);
-        registryCoordinator.deregisterOperator(operatorToDeregisterQuorumNumbers, operatorToDeregisterPubKey);
+        registryCoordinator.deregisterOperator(operatorToDeregisterQuorumNumbers);
 
         assertEq(
             keccak256(abi.encode(registryCoordinator.getOperator(operatorToDerigister))), 
@@ -589,7 +575,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
             registryCoordinator.getQuorumBitmapUpdateByIndex(defaultOperatorId, 0);
 
         // re-register the operator
-        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultSocket);
 
         // check success of registration
         uint256 quorumBitmap = BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers);
@@ -658,8 +644,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
             operatorKickParams[0] = IBLSRegistryCoordinatorWithIndices.OperatorKickParam({
                 quorumNumber: defaultQuorumNumber,
-                operator: operatorToKick,
-                pubkey: pubKey
+                operator: operatorToKick
             });
         }
 
@@ -689,7 +674,6 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
             uint256 gasBefore = gasleft();
             registryCoordinator.registerOperatorWithChurn(
                 quorumNumbers, 
-                operatorToRegisterPubKey, 
                 defaultSocket, 
                 operatorKickParams, 
                 signatureWithExpiry
@@ -739,7 +723,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         ISignatureUtils.SignatureWithSaltAndExpiry memory signatureWithExpiry = _signOperatorChurnApproval(operatorToRegisterId, operatorKickParams, defaultSalt, block.timestamp + 10);
         cheats.prank(operatorToRegister);
         cheats.expectRevert("BLSRegistryCoordinatorWithIndices.registerOperatorWithChurn: registering operator has less than kickBIPsOfOperatorStake");
-        registryCoordinator.registerOperatorWithChurn(quorumNumbers, operatorToRegisterPubKey, defaultSocket, operatorKickParams, signatureWithExpiry);
+        registryCoordinator.registerOperatorWithChurn(quorumNumbers, defaultSocket, operatorKickParams, signatureWithExpiry);
     }
 
     function testRegisterOperatorWithCoordinatorWithKicks_LessThanKickBIPsOfTotalStake_Reverts(uint256 pseudoRandomNumber) public {
@@ -762,7 +746,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         ISignatureUtils.SignatureWithSaltAndExpiry memory signatureWithExpiry = _signOperatorChurnApproval(operatorToRegisterId, operatorKickParams, defaultSalt, block.timestamp + 10);
         cheats.prank(operatorToRegister);
         cheats.expectRevert("BLSRegistryCoordinatorWithIndices.registerOperatorWithChurn: operator to kick has more than kickBIPSOfTotalStake");
-        registryCoordinator.registerOperatorWithChurn(quorumNumbers, operatorToRegisterPubKey, defaultSocket, operatorKickParams, signatureWithExpiry);
+        registryCoordinator.registerOperatorWithChurn(quorumNumbers, defaultSocket, operatorKickParams, signatureWithExpiry);
     }
 
     function testRegisterOperatorWithCoordinatorWithKicks_InvalidSignatures_Reverts(uint256 pseudoRandomNumber) public {
@@ -771,7 +755,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
         (   
             address operatorToRegister, 
-            BN254.G1Point memory operatorToRegisterPubKey,
+            ,
             IBLSRegistryCoordinatorWithIndices.OperatorKickParam[] memory operatorKickParams
         ) = _testRegisterOperatorWithKicks_SetUp(pseudoRandomNumber, quorumNumbers, defaultStake);
 
@@ -785,7 +769,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         signatureWithSaltAndExpiry.salt = defaultSalt;
         cheats.prank(operatorToRegister);
         cheats.expectRevert("ECDSA: invalid signature");
-        registryCoordinator.registerOperatorWithChurn(quorumNumbers, operatorToRegisterPubKey, defaultSocket, operatorKickParams, signatureWithSaltAndExpiry);
+        registryCoordinator.registerOperatorWithChurn(quorumNumbers, defaultSocket, operatorKickParams, signatureWithSaltAndExpiry);
     }
 
     function testRegisterOperatorWithCoordinatorWithKicks_ExpiredSignatures_Reverts(uint256 pseudoRandomNumber) public {
@@ -806,7 +790,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         ISignatureUtils.SignatureWithSaltAndExpiry memory signatureWithSaltAndExpiry = _signOperatorChurnApproval(operatorToRegisterId, operatorKickParams, defaultSalt, block.timestamp - 1);
         cheats.prank(operatorToRegister);
         cheats.expectRevert("BLSRegistryCoordinatorWithIndices._verifyChurnApproverSignature: churnApprover signature expired");
-        registryCoordinator.registerOperatorWithChurn(quorumNumbers, operatorToRegisterPubKey, defaultSocket, operatorKickParams, signatureWithSaltAndExpiry);
+        registryCoordinator.registerOperatorWithChurn(quorumNumbers, defaultSocket, operatorKickParams, signatureWithSaltAndExpiry);
     }
 
     function testEjectOperatorFromCoordinator_AllQuorums_Valid() public {
@@ -817,7 +801,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         stakeRegistry.setOperatorWeight(uint8(quorumNumbers[0]), defaultOperator, defaultStake);
 
         cheats.prank(defaultOperator);
-        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultSocket);
 
         cheats.expectEmit(true, true, true, true, address(blsPubkeyRegistry));
         emit OperatorRemovedFromQuorums(defaultOperator, quorumNumbers);
@@ -827,7 +811,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
         // eject
         cheats.prank(ejector);
-        registryCoordinator.ejectOperator(defaultOperator, quorumNumbers, defaultPubKey);
+        registryCoordinator.ejectOperator(defaultOperator, quorumNumbers);
         
         // make sure the operator is deregistered
         assertEq(
@@ -852,7 +836,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         }
 
         cheats.prank(defaultOperator);
-        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultSocket);
 
         // eject from only first quorum
         bytes memory quorumNumbersToEject = new bytes(1);
@@ -865,7 +849,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         emit StakeUpdate(defaultOperatorId, uint8(quorumNumbersToEject[0]), 0);
 
         cheats.prank(ejector);
-        registryCoordinator.ejectOperator(defaultOperator, quorumNumbersToEject, defaultPubKey);
+        registryCoordinator.ejectOperator(defaultOperator, quorumNumbersToEject);
         
         // make sure the operator is registered
         assertEq(
@@ -889,11 +873,11 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         stakeRegistry.setOperatorWeight(uint8(quorumNumbers[0]), defaultOperator, defaultStake);
 
         cheats.prank(defaultOperator);
-        registryCoordinator.registerOperator(quorumNumbers, defaultPubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultSocket);
         
         cheats.expectRevert("BLSRegistryCoordinatorWithIndices.onlyEjector: caller is not the ejector");
         cheats.prank(defaultOperator);
-        registryCoordinator.ejectOperator(defaultOperator, quorumNumbers, defaultPubKey);
+        registryCoordinator.ejectOperator(defaultOperator, quorumNumbers);
     }
 
     function testUpdateSocket() public {
@@ -952,8 +936,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
             operatorKickParams[0] = IBLSRegistryCoordinatorWithIndices.OperatorKickParam({
                 quorumNumber: uint8(quorumNumbers[0]),
-                operator: operatorToKick,
-                pubkey: pubKey
+                operator: operatorToKick
             });
         }
 

--- a/test/unit/BLSSignatureCheckerUnit.t.sol
+++ b/test/unit/BLSSignatureCheckerUnit.t.sol
@@ -161,7 +161,7 @@ contract BLSSignatureCheckerUnitTests is BLSMockAVSDeployer {
         // set the quorumApkIndices to a different value
         nonSignerStakesAndSignature.quorumApkIndices[0] = 0;
 
-        cheats.expectRevert("BLSPubkeyRegistry._validateApkHashForQuorumAtBlockNumber: not latest apk update");
+        cheats.expectRevert("BLSPubkeyRegistry._validateApkHashAtBlockNumber: not latest apk update");
         blsSignatureChecker.checkSignatures(
             msgHash, 
             quorumNumbers,

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -306,7 +306,7 @@ contract MockAVSDeployer is Test {
         }
 
         cheats.prank(operator);
-        registryCoordinator.registerOperator(quorumNumbers, pubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultSocket);
     }
 
     /**
@@ -324,7 +324,7 @@ contract MockAVSDeployer is Test {
         }
 
         cheats.prank(operator);
-        registryCoordinator.registerOperator(quorumNumbers, pubKey, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultSocket);
     }
 
     function _registerRandomOperators(uint256 pseudoRandomNumber) internal returns(OperatorMetadata[] memory, uint256[][] memory) {


### PR DESCRIPTION
Builds on PR #28 and #43; merge those first! It looks like I'm merging 20 commits, but those are actually commits from the other PRs :) Only the final 2 commits in this PR are relevant.

Functional changes in this PR:
* adds a new mapping to `BLSPublicKeyCompendium` : `operatorToPubkey`, which maps operator addresses to `G1Point` 
* adds a method `BLSPublicKeyCompendium.getRegisteredPubkey(address)` which performs a pubkey lookup along with validation that the pubkey exists/isn't the zero pubkey. 
  * Validation logic here was previously performed in the `BLSPubkeyRegistry`
* Removes the "pubkey" parameter from various functions, like in the `BLSPubkeyRegistry` and `BLSRegistryCoordinatorWithIndices`. The pubkey registry is able to look up pubkeys with just an operator address, now.

`BLSPubkeyRegistry` state variable naming changes (these better match the rest of the contracts):
* `quorumApk` -> `currentApk`
* `quorumApkUpdates` -> `apkHistory` 

`BLSPubkeyRegistry` view function naming changes:
* `getApkIndicesForQuorumsAtBlockNumber` -> `getApkIndicesAtBlockNumber`
* `getApkForQuorum` -> `getApk`
* `getApkUpdateForQuorumByIndex` -> `getApkUpdateAtIndex`
* `getApkHashForQuorumAtBlockNumberFromIndex` -> `getApkHashAtBlockNumberAndIndex`
* `getQuorumApkHistoryLength` -> `getApkHistoryLength`

**Recommended review order:**
1. Check out the `BLSPublicKeyCompendium` changes in `b883fd0` to see what new state we're tracking and get some context for the other changes in this commit.
2. Review the rest of the commit, noting all the places we're no longer passing in pubkeys.
3. Skim the final commit - this is solely naming-related changes (listed above)