### PR TITLE
feat: more general interface for querying operator weights

### DIFF
--- a/src/StakeRegistry.sol
+++ b/src/StakeRegistry.sol
@@ -495,14 +495,14 @@ contract StakeRegistry is StakeRegistryStorage {
     *******************************************************************************/
 
     /**
-     * @notice This function computes the total weight of the @param operator in the quorum @param quorumNumber.
+     * @notice This function computes the total weight of the @param operator in the quorum @param quorumId.
      * @dev reverts if the quorum does not exist
      */
-    function weightOfOperatorForQuorum(
-        uint8 quorumNumber, 
-        address operator
-    ) public virtual view quorumExists(quorumNumber) returns (uint96) {
-        (uint96 stake, ) = _weightOfOperatorForQuorum(quorumNumber, operator);
+    function weightOfOperator(
+        address operator,
+        bytes32 quorumId
+    ) public virtual view quorumExists(uint8(uint256(quorumId))) returns (uint256) {
+        (uint96 stake, ) = _weightOfOperatorForQuorum(uint8(uint256(quorumId)), operator);
         return stake;
     }
 

--- a/src/interfaces/IStakeRegistry.sol
+++ b/src/interfaces/IStakeRegistry.sol
@@ -140,11 +140,8 @@ interface IStakeRegistry is IRegistry {
         uint256 index
     ) external view returns (StrategyParams memory);
 
-    /**
-     * @notice This function computes the total weight of the @param operator in the quorum @param quorumNumber.
-     * @dev reverts in the case that `quorumNumber` is greater than or equal to `quorumCount`
-     */
-    function weightOfOperatorForQuorum(uint8 quorumNumber, address operator) external view returns (uint96);
+    // @notice This function computes the weight of the @param operator in the quorum @param quorumId.
+    function weightOfOperator(address operator, bytes32 quorumId) external view returns (uint256);
 
     /**
      * @notice Returns the entire `operatorIdToStakeHistory[operatorId][quorumNumber]` array.

--- a/test/harnesses/StakeRegistryHarness.sol
+++ b/test/harnesses/StakeRegistryHarness.sol
@@ -23,8 +23,8 @@ contract StakeRegistryHarness is StakeRegistry {
     }
 
     // mocked function so we can set this arbitrarily without having to mock other elements
-    function weightOfOperatorForQuorum(uint8 quorumNumber, address operator) public override view returns(uint96) {
-        return __weightOfOperatorForQuorum[quorumNumber][operator];
+    function weightOfOperator(address operator, bytes32 quorumId) public override view returns (uint256) {
+        return __weightOfOperatorForQuorum[uint8(uint256(quorumId))][operator];
     }
 
     function _weightOfOperatorForQuorum(uint8 quorumNumber, address operator) internal override view returns(uint96, bool) {

--- a/test/mocks/StakeRegistryMock.sol
+++ b/test/mocks/StakeRegistryMock.sol
@@ -95,9 +95,9 @@ contract StakeRegistryMock is IStakeRegistry {
 
     /**
      * @notice This function computes the total weight of the @param operator in the quorum @param quorumNumber.
-     * @dev reverts in the case that `quorumNumber` is greater than or equal to `quorumCount`
+     * @dev reverts in the case that `quorumId` is greater than or equal to `quorumCount`
      */
-    function weightOfOperatorForQuorum(uint8 quorumNumber, address operator) external view returns (uint96) {}
+    function weightOfOperator(address operator, bytes32 quorumId) external view returns (uint256) {}
 
     /**
      * @notice Returns the entire `operatorIdToStakeHistory[operatorId][quorumNumber]` array.


### PR DESCRIPTION
We'd like to have more flexible, forward-looking interfaces. Constraining the sizes of input/return variables _in the interface itself_ doesn't seem to be serving any practical purpose here, so this commit relaxes the requirement.

Basically no cost / slightly more flexibility :+1: