### PR TITLE
Update README.md to avoid confusing phrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There are two things that matter in terms of operators’ onchain interaction wi
 - What qualities of operators need to be kept track of onchain? (e.g. stake, BLS pubkeys, etc.)
 - Registration/Deregistration conditions
 
-These two points have been addressed through the Registry Coordinator/Registry Architecture.
+These two points have been addressed through the architecture of Registry Coordinator and Registry.
 
 ### Definitions
 


### PR DESCRIPTION
I initially didn't understand "Registry Coordinator/Registry Architecture" in the doc as this phrasing appears to be symmetric of "Registry Coordinator" + "Registry Architecture"

after reading the doc, i realized it's actually "Architecture of Registry Coordinator and Registry"

so making a change to avoid confusing others