### PR TITLE
Anvil testing update stakes

### DIFF
--- a/script/AVSContractsDeploy.s.sol
+++ b/script/AVSContractsDeploy.s.sol
@@ -151,7 +151,8 @@ contract EigenLayerDeploy is Script, Test {
 
         // START RECORDING TRANSACTIONS FOR DEPLOYMENT
         vm.startBroadcast();
-
+        console.log(address(this));
+        console.log(address(this).balance);
         // deploy proxy admin for ability to upgrade proxy contracts
         eigenLayerProxyAdmin = new ProxyAdmin();
 

--- a/script/configs/M1_deployment_goerli_2023_3_23.json
+++ b/script/configs/M1_deployment_goerli_2023_3_23.json
@@ -1,0 +1,37 @@
+{
+  "addresses": {
+    "baseStrategyImplementation": "0x2c836f44207A732bC951df98f0cAcE4704432B7E",
+    "delayedWithdrawalRouter": "0x89581561f1F98584F88b0d57c2180fb89225388f",
+    "delayedWithdrawalRouterImplementation": "0x6854c0eF4A8dF70a5E832cC3b3b4C5a500063837",
+    "delegation": "0x1b7b8F6b258f95Cf9596EabB9aa18B62940Eb0a8",
+    "delegationImplementation": "0xeBea7B291b6631806244Ed0E3d1E585e76BB37fb",
+    "eigenLayerPauserReg": "0x7cB9c5D6b9702f2f680e4d35cb1fC945D08208F6",
+    "eigenLayerProxyAdmin": "0x28ceac2ff82B2E00166e46636e2A4818C29902e2",
+    "eigenPodBeacon": "0x3093F3B560352F896F0e9567019902C9Aff8C9a5",
+    "eigenPodImplementation": "0x0062645382Af44593bA2E453F51604833277F371",
+    "eigenPodManager": "0xa286b84C96aF280a49Fe1F40B9627C2A2827df41",
+    "eigenPodManagerImplementation": "0xad46772384CFec11d140E255e6d240949A194f17",
+    "emptyContract": "0xa04bf5170D86833294b5c21c712C69C0Fb5735A4",
+    "slasher": "0xD11d60b669Ecf7bE10329726043B3ac07B380C22",
+    "slasherImplementation": "0x7dcbcb83f7e744ffa1a94f508419cee8279f469e",
+    "strategies": {
+      "WETH": "0x7CA911E83dabf90C90dD3De5411a10F1A6112184",
+      "rETH": "0x879944A8cB437a5f8061361f82A6d4EED59070b5",
+      "tsETH": "0xcFA9da720682bC4BCb55116675f16F503093ba13",
+      "wstETH": "0x13760F50a9d7377e4F20CB8CF9e4c26586c658ff",
+      "stETH": "0xB613E78E2068d7489bb66419fB1cfa11275d14da"
+    },
+    "strategyManager": "0x779d1b5315df083e3F9E94cB495983500bA8E907",
+    "strategyManagerImplementation": "0xcf19a2e2d1d83994ad9c89807d4173519aef72a0"
+  },
+  "chainInfo": {
+    "chainId": 5,
+    "deploymentBlock": 8705851
+  },
+  "parameters": {
+    "communityMultisig": "0x37bAFb55BC02056c5fD891DFa503ee84a97d89bF",
+    "operationsMultisig": "0x040353E9d057689b77DF275c07FFe1A46b98a4a6",
+    "executorMultisig": "0x3d9C2c2B40d890ad53E27947402e977155CD2808",
+    "timelock": "0xA7e72a0564ebf25Fa082Fc27020225edeAF1796E"
+  }
+}

--- a/script/configs/M2_deploy.config.json
+++ b/script/configs/M2_deploy.config.json
@@ -1,0 +1,54 @@
+{
+  "chainInfo": {
+    "chainId": 5
+  },
+
+  "permissions" : {
+    "owner": "0x37bAFb55BC02056c5fD891DFa503ee84a97d89bF",
+    "upgrader": "0x37bAFb55BC02056c5fD891DFa503ee84a97d89bF",
+    "churner": "0x37bAFb55BC02056c5fD891DFa503ee84a97d89bF",
+    "ejector": "0x37bAFb55BC02056c5fD891DFa503ee84a97d89bF"
+  },
+
+  "minimumStakes": [
+    32,
+    32
+  ],
+
+  "strategyWeights": [
+    [
+      {
+        "0_strategy": "0x7CA911E83dabf90C90dD3De5411a10F1A6112184",
+        "1_multiplier": 1
+      },
+      {
+        "0_strategy": "0x879944A8cB437a5f8061361f82A6d4EED59070b5", 
+        "1_multiplier": 1
+      },
+      {
+        "0_strategy": "0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0",
+        "1_multiplier": 1
+      }
+    ],
+    [
+      {
+        "0_strategy": "",
+        "1_multiplier": 1
+      }
+    ]
+  ],
+
+  "operatorSetParams": [
+    {
+      "0_maxOperatorCount" : 200,
+      "1_kickBIPsOfOperatorStake" : 11000,
+      "2_kickBIPsOfTotalStake" : 50
+    },
+    {
+      "0_maxOperatorCount" : 65535,
+      "1_kickBIPsOfOperatorStake" : 65535,
+      "2_kickBIPsOfTotalStake" : 65535
+    }
+  ]
+
+}

--- a/script/configs/M2_deploy.config.json
+++ b/script/configs/M2_deploy.config.json
@@ -9,40 +9,161 @@
     "churner": "0x37bAFb55BC02056c5fD891DFa503ee84a97d89bF",
     "ejector": "0x37bAFb55BC02056c5fD891DFa503ee84a97d89bF"
   },
-
   "minimumStakes": [
+    32,
+    32,
+    32,
+    32,
+    32,
+    32,
+    32,
+    32,
     32,
     32
   ],
-
   "strategyWeights": [
     [
       {
-        "0_strategy": "0x7CA911E83dabf90C90dD3De5411a10F1A6112184",
+        "0_strategy": "0x0000000000000000000000000000000000000001",
         "1_multiplier": 1
       },
       {
-        "0_strategy": "0x879944A8cB437a5f8061361f82A6d4EED59070b5", 
+        "0_strategy": "0x0000000000000000000000000000000000000002",
         "1_multiplier": 1
       },
       {
-        "0_strategy": "0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0",
+        "0_strategy": "0x0000000000000000000000000000000000000003",
+        "1_multiplier": 1
+      },
+      {
+        "0_strategy": "0x0000000000000000000000000000000000000004",
+        "1_multiplier": 1
+      },
+      {
+        "0_strategy": "0x0000000000000000000000000000000000000005",
+        "1_multiplier": 1
+      },
+      {
+        "0_strategy": "0x0000000000000000000000000000000000000006",
+        "1_multiplier": 1
+      },
+      {
+        "0_strategy": "0x0000000000000000000000000000000000000007",
+        "1_multiplier": 1
+      },
+      {
+        "0_strategy": "0x0000000000000000000000000000000000000008",
+        "1_multiplier": 1
+      },
+      {
+        "0_strategy": "0x0000000000000000000000000000000000000009",
+        "1_multiplier": 1
+      },
+      {
+        "0_strategy": "0x000000000000000000000000000000000000000A",
         "1_multiplier": 1
       }
     ],
     [
       {
-        "0_strategy": "",
+        "0_strategy": "0x0000000000000000000000000000000000000001",
+        "1_multiplier": 1
+      }
+    ],
+    [
+      {
+        "0_strategy": "0x0000000000000000000000000000000000000001",
+        "1_multiplier": 1
+      }
+    ],
+    [
+      {
+        "0_strategy": "0x0000000000000000000000000000000000000001",
+        "1_multiplier": 1
+      }
+    ],
+    [
+      {
+        "0_strategy": "0x0000000000000000000000000000000000000001",
+        "1_multiplier": 1
+      }
+    ],
+    [
+      {
+        "0_strategy": "0x0000000000000000000000000000000000000001",
+        "1_multiplier": 1
+      }
+    ],
+    [
+      {
+        "0_strategy": "0x0000000000000000000000000000000000000001",
+        "1_multiplier": 1
+      }
+    ],
+    [
+      {
+        "0_strategy": "0x0000000000000000000000000000000000000001",
+        "1_multiplier": 1
+      }
+    ],
+    [
+      {
+        "0_strategy": "0x0000000000000000000000000000000000000001",
+        "1_multiplier": 1
+      }
+    ],
+    [
+      {
+        "0_strategy": "0x0000000000000000000000000000000000000001",
         "1_multiplier": 1
       }
     ]
   ],
-
   "operatorSetParams": [
     {
       "0_maxOperatorCount" : 200,
       "1_kickBIPsOfOperatorStake" : 11000,
       "2_kickBIPsOfTotalStake" : 50
+    },
+    {
+      "0_maxOperatorCount" : 65535,
+      "1_kickBIPsOfOperatorStake" : 65535,
+      "2_kickBIPsOfTotalStake" : 65535
+    },
+    {
+      "0_maxOperatorCount" : 65535,
+      "1_kickBIPsOfOperatorStake" : 65535,
+      "2_kickBIPsOfTotalStake" : 65535
+    },
+    {
+      "0_maxOperatorCount" : 65535,
+      "1_kickBIPsOfOperatorStake" : 65535,
+      "2_kickBIPsOfTotalStake" : 65535
+    },
+    {
+      "0_maxOperatorCount" : 65535,
+      "1_kickBIPsOfOperatorStake" : 65535,
+      "2_kickBIPsOfTotalStake" : 65535
+    },
+    {
+      "0_maxOperatorCount" : 65535,
+      "1_kickBIPsOfOperatorStake" : 65535,
+      "2_kickBIPsOfTotalStake" : 65535
+    },
+    {
+      "0_maxOperatorCount" : 65535,
+      "1_kickBIPsOfOperatorStake" : 65535,
+      "2_kickBIPsOfTotalStake" : 65535
+    },
+    {
+      "0_maxOperatorCount" : 65535,
+      "1_kickBIPsOfOperatorStake" : 65535,
+      "2_kickBIPsOfTotalStake" : 65535
+    },
+    {
+      "0_maxOperatorCount" : 65535,
+      "1_kickBIPsOfOperatorStake" : 65535,
+      "2_kickBIPsOfTotalStake" : 65535
     },
     {
       "0_maxOperatorCount" : 65535,

--- a/script/configs/M2_deployment_data.json
+++ b/script/configs/M2_deployment_data.json
@@ -1,0 +1,24 @@
+{
+  "addresses": {
+    "blsOperatorStateRetriever": "0x48b3B854A229980A678Cb2f0039207854463a530",
+    "blsPubKeyCompendium": "0x2Ba2479333F93C56C806fC8a9DfDF19211495B16",
+    "eigenDAProxyAdmin": "0xb87F1ad08b8f12fCfEA21b0f496089a79e71E578",
+    "eigenDAServiceManager": "0xc51E5EE87fB2E0a4824899CB30A552fE77ffef12",
+    "indexRegistry": "0xB845a945859B905A5af925DEee88A9426bFC5Cc3",
+    "indexRegistryImplementation": "0x55aeb83fCcDB030e48dE47AD012b51CA85e8d9eD",
+    "registryCoordinator": "0x3E9a4fBa134F780C8785a41459A4B770f21B399e",
+    "registryCoordinatorImplementation": "0x6AD15A2B4646e843CD1e3CeDDe01e4897153f282",
+    "stakeRegistry": "0xEa2fbF036D5b885Ef5c9958DB4249D5A0C7d32c1",
+    "stakeRegistryImplementation": "0xB5A82eC52AeF2d029f05805414F0E76e1A2f6B9E"
+  },
+  "chainInfo": {
+    "chainId": 5,
+    "deploymentBlock": 10004326
+  },
+  "permissions": {
+    "eigenDAChurner": "0x37bAFb55BC02056c5fD891DFa503ee84a97d89bF",
+    "eigenDAEjector": "0x37bAFb55BC02056c5fD891DFa503ee84a97d89bF",
+    "eigenDAOwner": "0x37bAFb55BC02056c5fD891DFa503ee84a97d89bF",
+    "eigenDAUpgrader": "0x37bAFb55BC02056c5fD891DFa503ee84a97d89bF"
+  }
+}

--- a/script/testing/M2_DeployTesting.s.sol
+++ b/script/testing/M2_DeployTesting.s.sol
@@ -1,0 +1,436 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "eigenlayer-contracts/script/utils/ExistingDeploymentParser.sol";
+
+import "src/BLSPublicKeyCompendium.sol";
+import "src/BLSRegistryCoordinatorWithIndices.sol";
+import "src/BLSPubkeyRegistry.sol";
+import "src/IndexRegistry.sol";
+import "src/StakeRegistry.sol";
+import "src/BLSOperatorStateRetriever.sol";
+
+import "eigenlayer-contracts/src/contracts/permissions/PauserRegistry.sol";
+import "eigenlayer-contracts/src/contracts/permissions/PauserRegistry.sol";
+import {ServiceManagerMock} from "test/mocks/ServiceManagerMock.sol";
+import {BLSPublicKeyCompendiumMock} from "test/mocks/BLSPublicKeyCompendiumMock.sol";
+import {BLSPubkeyRegistryMock} from "test/mocks/BLSPubkeyRegistryMock.sol";
+
+//forge script script/testing/M2_DeployTesting.s.sol:Deployer_M2 --rpc-url $RPC_URL  --private-key $PRIVATE_KEY --broadcast -vvvv
+//forge script script/testing/M2_DeployTesting.s.sol:Deployer_M2 --rpc-url http://127.0.0.1:8545  --private-key $PRIVATE_KEY --broadcast -vvvv
+contract Deployer_M2 is ExistingDeploymentParser {
+    string internal constant TEST_MNEMONIC = "test test test test test test test test test test test junk";
+
+
+    string public existingDeploymentInfoPath  = string(bytes("./script/configs/M1_deployment_goerli_2023_3_23.json"));
+    string public deployConfigPath = string(bytes("./script/configs/M2_deploy.config.json"));
+    string public outputPath = "./script/configs/M2_deployment_data.json";
+
+    //permissioned addresses
+    ProxyAdmin public eigenDAProxyAdmin;
+    address public eigenDAOwner;
+    address public eigenDAUpgrader;
+
+    //non-upgradeable contracts
+    BLSOperatorStateRetriever public blsOperatorStateRetriever;
+
+    // mocks
+    BLSPubkeyRegistryMock public blsPubkeyRegistryMock;
+    BLSPublicKeyCompendiumMock public pubkeyCompendiumMock;
+
+    
+    //upgradeable contracts
+    IServiceManager public eigenDAServiceManager;
+    BLSRegistryCoordinatorWithIndices public registryCoordinator;
+    IndexRegistry public indexRegistry;
+    StakeRegistry public stakeRegistry;
+
+    //upgradeable contract implementations
+    IServiceManager public eigenDAServiceManagerImplementation;
+    BLSRegistryCoordinatorWithIndices public registryCoordinatorImplementation;
+    IndexRegistry public indexRegistryImplementation;
+    StakeRegistry public stakeRegistryImplementation;
+
+
+    function run() external {
+        // get info on all the already-deployed contracts
+        _parseDeployedContracts(existingDeploymentInfoPath);
+
+        // READ JSON CONFIG DATA
+        string memory config_data = vm.readFile(deployConfigPath);
+
+        // check that the chainID matches the one in the config
+        uint256 currentChainId = block.chainid;
+        uint256 configChainId = stdJson.readUint(config_data, ".chainInfo.chainId");
+        emit log_named_uint("You are deploying on ChainID", currentChainId);
+        require(configChainId == currentChainId, "You are on the wrong chain for this config");
+
+        // parse initalization params and permissions from config data
+        (uint96[] memory minimumStakeForQuourm, IVoteWeigher.StrategyAndWeightingMultiplier[][] memory strategyAndWeightingMultipliers) = _parseStakeRegistryParams(config_data);
+        (IBLSRegistryCoordinatorWithIndices.OperatorSetParam[] memory operatorSetParams, address churner, address ejector) = _parseRegistryCoordinatorParams(config_data);
+
+        eigenDAOwner = stdJson.readAddress(config_data, ".permissions.owner");
+        eigenDAUpgrader = stdJson.readAddress(config_data, ".permissions.upgrader");
+
+        // begin deployment
+        vm.startBroadcast();
+
+        // deploy proxy admin for ability to upgrade proxy contracts
+        eigenDAProxyAdmin = new ProxyAdmin();
+
+        //deploy non-upgradeable contracts
+        pubkeyCompendiumMock = new BLSPublicKeyCompendiumMock();
+        blsOperatorStateRetriever = new BLSOperatorStateRetriever();
+
+        // deploy mocks
+        blsPubkeyRegistryMock = new BLSPubkeyRegistryMock(registryCoordinator, pubkeyCompendiumMock);
+        pubkeyCompendiumMock = new BLSPublicKeyCompendiumMock();
+
+        //Deploy upgradeable proxy contracts that point to empty contract implementations
+        // eigenDAServiceManager = EigenDAServiceManager(
+        //     address(new TransparentUpgradeableProxy(address(emptyContract), address(eigenDAProxyAdmin), ""))
+        // );
+        eigenDAServiceManager = new ServiceManagerMock(slasher);
+        registryCoordinator = BLSRegistryCoordinatorWithIndices(
+            address(new TransparentUpgradeableProxy(address(emptyContract), address(eigenDAProxyAdmin), ""))
+        );
+        indexRegistry = IndexRegistry(
+            address(new TransparentUpgradeableProxy(address(emptyContract), address(eigenDAProxyAdmin), ""))
+        );
+        stakeRegistry = StakeRegistry(
+            address(new TransparentUpgradeableProxy(address(emptyContract), address(eigenDAProxyAdmin), ""))
+        );
+
+        // deploy StakeRegistry
+        stakeRegistryImplementation = new StakeRegistry(
+            registryCoordinator,
+            indexRegistry,
+            strategyManager,
+            IServiceManager(address(eigenDAServiceManager))
+        );
+
+        // upgrade stake registry proxy to implementation and initialbize
+        eigenDAProxyAdmin.upgradeAndCall(
+            TransparentUpgradeableProxy(payable(address(stakeRegistry))),
+            address(stakeRegistryImplementation),
+            abi.encodeWithSelector(
+                StakeRegistry.initialize.selector,
+                minimumStakeForQuourm,
+                strategyAndWeightingMultipliers
+            )
+        );
+
+        // deploy RegistryCoordinator
+        registryCoordinatorImplementation = new BLSRegistryCoordinatorWithIndices(
+            slasher,
+            IServiceManager(address(eigenDAServiceManager)),
+            stakeRegistry,
+            blsPubkeyRegistryMock,
+            indexRegistry
+        );
+
+        // upgrade registry coordinator proxy to implementation and initialize
+        eigenDAProxyAdmin.upgradeAndCall(
+            TransparentUpgradeableProxy(payable(address(registryCoordinator))),
+            address(registryCoordinatorImplementation),
+            abi.encodeWithSelector(
+                BLSRegistryCoordinatorWithIndices.initialize.selector,
+                churner,
+                ejector,
+                operatorSetParams,
+                eigenLayerPauserReg,
+                0
+            )
+        );
+
+        //deploy IndexRegistry
+        indexRegistryImplementation = new IndexRegistry(
+            registryCoordinator
+        );
+
+        // upgrade index registry proxy to implementation
+        eigenDAProxyAdmin.upgrade(
+            TransparentUpgradeableProxy(payable(address(indexRegistry))),
+            address(indexRegistryImplementation)
+        );
+
+        // transfer ownership of proxy admin to upgrader
+        eigenDAProxyAdmin.transferOwnership(eigenDAUpgrader);
+
+        // end deployment
+        vm.stopBroadcast();
+
+        // sanity checks
+        _verifyContractPointers(
+            eigenDAServiceManager,
+            registryCoordinator,
+            // blsPubkeyRegistryMock,
+            indexRegistry,
+            stakeRegistry
+        );
+
+        _verifyContractPointers(
+            eigenDAServiceManagerImplementation,
+            registryCoordinatorImplementation,
+            // blsPubkeyRegistryImplementation,
+            indexRegistryImplementation,
+            stakeRegistryImplementation
+        );
+
+        _verifyImplementations();
+        _verifyInitalizations(churner, ejector, operatorSetParams, minimumStakeForQuourm, strategyAndWeightingMultipliers);
+
+        //write output
+        _writeOutput(churner, ejector);
+
+        // test
+        _testUpdateStakesAllOperators_200OperatorsValid();
+    }
+
+    function _parseStakeRegistryParams(string memory config_data) internal pure returns (uint96[] memory minimumStakeForQuourm, IVoteWeigher.StrategyAndWeightingMultiplier[][] memory strategyAndWeightingMultipliers) {
+        bytes memory stakesConfigsRaw = stdJson.parseRaw(config_data, ".minimumStakes");
+        minimumStakeForQuourm = abi.decode(stakesConfigsRaw, (uint96[]));
+        
+        bytes memory strategyConfigsRaw = stdJson.parseRaw(config_data, ".strategyWeights");
+        strategyAndWeightingMultipliers = abi.decode(strategyConfigsRaw, (IVoteWeigher.StrategyAndWeightingMultiplier[][]));
+    }
+
+    function _parseRegistryCoordinatorParams(string memory config_data) internal returns (IBLSRegistryCoordinatorWithIndices.OperatorSetParam[] memory operatorSetParams, address churner, address ejector) {
+        bytes memory operatorConfigsRaw = stdJson.parseRaw(config_data, ".operatorSetParams");
+        operatorSetParams = abi.decode(operatorConfigsRaw, (IBLSRegistryCoordinatorWithIndices.OperatorSetParam[]));
+
+        churner = stdJson.readAddress(config_data, ".permissions.churner");
+        ejector = stdJson.readAddress(config_data, ".permissions.ejector");
+    }
+
+    function _verifyContractPointers(
+        IServiceManager _eigenDAServiceManager,
+        BLSRegistryCoordinatorWithIndices _registryCoordinator,
+        IndexRegistry _indexRegistry,
+        StakeRegistry _stakeRegistry
+    ) internal view {
+        require(_registryCoordinator.slasher() == slasher, "registryCoordinator.slasher() != slasher");
+        require(address(_registryCoordinator.serviceManager()) == address(eigenDAServiceManager), "registryCoordinator.eigenDAServiceManager() != eigenDAServiceManager");
+        require(_registryCoordinator.stakeRegistry() == stakeRegistry, "registryCoordinator.stakeRegistry() != stakeRegistry");
+        require(_registryCoordinator.blsPubkeyRegistry() == blsPubkeyRegistryMock, "registryCoordinator.blsPubkeyRegistry() != blsPubkeyRegistry");
+        require(_registryCoordinator.indexRegistry() == indexRegistry, "registryCoordinator.indexRegistry() != indexRegistry");
+
+        require(_indexRegistry.registryCoordinator() == registryCoordinator, "indexRegistry.registryCoordinator() != registryCoordinator");
+
+        require(_stakeRegistry.registryCoordinator() == registryCoordinator, "stakeRegistry.registryCoordinator() != registryCoordinator");
+        require(_stakeRegistry.strategyManager() == strategyManager, "stakeRegistry.strategyManager() != strategyManager");
+        require(address(_stakeRegistry.serviceManager()) == address(eigenDAServiceManager), "stakeRegistry.eigenDAServiceManager() != eigenDAServiceManager");
+    }
+
+    function _verifyImplementations() internal view {
+        // require(eigenDAProxyAdmin.getProxyImplementation(
+        //     TransparentUpgradeableProxy(payable(address(eigenDAServiceManager)))) == address(eigenDAServiceManagerImplementation),
+        //     "eigenDAServiceManager: implementation set incorrectly");
+        require(eigenDAProxyAdmin.getProxyImplementation(
+            TransparentUpgradeableProxy(payable(address(registryCoordinator)))) == address(registryCoordinatorImplementation),
+            "registryCoordinator: implementation set incorrectly");
+        // require(eigenDAProxyAdmin.getProxyImplementation(
+        //     TransparentUpgradeableProxy(payable(address(blsPubkeyRegistry)))) == address(blsPubkeyRegistryImplementation),
+        //     "blsPubkeyRegistry: implementation set incorrectly");
+        require(eigenDAProxyAdmin.getProxyImplementation(
+            TransparentUpgradeableProxy(payable(address(indexRegistry)))) == address(indexRegistryImplementation),
+            "indexRegistry: implementation set incorrectly");
+        require(eigenDAProxyAdmin.getProxyImplementation(
+            TransparentUpgradeableProxy(payable(address(stakeRegistry)))) == address(stakeRegistryImplementation),
+            "stakeRegistry: implementation set incorrectly");
+    }
+
+    function _verifyInitalizations(
+        address churner, 
+        address ejector, 
+        IBLSRegistryCoordinatorWithIndices.OperatorSetParam[] memory operatorSetParams,
+        uint96[] memory minimumStakeForQuourm, 
+        IVoteWeigher.StrategyAndWeightingMultiplier[][] memory strategyAndWeightingMultipliers
+        ) internal view {
+        // require(eigenDAServiceManager.owner() == eigenDAOwner, "eigenDAServiceManager.owner() != eigenDAOwner");
+        // require(eigenDAServiceManager.pauserRegistry() == eigenLayerPauserReg, "eigenDAServiceManager: pauser registry not set correctly");
+        require(strategyManager.paused() == 0, "eigenDAServiceManager: init paused status set incorrectly");
+
+        require(registryCoordinator.churnApprover() == churner, "registryCoordinator.churner() != churner");
+        require(registryCoordinator.ejector() == ejector, "registryCoordinator.ejector() != ejector");
+        require(registryCoordinator.pauserRegistry() == eigenLayerPauserReg, "registryCoordinator: pauser registry not set correctly");
+        require(registryCoordinator.paused() == 0, "registryCoordinator: init paused status set incorrectly");
+        
+        for (uint8 i = 0; i < operatorSetParams.length; ++i) {
+            require(keccak256(abi.encode(registryCoordinator.getOperatorSetParams(i))) == keccak256(abi.encode(operatorSetParams[i])), "registryCoordinator.operatorSetParams != operatorSetParams");
+        }
+
+        for (uint256 i = 0; i < minimumStakeForQuourm.length; ++i) {
+            require(stakeRegistry.minimumStakeForQuorum(i) == minimumStakeForQuourm[i], "stakeRegistry.minimumStakeForQuourm != minimumStakeForQuourm");
+        }
+
+        for (uint8 i = 0; i < strategyAndWeightingMultipliers.length; ++i) {
+            for(uint8 j = 0; j < strategyAndWeightingMultipliers[i].length; ++j) {
+                (IStrategy strategy, uint96 multiplier) = stakeRegistry.strategiesConsideredAndMultipliers(i, j);
+                require(address(strategy) == address(strategyAndWeightingMultipliers[i][j].strategy), "stakeRegistry.strategyAndWeightingMultipliers != strategyAndWeightingMultipliers");
+                require(multiplier == strategyAndWeightingMultipliers[i][j].multiplier, "stakeRegistry.strategyAndWeightingMultipliers != strategyAndWeightingMultipliers");
+            }
+        }
+
+        require(operatorSetParams.length == strategyAndWeightingMultipliers.length && operatorSetParams.length == minimumStakeForQuourm.length, "operatorSetParams, strategyAndWeightingMultipliers, and minimumStakeForQuourm must be the same length");
+    }
+
+    function _writeOutput(address churner, address ejector) internal {
+        string memory parent_object = "parent object";
+
+        string memory deployed_addresses = "addresses";
+        vm.serializeAddress(deployed_addresses, "eigenDAProxyAdmin", address(eigenDAProxyAdmin));
+        vm.serializeAddress(deployed_addresses, "blsPubKeyCompendium", address(pubkeyCompendiumMock));
+        vm.serializeAddress(deployed_addresses, "blsOperatorStateRetriever", address(blsOperatorStateRetriever));
+        vm.serializeAddress(deployed_addresses, "eigenDAServiceManager", address(eigenDAServiceManager));
+        // vm.serializeAddress(deployed_addresses, "eigenDAServiceManagerImplementation", address(eigenDAServiceManagerImplementation));
+        vm.serializeAddress(deployed_addresses, "registryCoordinator", address(registryCoordinator));
+        vm.serializeAddress(deployed_addresses, "registryCoordinatorImplementation", address(registryCoordinatorImplementation));
+        vm.serializeAddress(deployed_addresses, "indexRegistry", address(indexRegistry));
+        vm.serializeAddress(deployed_addresses, "indexRegistryImplementation", address(indexRegistryImplementation));
+        vm.serializeAddress(deployed_addresses, "stakeRegistry", address(stakeRegistry));
+        string memory deployed_addresses_output = vm.serializeAddress(deployed_addresses, "stakeRegistryImplementation", address(stakeRegistryImplementation));
+
+        string memory chain_info = "chainInfo";
+        vm.serializeUint(chain_info, "deploymentBlock", block.number);
+        string memory chain_info_output = vm.serializeUint(chain_info, "chainId", block.chainid);
+
+        string memory permissions = "permissions";
+        vm.serializeAddress(permissions, "eigenDAOwner", eigenDAOwner);
+        vm.serializeAddress(permissions, "eigenDAUpgrader", eigenDAUpgrader);
+        vm.serializeAddress(permissions, "eigenDAChurner", churner);
+        string memory permissions_output = vm.serializeAddress(permissions, "eigenDAEjector", ejector);
+        
+        vm.serializeString(parent_object, chain_info, chain_info_output);
+        vm.serializeString(parent_object, deployed_addresses, deployed_addresses_output);
+        string memory finalJson = vm.serializeString(parent_object, permissions, permissions_output);
+        vm.writeJson(finalJson, outputPath);
+    } 
+
+    function _updateStakesAllOperatorsTest() internal {
+        _testUpdateStakesAllOperators_200OperatorsValid();
+    }
+
+    /**
+     * @notice Testing gas estimations for 10 quorums, quorum0 has 10 strategies and quorum1-9 have 1 strategy each
+     * 200 operators all staked into quorum 0
+     * 50 operators are also staked into each of the quorums 1-9
+     */
+    function _testUpdateStakesAllOperators_200OperatorsValid() internal {
+        uint256 maxQuorumsToRegisterFor = 10;
+        // Add 9 additional strategies to quorum 0 which already has 1 strategy
+        uint256 numStratsToAdd = 9;
+        IVoteWeigher.StrategyAndWeightingMultiplier[] memory quorumStrategiesConsideredAndMultipliers = new IVoteWeigher.StrategyAndWeightingMultiplier[](numStratsToAdd);
+        for (uint256 i = 0; i < numStratsToAdd; ++i) {
+            quorumStrategiesConsideredAndMultipliers[i] = IVoteWeigher.StrategyAndWeightingMultiplier(
+                new StrategyBase(strategyManager),
+                uint96(i+1)
+            );
+        }
+        // Set 200 operator addresses
+        address[] memory operators = new address[](200);
+        for (uint256 i = 0; i < 200; ++i) {
+            operators[i] = address(uint160(i + 1000));
+        }
+        vm.broadcast();
+        stakeRegistry.addStrategiesConsideredAndMultipliers(0, quorumStrategiesConsideredAndMultipliers);
+        // OperatorsPerQuorum input param
+        address[][] memory updateOperators = new address[][](maxQuorumsToRegisterFor);
+
+
+        // Register operator with all quorums if first 50 operator, o/w just quorum 0
+        for (uint256 i = 0; i < 200; ++i) {
+            uint256 bitmap;
+            bytes memory quorumNumbers;
+            BN254.G1Point memory pubkey;
+            pubkey.X = i + 1;
+            pubkey.Y = i + 1;
+            (address operator, /*privateKey*/) = deriveRememberKey(TEST_MNEMONIC, uint32(i));
+            vm.broadcast(operator);
+            pubkeyCompendiumMock.setBLSPublicKey(operator, pubkey);
+            if (i < 50) {
+                bitmap = (1<<maxQuorumsToRegisterFor)-1;
+                quorumNumbers = BitmapUtils.bitmapToBytesArray(bitmap);
+            } else {
+                bitmap = 1;
+                quorumNumbers = BitmapUtils.bitmapToBytesArray(bitmap);
+            }
+            vm.broadcast(operator);
+            registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, pubkey, "");
+        }
+
+        // // Register 200 operators for quorum0
+        // updateOperators[0] = new address[](200);
+        // indexRegistryMock.setTotalOperatorsForQuorum(0, 200);
+        // for (uint256 i = 0; i < operators.length; ++i) {
+        //     defaultOperator = operators[i];
+        //     bytes32 operatorId = bytes32(i + 1);
+
+        //     (uint256 quorumBitmap, uint96 stakeForQuorum) = _registerOperatorSpecificQuorum(defaultOperator, operatorId, /*quorumNumber*/ 0);
+        //     require(quorumBitmap == 1, "quorumBitmap should be 1");
+        //     registryCoordinator.setOperatorId(defaultOperator, operatorId);
+        //     registryCoordinator.recordOperatorQuorumBitmapUpdate(operatorId, uint192(quorumBitmap));
+
+        //     bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(quorumBitmap);
+        //     _setOperatorQuorumWeight(uint8(quorumNumbers[0]), defaultOperator, stakeForQuorum + 1);
+        //     updateOperators[0][i] = operators[i];
+        // }
+        // // For each of the quorums 1-9, register 50 operators
+        // for (uint256 i = 0; i < 50; ++i) {
+        //     defaultOperator = operators[i];
+        //     bytes32 operatorId = bytes32(i + 1);
+        //     // Register operator for each quorum 1-9
+        //     uint256 newBitmap;
+        //     for (uint256 j = 1; j < 10; j++) {
+        //         // stakesForQuorum has 1 element for quorum j
+        //         (uint256 quorumBitmap, uint96 stakeForQuorum) = _registerOperatorSpecificQuorum(defaultOperator, operatorId, /*quorumNumber*/ j);
+        //         uint256 currentOperatorBitmap = registryCoordinator.getCurrentQuorumBitmapByOperatorId(operatorId);
+        //         newBitmap = currentOperatorBitmap | quorumBitmap;
+        //         registryCoordinator.recordOperatorQuorumBitmapUpdate(operatorId, uint192(newBitmap));
+        //         _setOperatorQuorumWeight(uint8(j), defaultOperator, stakeForQuorum + 1);
+        //     }
+        //     require(newBitmap == (1<<maxQuorumsToRegisterFor)-1, "Should be registered all quorums");
+        // }
+        // // Mocking indexRegistry to set total number of operators per quorum
+        // for (uint256 i = 1; i < maxQuorumsToRegisterFor; i++) {
+        //     updateOperators[i] = new address[](50);
+        //     indexRegistryMock.setTotalOperatorsForQuorum(i, 50);
+        //     for (uint256 j = 0; j < 50; j++) {
+        //         updateOperators[i][j] = operators[j];
+        //     }
+        // }
+
+        // // Check operators' stakehistory length, should be 1 if they registered
+        // for (uint256 i = 0; i < updateOperators.length; ++i) {
+        //     uint8 quorumNumber = uint8(i);
+        //     for (uint256 j = 0; j < updateOperators[i].length; ++j) {
+        //         bytes32 operatorId = registryCoordinator.getOperatorId(updateOperators[i][j]);
+        //         assertEq(stakeRegistry.getLengthOfOperatorIdStakeHistoryForQuorum(operatorId, quorumNumber), 1);    
+        //     }
+        // }
+        // stakeRegistry.updateStakesAllOperators(updateOperators);
+        // // Check operators' stakehistory length, should be 1 if they registered, 2 if they updated stakes again
+        // for (uint256 i = 0; i < updateOperators.length; ++i) {
+        //     uint8 quorumNumber = uint8(i);
+        //     for (uint256 j = 0; j < updateOperators[i].length; ++j) {
+        //         bytes32 operatorId = registryCoordinator.getOperatorId(updateOperators[i][j]);
+        //         assertLe(stakeRegistry.getLengthOfOperatorIdStakeHistoryForQuorum(operatorId, quorumNumber), 2);    
+        //     }
+        // }
+    }
+
+
+    function _sortArray(bytes32[] memory arr) private pure returns (bytes32[] memory) {
+        uint256 l = arr.length;
+        for(uint i = 0; i < l; i++) {
+            for(uint j = i+1; j < l ;j++) {
+                if(arr[i] > arr[j]) {
+                    bytes32 temp = arr[i];
+                    arr[i] = arr[j];
+                    arr[j] = temp;
+                }
+            }
+        }
+        return arr;
+    }
+}

--- a/test/mocks/BLSPubkeyRegistryMock.sol
+++ b/test/mocks/BLSPubkeyRegistryMock.sol
@@ -33,7 +33,7 @@ contract BLSPubkeyRegistryMock is BLSPubkeyRegistryStorage {
         bytes memory quorumNumbers,
         BN254.G1Point memory pubkey
     ) public virtual returns (bytes32) {
-        return bytes32(abi.encode(msg.sender));
+        return bytes32(abi.encode(operator));
     }
 
     /**

--- a/test/mocks/BLSPubkeyRegistryMock.sol
+++ b/test/mocks/BLSPubkeyRegistryMock.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "src/BLSPubkeyRegistryStorage.sol";
+import "eigenlayer-contracts/src/contracts/libraries/BN254.sol";
+
+contract BLSPubkeyRegistryMock is BLSPubkeyRegistryStorage {
+    using BN254 for BN254.G1Point;
+
+    /*******************************************************************************
+                      EXTERNAL FUNCTIONS - REGISTRY COORDINATOR
+    *******************************************************************************/
+    constructor(
+        IRegistryCoordinator _registryCoordinator, 
+        IBLSPublicKeyCompendium _pubkeyCompendium
+    ) BLSPubkeyRegistryStorage(_registryCoordinator, _pubkeyCompendium) {}
+
+    /**
+     * @notice Registers the `operator`'s pubkey for the specified `quorumNumbers`.
+     * @param operator The address of the operator to register.
+     * @param quorumNumbers The quorum numbers the operator is registering for, where each byte is an 8 bit integer quorumNumber.
+     * @param pubkey The operator's BLS public key.
+     * @return pubkeyHash of the operator's pubkey
+     * @dev access restricted to the RegistryCoordinator
+     * @dev Preconditions (these are assumed, not validated in this contract):
+     *         1) `quorumNumbers` has no duplicates
+     *         2) `quorumNumbers.length` != 0
+     *         3) `quorumNumbers` is ordered in ascending order
+     *         4) the operator is not already registered
+     */
+    function registerOperator(
+        address operator,
+        bytes memory quorumNumbers,
+        BN254.G1Point memory pubkey
+    ) public virtual returns (bytes32) {
+        return bytes32(abi.encode(msg.sender));
+    }
+
+    /**
+     * @notice Deregisters the `operator`'s pubkey for the specified `quorumNumbers`.
+     * @param operator The address of the operator to deregister.
+     * @param quorumNumbers The quorum numbers the operator is deregistering from, where each byte is an 8 bit integer quorumNumber.
+     * @param pubkey The public key of the operator.
+     * @dev access restricted to the RegistryCoordinator
+     * @dev Preconditions (these are assumed, not validated in this contract):
+     *         1) `quorumNumbers` has no duplicates
+     *         2) `quorumNumbers.length` != 0
+     *         3) `quorumNumbers` is ordered in ascending order
+     *         4) the operator is not already deregistered
+     *         5) `quorumNumbers` is a subset of the quorumNumbers that the operator is registered for
+     *         6) `pubkey` is the same as the parameter used when registering
+     */
+    function deregisterOperator(
+        address operator,
+        bytes memory quorumNumbers,
+        BN254.G1Point memory pubkey
+    ) public virtual {
+        emit OperatorRemovedFromQuorums(operator, quorumNumbers);
+    }
+
+    /*******************************************************************************
+                            VIEW FUNCTIONS
+    *******************************************************************************/
+
+    /**
+     * @notice Returns the indices of the quorumApks index at `blockNumber` for the provided `quorumNumbers`
+     * @dev Returns the current indices if `blockNumber >= block.number`
+     */
+    function getApkIndicesForQuorumsAtBlockNumber(
+        bytes calldata quorumNumbers,
+        uint256 blockNumber
+    ) external view returns (uint32[] memory) {
+        uint32[] memory indices = new uint32[](quorumNumbers.length);
+        return indices;
+    }
+
+    /// @notice Returns the current APK for the provided `quorumNumber `
+    function getApkForQuorum(
+        uint8 quorumNumber
+    ) external view returns (BN254.G1Point memory) {}
+
+    /// @notice Returns the `ApkUpdate` struct at `index` in the list of APK updates for the `quorumNumber`
+    function getApkUpdateForQuorumByIndex(
+        uint8 quorumNumber,
+        uint256 index
+    ) external view returns (ApkUpdate memory) {}
+
+    /**
+     * @notice get hash of the apk of `quorumNumber` at `blockNumber` using the provided `index`;
+     * called by checkSignatures in BLSSignatureChecker.sol.
+     * @param quorumNumber is the quorum whose ApkHash is being retrieved
+     * @param blockNumber is the number of the block for which the latest ApkHash will be retrieved
+     * @param index is the index of the apkUpdate being retrieved from the list of quorum apkUpdates in storage
+     */
+    function getApkHashForQuorumAtBlockNumberFromIndex(
+        uint8 quorumNumber,
+        uint32 blockNumber,
+        uint256 index
+    ) external view returns (bytes24) {}
+
+    /// @notice Returns the length of ApkUpdates for the provided `quorumNumber`
+    function getQuorumApkHistoryLength(
+        uint8 quorumNumber
+    ) external view returns (uint32) {}
+
+    /// @notice Returns the operator address for the given `pubkeyHash`
+    function getOperatorFromPubkeyHash(
+        bytes32 pubkeyHash
+    ) public view returns (address) {}
+}


### PR DESCRIPTION
Performed some local testing by running the following commands

Setup anvil node
`anvil -f https://ethereum-goerli.publicnode.com --accounts 200`
Run the testing script
`forge script script/testing/M2_DeployTesting.s.sol:Deployer_M2 --rpc-url http://127.0.0.1:8545  --private-key $PRIVATE_KEY --broadcast -vvv`


With a setup of 10 total quorums, 10 strategies in quorum0, 1 strategy each in quorums1-9
200 operators registered in quorum0, 50 operators each in quorum1-9. Gas cost for `updateStakesAllOperators` is **~26million gas** and results in the error `(code: -32000, message: intrinsic gas too high, data: None)`