### PR TITLE
test: refactor StakeRegistryUnit tests to use new testing guidelines

### DIFF
--- a/docs/StakeRegistry.md
+++ b/docs/StakeRegistry.md
@@ -6,33 +6,48 @@
 
 <!-- This contract is deployed for every AVS and keeps track of the AVS's operators' stakes over time and the total stakes for each quorum. In addition, this contract also handles the adding and modification of quorum. -->
 
-The StakeRegistry manages
+TODO
+
+The StakeRegistry manages the historical stake of operators for each quorum.
 
 <!-- ## Upstream Dependencies
 
 The main integration with the StakeRegistry is used by the AVSs [BLSSignatureChecker](./BLSSignatureChecker.md). An offchain actor provides an operator id, a quorum id, and an index in the array of the operator's stake updates to verify the stake of an operator at a particular block number. They also provide a quorum id and an index in the array of total stake updates to verify the stake of the entire quorum at a particular block number. -->
 
-(TODO) high-level description
-
 #### High-level Concepts
 
 This document organizes methods according to the following themes (click each to be taken to the relevant section):
 * [`Operator Lifecycle`](#operator-lifecycle)
-* [`Quorums and Configuration`]()
+* [`Quorums and Configuration`](#quorums-and-configuration)
 
 #### Important State Variables
 
-* `StateVar`: description
+* `uint96[256] public minimumStakeForQuorum`: TODO
+* `StakeUpdate[][256] internal _totalStakeHistory`: TODO
+* `mapping(bytes32 => mapping(uint8 => StakeUpdate[])) internal operatorStakeHistory`: TODO
 
 #### Helpful Definitions
 
-<!-- A **quorum** is defined by list of the following structs:
+TODO
+
+```solidity
+struct StakeUpdate {
+    // the block number at which the stake amounts were updated and stored
+    uint32 updateBlockNumber;
+    // the block number at which the *next update* occurred.
+    /// @notice This entry has the value **0** until another update takes place.
+    uint32 nextUpdateBlockNumber;
+    // stake weight for the quorum
+    uint96 stake;
+}
 ```
-struct StrategyAndWeightingMultiplier {
+
+```solidity
+struct StrategyParams {
     IStrategy strategy;
     uint96 multiplier;
 }
-``` -->
+```
 
 ---
 

--- a/docs/StakeRegistry.md
+++ b/docs/StakeRegistry.md
@@ -1,30 +1,64 @@
-# StakeRegistry
+## StakeRegistry
 
-This contract is deployed for every AVS and keeps track of the AVS's operators' stakes over time and the total stakes for each quorum. In addition, this contract also handles the adding and modification of quorum.
+| File | Type | Proxy? |
+| -------- | -------- | -------- |
+| [`StakeRegistry.sol`](../src/StakeRegistry.sol) | Singleton | Transparent proxy |
 
-# Definitions
+<!-- This contract is deployed for every AVS and keeps track of the AVS's operators' stakes over time and the total stakes for each quorum. In addition, this contract also handles the adding and modification of quorum. -->
 
-A **quorum** is defined by list of the following structs:
+The StakeRegistry manages
+
+<!-- ## Upstream Dependencies
+
+The main integration with the StakeRegistry is used by the AVSs [BLSSignatureChecker](./BLSSignatureChecker.md). An offchain actor provides an operator id, a quorum id, and an index in the array of the operator's stake updates to verify the stake of an operator at a particular block number. They also provide a quorum id and an index in the array of total stake updates to verify the stake of the entire quorum at a particular block number. -->
+
+(TODO) high-level description
+
+#### High-level Concepts
+
+This document organizes methods according to the following themes (click each to be taken to the relevant section):
+* [`Operator Lifecycle`](#operator-lifecycle)
+* [`Quorums and Configuration`]()
+
+#### Important State Variables
+
+* `StateVar`: description
+
+#### Helpful Definitions
+
+<!-- A **quorum** is defined by list of the following structs:
 ```
 struct StrategyAndWeightingMultiplier {
     IStrategy strategy;
     uint96 multiplier;
 }
+``` -->
+
+---
+
+### Operator Lifecycle
+
+(TODO) Brief description, here are the functions:
+
+* [`StakeRegistry.registerOperator`](#registeroperator)
+* [`StakeRegistry.deregisterOperator`](#deregisteroperator)
+* [`StakeRegistry.updateOperatorStake`](#updateoperatorstake)
+
+#### `registerOperator`
+
+```solidity
+function registerOperator(
+    address operator,
+    bytes32 operatorId,
+    bytes calldata quorumNumbers
+) 
+    public 
+    virtual 
+    onlyRegistryCoordinator 
+    returns (uint96[] memory, uint96[] memory)
 ```
 
-## Flows
-
-### createQuorum
-
-The owner of the StakeRegistry can create a quorum by providing the list of `StrategyAndWeightingMultiplier`s. Quorums cannot be removed.
-
-### modifyQuorum
-
-The owner of the StakeRegistry can modify the set of strategies and they multipliers for a certain quorum.
-
-### registerOperator
-
-The RegistryCoordinator for the AVS makes a call to the StakeRegistry to register an operator for a certain set of quorums. For each of the quorums being registered for, the StakeRegistry calculates a linear combination of the operator's delegated shares of each `strategy` in the quorum and their corresponding `multiplier` to get a `stake`. The contract then stores the stake in the following struct:
+<!-- The RegistryCoordinator for the AVS makes a call to the StakeRegistry to register an operator for a certain set of quorums. For each of the quorums being registered for, the StakeRegistry calculates a linear combination of the operator's delegated shares of each `strategy` in the quorum and their corresponding `multiplier` to get a `stake`. The contract then stores the stake in the following struct:
 ```
 /// @notice struct used to store the stakes of an individual operator or the sum of all operators' stakes, for storage
 struct OperatorStakeUpdate {
@@ -37,20 +71,181 @@ struct OperatorStakeUpdate {
     uint96 stake;
 }
 ```
-For each quorum the operator is a part of.
+For each quorum the operator is a part of. -->
 
-### deregisterOperator
+(TODO) description
 
-The RegistryCoordinator for the AVS calls the StakeRegistry to deregister an operator for a certain set of quorums. For each of the quorums being registered for, the StakeRegistry ends the block range of the current `OperatorStakeUpdate` for the operator for the quorum.
+*Entry Points*:
+* `BLSRegistryCoordinatorWithIndices.registerOperator`
+* `BLSRegistryCoordinatorWithIndices.registerOperatorWithChurn`
 
-Note that the contract does not check that the quorums that the operator is being deregistered from are a subset of the quorums the operator is registered for, that logic is expected to be done in the RegistryCoordinator.
+*Effects*:
+* 
 
-### updateStakes
+*Requirements*:
+* 
 
-An offchain actor can provide a list of operator ids, their corresponding addresses, and a few other witnesses in order to recalculate the stakes of the provided operators for all of the quorums each operator is registered for. This ends block range of the current `OperatorStakeUpdate`s for each of the quorums for each of the provided operators and pushes a new update for each of them.
+#### `deregisterOperator`
 
-This has more implications after slashing is enabled... TODO
+```solidity
+function deregisterOperator(
+    bytes32 operatorId,
+    bytes calldata quorumNumbers
+) 
+    public 
+    virtual 
+    onlyRegistryCoordinator
+```
 
-## Upstream Dependencies
+<!-- The RegistryCoordinator for the AVS calls the StakeRegistry to deregister an operator for a certain set of quorums. For each of the quorums being registered for, the StakeRegistry ends the block range of the current `OperatorStakeUpdate` for the operator for the quorum.
 
-The main integration with the StakeRegistry is used by the AVSs [BLSSignatureChecker](./BLSSignatureChecker.md). An offchain actor provides an operator id, a quorum id, and an index in the array of the operator's stake updates to verify the stake of an operator at a particular block number. They also provide a quorum id and an index in the array of total stake updates to verify the stake of the entire quorum at a particular block number.
+Note that the contract does not check that the quorums that the operator is being deregistered from are a subset of the quorums the operator is registered for, that logic is expected to be done in the RegistryCoordinator. -->
+
+(TODO) description
+
+*Entry Points*:
+* `BLSRegistryCoordinatorWithIndices.registerOperatorWithChurn`
+* `BLSRegistryCoordinatorWithIndices.updateOperators`
+* `BLSRegistryCoordinatorWithIndices.deregisterOperator`
+* `BLSRegistryCoordinatorWithIndices.ejectOperator`
+
+*Effects*:
+* 
+
+*Requirements*:
+* 
+
+#### `updateOperatorStake`
+
+```solidity
+function updateOperatorStake(
+    address operator, 
+    bytes32 operatorId, 
+    bytes calldata quorumNumbers
+) 
+    external 
+    onlyRegistryCoordinator 
+    returns (uint192)
+```
+
+<!-- An offchain actor can provide a list of operator ids, their corresponding addresses, and a few other witnesses in order to recalculate the stakes of the provided operators for all of the quorums each operator is registered for. This ends block range of the current `OperatorStakeUpdate`s for each of the quorums for each of the provided operators and pushes a new update for each of them.
+
+This has more implications after slashing is enabled... TODO -->
+
+(TODO) description
+
+*Entry Points*:
+* `BLSRegistryCoordinatorWithIndices.updateOperators`
+
+*Effects*:
+* 
+
+*Requirements*:
+* 
+
+---
+
+### Quorums and Configuration
+
+(TODO) Brief description, here are the functions:
+
+* [`StakeRegistry.initializeQuorum`](#TODO)
+* [`StakeRegistry.setMinimumStakeForQuorum`](#TODO)
+* [`StakeRegistry.addStrategies`](#TODO)
+* [`StakeRegistry.removeStrategies`](#TODO)
+* [`StakeRegistry.modifyStrategyParams`](#TODO)
+
+#### `initializeQuorum`
+
+```solidity
+TODO
+```
+
+<!-- ### createQuorum
+
+The owner of the StakeRegistry can create a quorum by providing the list of `StrategyAndWeightingMultiplier`s. Quorums cannot be removed. -->
+
+(TODO) description
+
+*Entry Points*:
+* `ContractName.functionName`
+
+*Effects*:
+* 
+
+*Requirements*:
+* 
+
+#### `setMinimumStakeForQuorum`
+
+```solidity
+TODO
+```
+
+(TODO) description
+
+*Entry Points*:
+* `ContractName.functionName`
+
+*Effects*:
+* 
+
+*Requirements*:
+* 
+
+#### `addStrategies`
+
+```solidity
+TODO
+```
+
+(TODO) description
+
+*Entry Points*:
+* `ContractName.functionName`
+
+*Effects*:
+* 
+
+*Requirements*:
+* 
+
+#### `removeStrategies`
+
+```solidity
+TODO
+```
+
+(TODO) description
+
+*Entry Points*:
+* `ContractName.functionName`
+
+*Effects*:
+* 
+
+*Requirements*:
+* 
+
+#### `modifyStrategyParams`
+
+```solidity
+TODO
+```
+
+<!-- ### modifyQuorum
+
+The owner of the StakeRegistry can modify the set of strategies and they multipliers for a certain quorum. -->
+
+(TODO) description
+
+*Entry Points*:
+* `ContractName.functionName`
+
+*Effects*:
+* 
+
+*Requirements*:
+* 
+
+---

--- a/src/BLSSignatureChecker.sol
+++ b/src/BLSSignatureChecker.sol
@@ -138,7 +138,7 @@ contract BLSSignatureChecker is IBLSSignatureChecker {
                     // keep track of the nonSigners index in the quorum
                     uint32 nonSignerForQuorumIndex = 0;
                     // if the nonSigner is a part of the quorum, subtract their stake from the running total
-                    if (BitmapUtils.numberIsInBitmap(nonSignerQuorumBitmaps[i], quorumNumber)) {
+                    if (BitmapUtils.isSet(nonSignerQuorumBitmaps[i], quorumNumber)) {
                         quorumStakeTotals.signedStakeForQuorum[quorumNumberIndex] -=
                             stakeRegistry.getStakeAtBlockNumberAndIndex(
                                 quorumNumber,

--- a/src/StakeRegistry.sol
+++ b/src/StakeRegistry.sol
@@ -19,6 +19,8 @@ import "src/StakeRegistryStorage.sol";
  * @author Layr Labs, Inc.
  */
 contract StakeRegistry is StakeRegistryStorage {
+
+    using BitmapUtils for *;
     
     modifier onlyRegistryCoordinator() {
         require(
@@ -136,9 +138,8 @@ contract StakeRegistry is StakeRegistryStorage {
     /**
      * @notice Called by the registry coordinator to update an operator's stake for one
      * or more quorums.
-     *
      * If the operator no longer has the minimum stake required for a quorum, they are
-     * added to the
+     * added to `quorumsToRemove`, which is returned to the registry coordinator
      * @return A bitmap of quorums where the operator no longer meets the minimum stake
      * and should be deregistered.
      */
@@ -168,7 +169,7 @@ contract StakeRegistry is StakeRegistryStorage {
             // If the operator no longer meets the minimum stake, set their stake to zero and mark them for removal
             if (!hasMinimumStake) {
                 stakeWeight = 0;
-                quorumsToRemove |= quorumNumber;
+                quorumsToRemove = uint192(quorumsToRemove.setBit(quorumNumber));
             }
 
             // Update the operator's stake and retrieve the delta

--- a/src/libraries/BitmapUtils.sol
+++ b/src/libraries/BitmapUtils.sol
@@ -295,9 +295,19 @@ library BitmapUtils {
         return count;
     }
 
-    /// @notice returns 'true' if `numberToCheckForInclusion` is in `bitmap` and 'false' otherwise.
-    function numberIsInBitmap(uint256 bitmap, uint8 numberToCheckForInclusion) internal pure returns (bool) {
-        return (((bitmap >> numberToCheckForInclusion) & 1) == 1);
+    /// @notice Returns `true` if `bit` is in `bitmap`. Returns `false` otherwise.
+    function isSet(uint256 bitmap, uint8 bit) internal pure returns (bool) {
+        return 1 == ((bitmap >> bit) & 1);
+    }
+
+    /**
+     * @notice Returns a copy of `bitmap` with `bit` set. 
+     * @dev IMPORTANT: we're dealing with stack values here, so this doesn't modify
+     * the original bitmap. Using this correctly requires an assignment statement:
+     * `bitmap = bitmap.setBit(bit);`
+     */
+    function setBit(uint256 bitmap, uint8 bit) internal pure returns (uint256) {
+        return bitmap | (1 << bit);
     }
 
     /**

--- a/test/harnesses/BitmapUtilsWrapper.sol
+++ b/test/harnesses/BitmapUtilsWrapper.sol
@@ -33,7 +33,7 @@ contract BitmapUtilsWrapper {
         return BitmapUtils.countNumOnes(n);
     }
 
-    function numberIsInBitmap(uint256 bitmap, uint8 numberToCheckForInclusion) external pure returns (bool) {
-        return BitmapUtils.numberIsInBitmap(bitmap, numberToCheckForInclusion);
+    function isSet(uint256 bitmap, uint8 numberToCheckForInclusion) external pure returns (bool) {
+        return BitmapUtils.isSet(bitmap, numberToCheckForInclusion);
     }
 }

--- a/test/harnesses/StakeRegistryHarness.sol
+++ b/test/harnesses/StakeRegistryHarness.sol
@@ -40,36 +40,11 @@ contract StakeRegistryHarness is StakeRegistry {
         __weightOfOperatorForQuorum[quorumNumber][operator] = weight;
     }
 
-    // mocked function to register an operator without having to mock other elements
-    // This is just a copy/paste from `registerOperator`, since that no longer uses an internal method
-    function registerOperatorNonCoordinator(address operator, bytes32 operatorId, bytes calldata quorumNumbers) external returns (uint96[] memory, uint96[] memory) {
-        uint96[] memory currentStakes = new uint96[](quorumNumbers.length);
-        uint96[] memory totalStakes = new uint96[](quorumNumbers.length);
-        for (uint256 i = 0; i < quorumNumbers.length; i++) {            
-            
-            uint8 quorumNumber = uint8(quorumNumbers[i]);
-            require(_quorumExists(quorumNumber), "StakeRegistry.registerOperator: quorum does not exist");
+    function calculateDelta(uint96 prev, uint96 cur) external pure returns (int256) {
+        return _calculateDelta(prev, cur);
+    }
 
-            // Retrieve the operator's current weighted stake for the quorum, reverting if they have not met
-            // the minimum.
-            (uint96 currentStake, bool hasMinimumStake) = _weightOfOperatorForQuorum(quorumNumber, operator);
-            require(
-                hasMinimumStake,
-                "StakeRegistry.registerOperator: Operator does not meet minimum stake requirement for quorum"
-            );
-
-            // Update the operator's stake
-            int256 stakeDelta = _recordOperatorStakeUpdate({
-                operatorId: operatorId, 
-                quorumNumber: quorumNumber,
-                newStake: currentStake
-            });
-
-            // Update this quorum's total stake by applying the operator's delta
-            currentStakes[i] = currentStake;
-            totalStakes[i] = _recordTotalStakeUpdate(quorumNumber, stakeDelta);
-        }
-
-        return (currentStakes, totalStakes);
+    function applyDelta(uint96 value, int256 delta) external pure returns (uint96) {
+        return _applyDelta(value, delta);
     }
 }

--- a/test/tree/StakeRegistryUnit.tree
+++ b/test/tree/StakeRegistryUnit.tree
@@ -42,7 +42,20 @@
 ### given the total stake history was updated in the current block
 #### it should update the last total stake update with the new stake
 # when updateOperatorStake is called
-## TODO
+## given caller is not the registry coordinator
+### it should revert
+## given quorum does not exist
+### it should revert
+## given the operator currently meets the minimum stake for the quorum
+### given they still do after updating
+#### it should update their history and apply the change to the total history
+### given they no longer meet the minimum
+#### it should set their stake to zero, remove it from the total stake, and add the quorum to the return bitmap
+## given the operator does not currently meet the minimum stake for the quorum
+### given they still do not meet the minimum
+#### it should not perform any updates, and it should add the quorum to the return bitmap
+### given they meet the minimum after the update
+#### it should update the operator and total history with the stake
 # when setMinimumStakeForQuorum is called ***
 ## TODO
 # when addStrategies is called ***

--- a/test/tree/StakeRegistryUnit.tree
+++ b/test/tree/StakeRegistryUnit.tree
@@ -1,35 +1,53 @@
 .
-├── .
-├── StakeRegistry tree (*** denotes that integration tests are needed to validate path)
-├── when initializeQuorum is called
-│   └── TODO
-├── when registerOperator is called
-│   ├── given caller is not the registry coordinator
-│   │   └── it should revert
-│   ├── given quorum does not exist
-│   │   └── it should revert
-│   ├── given the operator does not meet the minimum stake for a quorum
-│   │   └── it should revert
-│   └── given that the above conditions are satisfied
-│       ├── given the operator's stake is unchanged ***
-│       │   └── it should not update the operator's stake
-│       ├── given the operator does not have a stake update from the current block
-│       │   └── it should push a new stake update for the operator
-│       ├── given the operator does have a stake update for the current block ***
-│       │   └── it should update the operator's last stake update with the new stake
-│       ├── given the total stake history was not updated in the current block
-│       │   └── it should push a new stake update for the total stake
-│       └── given the total stake history was updated in the current block
-│           └── it should update the last total stake update with the new stake
-├── when deregisterOperator is called
-│   └── TODO
-├── when updateOperatorStake is called
-│   └── TODO
-├── when setMinimumStakeForQuorum is called ***
-│   └── TODO
-├── when addStrategies is called ***
-│   └── TODO
-├── when removeStrategies is called ***
-│   └── TODO
-└── when modifyStrategyParams is called ***
-    └── TODO
+# .
+# .
+# StakeRegistry tree (*** denotes that integration tests are needed to validate path)
+# when any function is called (invariants)
+## when parameters contain uninitialized quorumNumbers
+### it should revert
+# when initializeQuorum is called
+## TODO
+# when registerOperator is called
+## given caller is not the registry coordinator
+### it should revert
+## given quorum does not exist
+### it should revert
+## given the operator does not meet the minimum stake for a quorum
+### it should revert
+## given that the above conditions are satisfied
+### given the operator's stake is unchanged ***
+#### it should not update the operator's stake
+### given the operator does not have a stake update from the current block
+#### it should push a new stake update for the operator
+### given the operator does have a stake update for the current block ***
+#### it should update the operator's last stake update with the new stake
+### given the total stake history was not updated in the current block
+#### it should push a new stake update for the total stake
+### given the total stake history was updated in the current block
+#### it should update the last total stake update with the new stake
+# when deregisterOperator is called
+## given caller is not the registry coordinator
+### it should revert
+## given quorum does not exist
+### it should revert
+## given that the above conditions are satisfied
+### given the operator's stake history is empty
+#### it should push a single entry with 0 stake
+### given the operator's current stake is 0 and their history is nonempty
+#### it should not update the operator's stake history or total history
+### given the operator's current stake is nonzero
+#### it should update or push an entry with zero stake to the operator's stake history
+### given the total stake history was not updated in the current block
+#### it should push a new stake update for the total stake
+### given the total stake history was updated in the current block
+#### it should update the last total stake update with the new stake
+# when updateOperatorStake is called
+## TODO
+# when setMinimumStakeForQuorum is called ***
+## TODO
+# when addStrategies is called ***
+## TODO
+# when removeStrategies is called ***
+## TODO
+# when modifyStrategyParams is called ***
+## TODO

--- a/test/tree/StakeRegistryUnit.tree
+++ b/test/tree/StakeRegistryUnit.tree
@@ -1,0 +1,35 @@
+.
+├── .
+├── StakeRegistry tree (*** denotes that integration tests are needed to validate path)
+├── when initializeQuorum is called
+│   └── TODO
+├── when registerOperator is called
+│   ├── given caller is not the registry coordinator
+│   │   └── it should revert
+│   ├── given quorum does not exist
+│   │   └── it should revert
+│   ├── given the operator does not meet the minimum stake for a quorum
+│   │   └── it should revert
+│   └── given that the above conditions are satisfied
+│       ├── given the operator's stake is unchanged ***
+│       │   └── it should not update the operator's stake
+│       ├── given the operator does not have a stake update from the current block
+│       │   └── it should push a new stake update for the operator
+│       ├── given the operator does have a stake update for the current block ***
+│       │   └── it should update the operator's last stake update with the new stake
+│       ├── given the total stake history was not updated in the current block
+│       │   └── it should push a new stake update for the total stake
+│       └── given the total stake history was updated in the current block
+│           └── it should update the last total stake update with the new stake
+├── when deregisterOperator is called
+│   └── TODO
+├── when updateOperatorStake is called
+│   └── TODO
+├── when setMinimumStakeForQuorum is called ***
+│   └── TODO
+├── when addStrategies is called ***
+│   └── TODO
+├── when removeStrategies is called ***
+│   └── TODO
+└── when modifyStrategyParams is called ***
+    └── TODO

--- a/test/unit/BitmapUtils.t.sol
+++ b/test/unit/BitmapUtils.t.sol
@@ -166,15 +166,15 @@ contract BitmapUtilsUnitTests is Test {
         require(libraryOutput == numOnes, "inconsistency in countNumOnes function");
     }
 
-    // @notice some simple sanity checks on the `numberIsInBitmap` function
+    // @notice some simple sanity checks on the `isSet` function
     function testNumberIsInBitmap() public view {
-        require(bitmapUtilsWrapper.numberIsInBitmap(2 ** 6, 6), "numberIsInBitmap function is broken 0");
-        require(bitmapUtilsWrapper.numberIsInBitmap(1, 0), "numberIsInBitmap function is broken 1");
-        require(bitmapUtilsWrapper.numberIsInBitmap(255, 7), "numberIsInBitmap function is broken 2");
-        require(bitmapUtilsWrapper.numberIsInBitmap(1024, 10), "numberIsInBitmap function is broken 3");
+        require(bitmapUtilsWrapper.isSet(2 ** 6, 6), "isSet function is broken 0");
+        require(bitmapUtilsWrapper.isSet(1, 0), "isSet function is broken 1");
+        require(bitmapUtilsWrapper.isSet(255, 7), "isSet function is broken 2");
+        require(bitmapUtilsWrapper.isSet(1024, 10), "isSet function is broken 3");
         for (uint256 i = 0; i < 256; ++i) {
-            require(bitmapUtilsWrapper.numberIsInBitmap(type(uint256).max, uint8(i)), "numberIsInBitmap function is broken 4");
-            require(!bitmapUtilsWrapper.numberIsInBitmap(0, uint8(i)), "numberIsInBitmap function is broken 5");
+            require(bitmapUtilsWrapper.isSet(type(uint256).max, uint8(i)), "isSet function is broken 4");
+            require(!bitmapUtilsWrapper.isSet(0, uint8(i)), "isSet function is broken 5");
         }
     }
 }


### PR DESCRIPTION
- contains a fix for `StakeRegistry.updateOperatorStake` not setting bits correctly
- begins process of updating/fixing docs
- starts adding "tree" files to test folder