### PR TITLE
refactor: remove quorumsAllExist modifier in favor of helper

### DIFF
--- a/src/BLSRegistryCoordinatorWithIndices.sol
+++ b/src/BLSRegistryCoordinatorWithIndices.sol
@@ -100,16 +100,6 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
         _;
     }
 
-    modifier quorumsAllExist(bytes calldata quorumNumbers) {
-        uint256 quorumNumbersBitmap = BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers);
-        uint256 initializedQuorumBitmap = 1 << quorumCount - 2;
-        require(
-            quorumNumbersBitmap.isSubsetOf(initializedQuorumBitmap),
-            "BLSRegistryCoordinatorWithIndices.quorumsAllExist: one or more quorums do not exist"
-        );
-        _;
-    }
-
     constructor(
         ISlasher _slasher,
         IServiceManager _serviceManager,
@@ -286,6 +276,7 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
 
             uint192 currentBitmap = _currentOperatorBitmap(operatorId);
             bytes memory currentQuorums = BitmapUtils.bitmapToBytesArray(currentBitmap);
+            require(_quorumsAllExist(currentBitmap), "BLSRegistryCoordinatorWithIndices.updateOperators: some quorums do not exist");
 
             /**
              * Update the operator's stake for their active quorums. The stakeRegistry returns a bitmap
@@ -315,11 +306,15 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
     function updateOperatorsForQuorum(
         address[][] calldata operatorsPerQuorum,
         bytes calldata quorumNumbers
-    ) external onlyWhenNotPaused(PAUSED_UPDATE_OPERATOR) quorumsAllExist(quorumNumbers) {
+    ) external onlyWhenNotPaused(PAUSED_UPDATE_OPERATOR) {
         require(
             operatorsPerQuorum.length == quorumNumbers.length,
             "BLSRegistryCoordinatorWithIndices.updateOperatorsForQuorum: input length mismatch"
         );
+
+        uint192 quorumBitmap = uint192(BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers));
+        require(_quorumsAllExist(quorumBitmap), "BLSRegistryCoordinatorWithIndices.updateOperatorsForQuorum: some quorums do not exist");
+
         _updateOperatorsForQuorum(operatorsPerQuorum, quorumNumbers);
     }
 
@@ -426,6 +421,7 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
         uint192 quorumsToAdd = uint192(BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers, quorumCount));
         uint192 currentBitmap = _currentOperatorBitmap(operatorId);
         require(!quorumsToAdd.isEmpty(), "BLSRegistryCoordinatorWithIndices._registerOperator: bitmap cannot be 0");
+        require(_quorumsAllExist(quorumsToAdd), "BLSRegistryCoordinatorWithIndices._registerOperator: some quorums do not exist");
         require(quorumsToAdd.noBitsInCommon(currentBitmap), "BLSRegistryCoordinatorWithIndices._registerOperator: operator already registered for some quorums being registered for");
         uint192 newBitmap = uint192(currentBitmap.plus(quorumsToAdd));
 
@@ -513,6 +509,7 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
         uint192 quorumsToRemove = uint192(BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers, quorumCount));
         uint192 currentBitmap = _currentOperatorBitmap(operatorId);
         require(!quorumsToRemove.isEmpty(), "BLSRegistryCoordinatorWithIndices._deregisterOperator: bitmap cannot be 0");
+        require(_quorumsAllExist(quorumsToRemove), "BLSRegistryCoordinatorWithIndices._deregisterOperator: some quorums do not exist");
         require(quorumsToRemove.isSubsetOf(currentBitmap), "BLSRegistryCoordinatorWithIndices._deregisterOperator: operator is not registered for specified quorums");
         uint192 newBitmap = uint192(currentBitmap.minus(quorumsToRemove));
 
@@ -696,6 +693,14 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
                 }));
             }
         }
+    }
+
+    /**
+     * @notice Returns true iff all of the bits in `quorumBitmap` belong to initialized quorums
+     */
+     function _quorumsAllExist(uint192 quorumBitmap) internal view returns (bool) {
+        uint192 initializedQuorumBitmap = uint192(1 << quorumCount - 2);
+        return quorumBitmap.isSubsetOf(initializedQuorumBitmap);
     }
 
     /// @notice Get the most recent bitmap for the operator, returning an empty bitmap if


### PR DESCRIPTION
Also makes use of the helper in the contract's other methods