### PR TITLE
update nonSignerForQuorumIndex outside of loop

### DIFF
--- a/src/BLSSignatureChecker.sol
+++ b/src/BLSSignatureChecker.sol
@@ -132,11 +132,13 @@ contract BLSSignatureChecker is IBLSSignatureChecker {
                     stakeRegistry.getTotalStakeAtBlockNumberFromIndex(quorumNumber, referenceBlockNumber, nonSignerStakesAndSignature.totalStakeIndices[quorumNumberIndex]);
                 // copy total stake to signed stake
                 quorumStakeTotals.signedStakeForQuorum[quorumNumberIndex] = quorumStakeTotals.totalStakeForQuorum[quorumNumberIndex];
+                
+                // keep track of the nonSigners index in the quorum
+                uint32 nonSignerForQuorumIndex = 0;
+                
                 // loop through all nonSigners, checking that they are a part of the quorum via their quorumBitmap
                 // if so, load their stake at referenceBlockNumber and subtract it from running stake signed
                 for (uint32 i = 0; i < nonSignerStakesAndSignature.nonSignerPubkeys.length; i++) {
-                    // keep track of the nonSigners index in the quorum
-                    uint32 nonSignerForQuorumIndex = 0;
                     // if the nonSigner is a part of the quorum, subtract their stake from the running total
                     if (BitmapUtils.numberIsInBitmap(nonSignerQuorumBitmaps[i], quorumNumber)) {
                         quorumStakeTotals.signedStakeForQuorum[quorumNumberIndex] -=


### PR DESCRIPTION
fixes a bug where the first nonSignerStakeIndex is used for all non signers