### PR TITLE
style: rename OperatorStakeUpdate struct to StakeUpdate, and swap eve…

### DIFF
--- a/src/StakeRegistryStorage.sol
+++ b/src/StakeRegistryStorage.sol
@@ -36,10 +36,10 @@ abstract contract StakeRegistryStorage is IStakeRegistry {
     uint96[256] public minimumStakeForQuorum;
 
     /// @notice array of the history of the total stakes for each quorum -- marked as internal since getTotalStakeFromIndex is a getter for this
-    OperatorStakeUpdate[][256] internal _totalStakeHistory;
+    StakeUpdate[][256] internal _totalStakeHistory;
 
     /// @notice mapping from operator's operatorId to the history of their stake updates
-    mapping(bytes32 => mapping(uint8 => OperatorStakeUpdate[])) internal operatorStakeHistory;
+    mapping(bytes32 => mapping(uint8 => StakeUpdate[])) internal operatorStakeHistory;
 
     /**
      * @notice mapping from quorum number to the list of strategies considered and their

--- a/src/interfaces/IStakeRegistry.sol
+++ b/src/interfaces/IStakeRegistry.sol
@@ -16,7 +16,7 @@ interface IStakeRegistry is IRegistry {
     // DATA STRUCTURES
 
     /// @notice struct used to store the stakes of an individual operator or the sum of all operators' stakes, for storage
-    struct OperatorStakeUpdate {
+    struct StakeUpdate {
         // the block number at which the stake amounts were updated and stored
         uint32 updateBlockNumber;
         // the block number at which the *next update* occurred.
@@ -38,7 +38,7 @@ interface IStakeRegistry is IRegistry {
     // EVENTS
 
     /// @notice emitted whenever the stake of `operator` is updated
-    event StakeUpdate(
+    event OperatorStakeUpdate(
         bytes32 indexed operatorId,
         uint8 quorumNumber,
         uint96 stake
@@ -151,7 +151,7 @@ interface IStakeRegistry is IRegistry {
      * @param operatorId The id of the operator of interest.
      * @param quorumNumber The quorum number to get the stake for.
      */
-    function getStakeHistory(bytes32 operatorId, uint8 quorumNumber) external view returns (OperatorStakeUpdate[] memory);
+    function getStakeHistory(bytes32 operatorId, uint8 quorumNumber) external view returns (StakeUpdate[] memory);
 
     function getTotalStakeHistoryLength(uint8 quorumNumber) external view returns (uint256);
 
@@ -160,7 +160,7 @@ interface IStakeRegistry is IRegistry {
      * @param quorumNumber The quorum number to get the stake for.
      * @param index Array index for lookup, within the dynamic array `totalStakeHistory[quorumNumber]`.
      */
-    function getTotalStakeUpdateAtIndex(uint8 quorumNumber, uint256 index) external view returns (OperatorStakeUpdate memory);
+    function getTotalStakeUpdateAtIndex(uint8 quorumNumber, uint256 index) external view returns (StakeUpdate memory);
 
     /// @notice Returns the indices of the operator stakes for the provided `quorumNumber` at the given `blockNumber`
     function getStakeUpdateIndexAtBlockNumber(bytes32 operatorId, uint8 quorumNumber, uint32 blockNumber)
@@ -181,13 +181,13 @@ interface IStakeRegistry is IRegistry {
     function getStakeUpdateAtIndex(uint8 quorumNumber, bytes32 operatorId, uint256 index)
         external
         view
-        returns (OperatorStakeUpdate memory);
+        returns (StakeUpdate memory);
 
     /**
      * @notice Returns the most recent stake weight for the `operatorId` for a certain quorum
-     * @dev Function returns an OperatorStakeUpdate struct with **every entry equal to 0** in the event that the operator has no stake history
+     * @dev Function returns an StakeUpdate struct with **every entry equal to 0** in the event that the operator has no stake history
      */
-    function getLatestStakeUpdate(bytes32 operatorId, uint8 quorumNumber) external view returns (OperatorStakeUpdate memory);
+    function getLatestStakeUpdate(bytes32 operatorId, uint8 quorumNumber) external view returns (StakeUpdate memory);
 
     /**
      * @notice Returns the stake weight corresponding to `operatorId` for quorum `quorumNumber`, at the

--- a/test/mocks/StakeRegistryMock.sol
+++ b/test/mocks/StakeRegistryMock.sol
@@ -104,7 +104,7 @@ contract StakeRegistryMock is IStakeRegistry {
      * @param operatorId The id of the operator of interest.
      * @param quorumNumber The quorum number to get the stake for.
      */
-    function getStakeHistory(bytes32 operatorId, uint8 quorumNumber) external view returns (OperatorStakeUpdate[] memory) {}
+    function getStakeHistory(bytes32 operatorId, uint8 quorumNumber) external view returns (StakeUpdate[] memory) {}
 
     function getTotalStakeHistoryLength(uint8 quorumNumber) external view returns (uint256) {}
 
@@ -113,7 +113,7 @@ contract StakeRegistryMock is IStakeRegistry {
      * @param quorumNumber The quorum number to get the stake for.
      * @param index Array index for lookup, within the dynamic array `totalStakeHistory[quorumNumber]`.
      */
-    function getTotalStakeUpdateAtIndex(uint8 quorumNumber, uint256 index) external view returns (OperatorStakeUpdate memory) {}
+    function getTotalStakeUpdateAtIndex(uint8 quorumNumber, uint256 index) external view returns (StakeUpdate memory) {}
 
     /// @notice Returns the indices of the operator stakes for the provided `quorumNumber` at the given `blockNumber`
     function getStakeUpdateIndexAtBlockNumber(bytes32 operatorId, uint8 quorumNumber, uint32 blockNumber)
@@ -134,13 +134,13 @@ contract StakeRegistryMock is IStakeRegistry {
     function getStakeUpdateAtIndex(uint8 quorumNumber, bytes32 operatorId, uint256 index)
         external
         view
-        returns (OperatorStakeUpdate memory) {}
+        returns (StakeUpdate memory) {}
 
     /**
      * @notice Returns the most recent stake weight for the `operatorId` for a certain quorum
-     * @dev Function returns an OperatorStakeUpdate struct with **every entry equal to 0** in the event that the operator has no stake history
+     * @dev Function returns an StakeUpdate struct with **every entry equal to 0** in the event that the operator has no stake history
      */
-    function getLatestStakeUpdate(bytes32 operatorId, uint8 quorumNumber) external view returns (OperatorStakeUpdate memory) {}
+    function getLatestStakeUpdate(bytes32 operatorId, uint8 quorumNumber) external view returns (StakeUpdate memory) {}
 
     /**
      * @notice Returns the stake weight corresponding to `operatorId` for quorum `quorumNumber`, at the

--- a/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
+++ b/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
@@ -12,7 +12,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
     event OperatorSocketUpdate(bytes32 indexed operatorId, string socket);
 
     /// @notice emitted whenever the stake of `operator` is updated
-    event StakeUpdate(
+    event OperatorStakeUpdate(
         bytes32 indexed operatorId,
         uint8 quorumNumber,
         uint96 stake
@@ -159,7 +159,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         cheats.expectEmit(true, true, true, true, address(blsPubkeyRegistry));
         emit OperatorAddedToQuorums(defaultOperator, quorumNumbers);
         cheats.expectEmit(true, true, true, true, address(stakeRegistry));
-        emit StakeUpdate(defaultOperatorId, defaultQuorumNumber, defaultStake);
+        emit OperatorStakeUpdate(defaultOperatorId, defaultQuorumNumber, defaultStake);
         cheats.expectEmit(true, true, true, true, address(indexRegistry));
         emit QuorumIndexUpdate(defaultOperatorId, defaultQuorumNumber, 0);
 
@@ -207,7 +207,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
         for (uint i = 0; i < quorumNumbers.length; i++) {
             cheats.expectEmit(true, true, true, true, address(stakeRegistry));
-            emit StakeUpdate(defaultOperatorId, uint8(quorumNumbers[i]), defaultStake);
+            emit OperatorStakeUpdate(defaultOperatorId, uint8(quorumNumbers[i]), defaultStake);
         }    
 
         for (uint i = 0; i < quorumNumbers.length; i++) {
@@ -262,7 +262,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         cheats.expectEmit(true, true, true, true, address(blsPubkeyRegistry));
         emit OperatorAddedToQuorums(defaultOperator, newQuorumNumbers);
         cheats.expectEmit(true, true, true, true, address(stakeRegistry));
-        emit StakeUpdate(defaultOperatorId, uint8(newQuorumNumbers[0]), defaultStake);
+        emit OperatorStakeUpdate(defaultOperatorId, uint8(newQuorumNumbers[0]), defaultStake);
         cheats.expectEmit(true, true, true, true, address(indexRegistry));
         emit QuorumIndexUpdate(defaultOperatorId, uint8(newQuorumNumbers[0]), 0);
         cheats.roll(nextRegistrationBlockNumber);
@@ -407,7 +407,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         cheats.expectEmit(true, true, true, true, address(blsPubkeyRegistry));
         emit OperatorRemovedFromQuorums(defaultOperator, quorumNumbers);
         cheats.expectEmit(true, true, true, true, address(stakeRegistry));
-        emit StakeUpdate(defaultOperatorId, defaultQuorumNumber, 0);
+        emit OperatorStakeUpdate(defaultOperatorId, defaultQuorumNumber, 0);
 
         cheats.roll(deregistrationBlockNumber);
 
@@ -456,7 +456,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         emit OperatorRemovedFromQuorums(defaultOperator, quorumNumbers);
         for (uint i = 0; i < quorumNumbers.length; i++) {
             cheats.expectEmit(true, true, true, true, address(stakeRegistry));
-            emit StakeUpdate(defaultOperatorId, uint8(quorumNumbers[i]), 0);
+            emit OperatorStakeUpdate(defaultOperatorId, uint8(quorumNumbers[i]), 0);
         }
 
         cheats.roll(deregistrationBlockNumber);
@@ -533,7 +533,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         
         for (uint i = 0; i < operatorToDeregisterQuorumNumbers.length; i++) {
             cheats.expectEmit(true, true, true, true, address(stakeRegistry));
-            emit StakeUpdate(operatorToDerigisterId, uint8(operatorToDeregisterQuorumNumbers[i]), 0);
+            emit OperatorStakeUpdate(operatorToDerigisterId, uint8(operatorToDeregisterQuorumNumbers[i]), 0);
         }
 
         cheats.roll(deregistrationBlockNumber);
@@ -663,14 +663,14 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         cheats.expectEmit(true, true, true, true, address(blsPubkeyRegistry));
         emit OperatorAddedToQuorums(operatorToRegister, quorumNumbers);
         cheats.expectEmit(true, true, true, true, address(stakeRegistry));
-        emit StakeUpdate(operatorToRegisterId, defaultQuorumNumber, registeringStake);
+        emit OperatorStakeUpdate(operatorToRegisterId, defaultQuorumNumber, registeringStake);
         cheats.expectEmit(true, true, true, true, address(indexRegistry));
         emit QuorumIndexUpdate(operatorToRegisterId, defaultQuorumNumber, numOperators);
 
         cheats.expectEmit(true, true, true, true, address(blsPubkeyRegistry));
         emit OperatorRemovedFromQuorums(operatorKickParams[0].operator, quorumNumbers);
         cheats.expectEmit(true, true, true, true, address(stakeRegistry));
-        emit StakeUpdate(operatorToKickId, defaultQuorumNumber, 0);
+        emit OperatorStakeUpdate(operatorToKickId, defaultQuorumNumber, 0);
         cheats.expectEmit(true, true, true, true, address(indexRegistry));
         emit QuorumIndexUpdate(operatorToRegisterId, defaultQuorumNumber, numOperators - 1);
 
@@ -813,7 +813,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         emit OperatorRemovedFromQuorums(defaultOperator, quorumNumbers);
 
         cheats.expectEmit(true, true, true, true, address(stakeRegistry));
-        emit StakeUpdate(defaultOperatorId, uint8(quorumNumbers[0]), 0);
+        emit OperatorStakeUpdate(defaultOperatorId, uint8(quorumNumbers[0]), 0);
 
         // eject
         cheats.prank(ejector);
@@ -852,7 +852,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         emit OperatorRemovedFromQuorums(defaultOperator, quorumNumbersToEject);
 
         cheats.expectEmit(true, true, true, true, address(stakeRegistry));
-        emit StakeUpdate(defaultOperatorId, uint8(quorumNumbersToEject[0]), 0);
+        emit OperatorStakeUpdate(defaultOperatorId, uint8(quorumNumbersToEject[0]), 0);
 
         cheats.prank(ejector);
         registryCoordinator.ejectOperator(defaultOperator, quorumNumbersToEject);

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -72,7 +72,7 @@ contract StakeRegistryUnitTests is Test {
     uint256 gasUsed;
 
     /// @notice emitted whenever the stake of `operator` is updated
-    event StakeUpdate(
+    event OperatorStakeUpdate(
         bytes32 indexed operatorId,
         uint8 quorumNumber,
         uint96 stake
@@ -209,7 +209,7 @@ contract StakeRegistryUnitTests is Test {
                 // check that the operator has 1 stake update in the quorum numbers they registered for
                 assertEq(stakeRegistry.getStakeHistoryLength(defaultOperatorId, i), 1);
                 // make sure that the stake update is as expected
-                IStakeRegistry.OperatorStakeUpdate memory stakeUpdate =
+                IStakeRegistry.StakeUpdate memory stakeUpdate =
                     stakeRegistry.getStakeUpdateAtIndex(i, defaultOperatorId, 0);
                 emit log_named_uint("length  of paddedStakesForQuorum", paddedStakesForQuorum.length);
                 assertEq(stakeUpdate.stake, paddedStakesForQuorum[quorumNumberIndex]);
@@ -306,13 +306,13 @@ contract StakeRegistryUnitTests is Test {
             }
 
             // make sure that the stake update is as expected
-            IStakeRegistry.OperatorStakeUpdate memory totalStakeUpdate =
+            IStakeRegistry.StakeUpdate memory totalStakeUpdate =
                 stakeRegistry.getTotalStakeUpdateAtIndex(i, historyLength-1);
 
             assertEq(totalStakeUpdate.stake, cumulativeStake);
             // make sure that the next update block number of the previous stake update is as expected
             if (historyLength >= 2) {
-                IStakeRegistry.OperatorStakeUpdate memory prevTotalStakeUpdate =
+                IStakeRegistry.StakeUpdate memory prevTotalStakeUpdate =
                     stakeRegistry.getTotalStakeUpdateAtIndex(i, historyLength-2);
                 assertEq(prevTotalStakeUpdate.nextUpdateBlockNumber, cumulativeBlockNumber);
             }
@@ -384,7 +384,7 @@ contract StakeRegistryUnitTests is Test {
                 // check that the operator has 2 stake updates in the quorum numbers they registered for
                 assertEq(stakeRegistry.getStakeHistoryLength(operatorIdToDeregister, i), 2, "testDeregisterFirstOperator_Valid_0");
                 // make sure that the last stake update is as expected
-                IStakeRegistry.OperatorStakeUpdate memory lastStakeUpdate =
+                IStakeRegistry.StakeUpdate memory lastStakeUpdate =
                     stakeRegistry.getStakeUpdateAtIndex(i, operatorIdToDeregister, 1);
                 assertEq(lastStakeUpdate.stake, 0, "testDeregisterFirstOperator_Valid_1");
                 assertEq(lastStakeUpdate.updateBlockNumber, cumulativeBlockNumber, "testDeregisterFirstOperator_Valid_2");
@@ -393,7 +393,7 @@ contract StakeRegistryUnitTests is Test {
                 // Get history length for quorum
                 uint historyLength = stakeRegistry.getTotalStakeHistoryLength(i);
                 // make sure that the last stake update is as expected
-                IStakeRegistry.OperatorStakeUpdate memory lastTotalStakeUpdate 
+                IStakeRegistry.StakeUpdate memory lastTotalStakeUpdate 
                     = stakeRegistry.getTotalStakeUpdateAtIndex(i, historyLength-1);
                 assertEq(lastTotalStakeUpdate.stake, 
                     stakeRegistry.getTotalStakeUpdateAtIndex(i, historyLength-2).stake // the previous total stake
@@ -446,7 +446,7 @@ contract StakeRegistryUnitTests is Test {
         }
 
         // make sure that the last stake update is as expected
-        IStakeRegistry.OperatorStakeUpdate memory lastOperatorStakeUpdate = stakeRegistry.getLatestStakeUpdate(defaultOperatorId, defaultQuorumNumber);
+        IStakeRegistry.StakeUpdate memory lastOperatorStakeUpdate = stakeRegistry.getLatestStakeUpdate(defaultOperatorId, defaultQuorumNumber);
         assertEq(lastOperatorStakeUpdate.stake, stakes[i - 1], "1");
         assertEq(lastOperatorStakeUpdate.nextUpdateBlockNumber, uint32(0), "2");
     }
@@ -472,7 +472,7 @@ contract StakeRegistryUnitTests is Test {
             // Perform the update
             stakeRegistry.recordTotalStakeUpdate(defaultQuorumNumber, stakeDelta);
             
-            IStakeRegistry.OperatorStakeUpdate memory newStakeUpdate;
+            IStakeRegistry.StakeUpdate memory newStakeUpdate;
             uint historyLength = stakeRegistry.getTotalStakeHistoryLength(defaultQuorumNumber);
             if (historyLength != 0) {
                 newStakeUpdate = stakeRegistry.getTotalStakeUpdateAtIndex(defaultQuorumNumber, historyLength-1);


### PR DESCRIPTION
…nt to match

This naming has been bugging me, since `OperatorStakeUpdate` is used for both operator and total stake updates, and the corresponding event (`StakeUpdate`) should only apply to operator stake updates.