### PR TITLE
Build: Set lib/eigenlayer-contracts submodule to m2-mainnet branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,7 @@
 [submodule "lib/eigenlayer-contracts"]
 	path = lib/eigenlayer-contracts
 	url = https://github.com/Layr-labs/eigenlayer-contracts
+	branch = m2-mainnet
 [submodule "lib/ds-test"]
 	path = lib/ds-test
 	url = https://github.com/dapphub/ds-test


### PR DESCRIPTION
Updating commit from `bccae53` to `b91a743`
Latest m2-mainnet commits can be viewed here https://github.com/Layr-Labs/eigenlayer-contracts/commits/m2-mainnet