### PR TITLE
Feat: Add AVS/Operator Registration Support in RegistryCoordinator

### DIFF
--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -419,7 +419,7 @@ contract RegistryCoordinator is
      * @param _metadataURI is the metadata URI for the AVS
      * @dev only callable by the service manager owner
      */
-    function setMetadataURI(string memory _metadataURI) external onlyServiceManagerOwner {
+    function setMetadataURI(string memory _metadataURI) external onlyOwner {
         delegationManager.updateAVSMetadataURI(_metadataURI);
     }
 

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -559,7 +559,7 @@ contract RegistryCoordinator is
         // If the operator is no longer registered for any quorums, update their status and deregister from delegationManager
         if (newBitmap.isEmpty()) {
             operatorInfo.status = OperatorStatus.DEREGISTERED;
-            // delegationManager.deregisterOperatorFromAVS(operator);
+            delegationManager.deregisterOperatorFromAVS(operator);
             emit OperatorDeregistered(operator, operatorId);
         }
 

--- a/src/interfaces/IIndexRegistry.sol
+++ b/src/interfaces/IIndexRegistry.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity =0.8.12;
 
-// import {IRegistry} from "./IRegistry.sol";
+import {IRegistry} from "./IRegistry.sol";
 
 /**
  * @title Interface for a `Registry`-type contract that keeps track of an ordered list of operators for up to 256 quorums.
  * @author Layr Labs, Inc.
  */
-interface IIndexRegistry {
+interface IIndexRegistry is IIndexRegistry {
     // EVENTS
     
     // emitted when an operator's index in the orderd operator list for the quorum with number `quorumNumber` is updated

--- a/src/interfaces/IIndexRegistry.sol
+++ b/src/interfaces/IIndexRegistry.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity =0.8.12;
 
-import {IRegistry} from "./IRegistry.sol";
+// import {IRegistry} from "./IRegistry.sol";
 
 /**
  * @title Interface for a `Registry`-type contract that keeps track of an ordered list of operators for up to 256 quorums.
  * @author Layr Labs, Inc.
  */
-interface IIndexRegistry is IRegistry {
+interface IIndexRegistry {
     // EVENTS
     
     // emitted when an operator's index in the orderd operator list for the quorum with number `quorumNumber` is updated

--- a/src/interfaces/IIndexRegistry.sol
+++ b/src/interfaces/IIndexRegistry.sol
@@ -7,7 +7,7 @@ import {IRegistry} from "./IRegistry.sol";
  * @title Interface for a `Registry`-type contract that keeps track of an ordered list of operators for up to 256 quorums.
  * @author Layr Labs, Inc.
  */
-interface IIndexRegistry is IIndexRegistry {
+interface IIndexRegistry is IRegistry {
     // EVENTS
     
     // emitted when an operator's index in the orderd operator list for the quorum with number `quorumNumber` is updated

--- a/src/interfaces/IRegistryCoordinator.sol
+++ b/src/interfaces/IRegistryCoordinator.sol
@@ -26,7 +26,7 @@ interface IRegistryCoordinator {
 
     /// @notice emitted when all the operators for a quorum are updated at once
     event QuorumBlockNumberUpdated(uint8 indexed quorumNumber, uint256 blocknumber);
-    
+
     // DATA STRUCTURES
     enum OperatorStatus
     {

--- a/src/interfaces/IStakeRegistry.sol
+++ b/src/interfaces/IStakeRegistry.sol
@@ -10,7 +10,7 @@ import {IRegistry} from "./IRegistry.sol";
  * @title Interface for a `Registry` that keeps track of stakes of operators for up to 256 quorums.
  * @author Layr Labs, Inc.
  */
-interface IStakeRegistry is IRegistry {
+interface IStakeRegistry {
     
     // DATA STRUCTURES
 

--- a/src/interfaces/IStakeRegistry.sol
+++ b/src/interfaces/IStakeRegistry.sol
@@ -10,7 +10,7 @@ import {IRegistry} from "./IRegistry.sol";
  * @title Interface for a `Registry` that keeps track of stakes of operators for up to 256 quorums.
  * @author Layr Labs, Inc.
  */
-interface IStakeRegistry {
+interface IStakeRegistry is IRegistry {
     
     // DATA STRUCTURES
 

--- a/test/harnesses/RegistryCoordinatorHarness.sol
+++ b/test/harnesses/RegistryCoordinatorHarness.sol
@@ -6,11 +6,12 @@ import "src/RegistryCoordinator.sol";
 // wrapper around the RegistryCoordinator contract that exposes the internal functions for unit testing.
 contract RegistryCoordinatorHarness is RegistryCoordinator {
     constructor(
+        IDelegationManager _delegationManager,
         ISlasher _slasher,
         IStakeRegistry _stakeRegistry,
         IBLSApkRegistry _blsApkRegistry,
         IIndexRegistry _indexRegistry
-    ) RegistryCoordinator(_slasher, _stakeRegistry, _blsApkRegistry, _indexRegistry) {
+    ) RegistryCoordinator(_delegationManager, _slasher, _stakeRegistry, _blsApkRegistry, _indexRegistry) {
         _transferOwnership(msg.sender);
     }
 

--- a/test/integration/CoreRegistration.t.sol
+++ b/test/integration/CoreRegistration.t.sol
@@ -43,7 +43,6 @@ contract Test_CoreRegistration is MockAVSDeployer {
         registryCoordinatorImplementation = new RegistryCoordinatorHarness(
             delegationManager,
             slasher,
-            serviceManagerMock,
             stakeRegistry,
             blsApkRegistry,
             indexRegistry
@@ -129,14 +128,14 @@ contract Test_CoreRegistration is MockAVSDeployer {
         assertEq(uint8(operatorStatus), uint8(IDelegationManager.OperatorAVSRegistrationStatus.REGISTERED));
     }
 
-    function test_setMetadataURI_fail_notServiceManagerOwner(address invalidCaller) public {
+    function test_setMetadataURI_fail_notServiceManagerOwner() public {
         cheats.prank(operator);
-        cheats.expectRevert("RegistryCoordinator.onlyServiceManagerOwner: caller is not the service manager owner");
+        cheats.expectRevert("Ownable: caller is not the owner");
         registryCoordinator.setMetadataURI("Test MetadataURI");
     }
 
     function test_setMetadataURI() public {        
-        cheats.prank(serviceManagerOwner);
+        cheats.prank(registryCoordinatorOwner);
         registryCoordinator.setMetadataURI("Test MetadataURI");
     }
 
@@ -158,7 +157,7 @@ contract Test_CoreRegistration is MockAVSDeployer {
 
     function _getOperatorSignature(
         uint256 _operatorPrivateKey,
-        address operator,
+        address operatorToSign,
         address avs,
         bytes32 salt,
         uint256 expiry
@@ -166,7 +165,7 @@ contract Test_CoreRegistration is MockAVSDeployer {
         operatorSignature.salt = salt;
         operatorSignature.expiry = expiry;
         {
-            bytes32 digestHash = delegationManager.calculateOperatorAVSRegistrationDigestHash(operator, avs, salt, expiry);
+            bytes32 digestHash = delegationManager.calculateOperatorAVSRegistrationDigestHash(operatorToSign, avs, salt, expiry);
             (uint8 v, bytes32 r, bytes32 s) = cheats.sign(_operatorPrivateKey, digestHash);
             operatorSignature.signature = abi.encodePacked(r, s, v);
         }

--- a/test/integration/CoreRegistration.t.sol
+++ b/test/integration/CoreRegistration.t.sol
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "test/utils/MockAVSDeployer.sol";
+import { DelegationManager } from "eigenlayer-contracts/src/contracts/core/DelegationManager.sol";
+import { IDelegationManager } from "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
+
+contract Test_CoreRegistration is MockAVSDeployer {
+    // Contracts
+    DelegationManager public delegationManager;
+
+    // Operator info
+    uint256 operatorPrivateKey = 420;
+    address operator;
+    
+    // Dummy vals used across tests
+    bytes32 emptySalt;
+    uint256 maxExpiry = type(uint256).max;
+    string emptyStringForMetadataURI;
+
+    function setUp() public {
+        _deployMockEigenLayerAndAVS();
+
+        // Deploy New DelegationManager
+        DelegationManager delegationManagerImplementation = new DelegationManager(strategyManagerMock, slasher, eigenPodManagerMock);
+        delegationManager = DelegationManager(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(delegationManagerImplementation),
+                    address(proxyAdmin),
+                    abi.encodeWithSelector(
+                        DelegationManager.initialize.selector,
+                        address(this),
+                        pauserRegistry,
+                        0, // 0 is initialPausedStatus
+                        50400 // Initial withdrawal delay blocks
+                    )
+                )
+            )
+        );
+
+        // Deploy New RegistryCoordinator
+        registryCoordinatorImplementation = new RegistryCoordinatorHarness(
+            delegationManager,
+            slasher,
+            serviceManagerMock,
+            stakeRegistry,
+            blsApkRegistry,
+            indexRegistry
+        );
+
+        // Upgrade Registry Coordinator
+        cheats.prank(proxyAdminOwner);
+        proxyAdmin.upgrade(
+            TransparentUpgradeableProxy(payable(address(registryCoordinator))),
+            address(registryCoordinatorImplementation)
+        );
+
+        // Set operator address
+        operator = cheats.addr(operatorPrivateKey);
+        pubkeyCompendium.setBLSPublicKey(operator, defaultPubKey);
+
+        // Register operator to EigenLayer
+        cheats.prank(operator);
+        delegationManager.registerAsOperator(
+            IDelegationManager.OperatorDetails({
+                earningsReceiver: operator,
+                delegationApprover: address(0),
+                stakerOptOutWindowBlocks: 0
+            }),
+            emptyStringForMetadataURI
+        );
+
+        // Set operator weight in single quorum
+        bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(MAX_QUORUM_BITMAP);
+        for (uint i = 0; i < quorumNumbers.length; i++) {
+            stakeRegistry.setOperatorWeight(uint8(quorumNumbers[i]), operator, defaultStake);
+        }    
+    }
+
+    function test_registerOperator_coreStateChanges() public {
+        bytes memory quorumNumbers = new bytes(1);
+
+        // Get operator signature
+        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = _getOperatorSignature(
+            operatorPrivateKey,
+            operator,
+            address(registryCoordinator),
+            emptySalt,
+            maxExpiry
+        );
+
+        // Register operator
+        cheats.prank(operator);
+        registryCoordinator.registerOperator(quorumNumbers, defaultSocket, operatorSignature);
+
+        // Check operator is registered
+        IDelegationManager.OperatorAVSRegistrationStatus operatorStatus = delegationManager.avsOperatorStatus(address(registryCoordinator), operator);
+        assertEq(uint8(operatorStatus), uint8(IDelegationManager.OperatorAVSRegistrationStatus.REGISTERED));
+    }
+
+    function test_deregisterOperator_coreStateChanges() public {
+        // Register operator
+        bytes memory quorumNumbers = new bytes(1);
+        _registerOperator(quorumNumbers);
+
+        // Deregister Operator
+        cheats.prank(operator);
+        registryCoordinator.deregisterOperator(quorumNumbers);
+
+        // Check operator is deregistered
+        IDelegationManager.OperatorAVSRegistrationStatus operatorStatus = delegationManager.avsOperatorStatus(address(registryCoordinator), operator);
+        assertEq(uint8(operatorStatus), uint8(IDelegationManager.OperatorAVSRegistrationStatus.UNREGISTERED));
+    }
+
+    function test_deregisterOperator_notGloballyDeregistered() public {
+        // Register operator with all quorums
+        bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(MAX_QUORUM_BITMAP);
+        emit log_named_bytes("quorumNumbers", quorumNumbers);
+        _registerOperator(quorumNumbers);
+
+        // Deregister Operator with single quorum
+        quorumNumbers = new bytes(1);
+        cheats.prank(operator);
+        registryCoordinator.deregisterOperator(quorumNumbers);
+
+        // Check operator is still registered
+        IDelegationManager.OperatorAVSRegistrationStatus operatorStatus = delegationManager.avsOperatorStatus(address(registryCoordinator), operator);
+        assertEq(uint8(operatorStatus), uint8(IDelegationManager.OperatorAVSRegistrationStatus.REGISTERED));
+    }
+
+    function test_setMetadataURI_fail_notServiceManagerOwner(address invalidCaller) public {
+        cheats.prank(operator);
+        cheats.expectRevert("RegistryCoordinator.onlyServiceManagerOwner: caller is not the service manager owner");
+        registryCoordinator.setMetadataURI("Test MetadataURI");
+    }
+
+    function test_setMetadataURI() public {        
+        cheats.prank(serviceManagerOwner);
+        registryCoordinator.setMetadataURI("Test MetadataURI");
+    }
+
+    // Utils
+    function _registerOperator(bytes memory quorumNumbers) internal {
+        // Get operator signature
+        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = _getOperatorSignature(
+            operatorPrivateKey,
+            operator,
+            address(registryCoordinator),
+            emptySalt,
+            maxExpiry
+        );
+
+        // Register operator
+        cheats.prank(operator);
+        registryCoordinator.registerOperator(quorumNumbers, defaultSocket, operatorSignature);
+    }
+
+    function _getOperatorSignature(
+        uint256 _operatorPrivateKey,
+        address operator,
+        address avs,
+        bytes32 salt,
+        uint256 expiry
+    ) internal view returns (ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature) {
+        operatorSignature.salt = salt;
+        operatorSignature.expiry = expiry;
+        {
+            bytes32 digestHash = delegationManager.calculateOperatorAVSRegistrationDigestHash(operator, avs, salt, expiry);
+            (uint8 v, bytes32 r, bytes32 s) = cheats.sign(_operatorPrivateKey, digestHash);
+            operatorSignature.signature = abi.encodePacked(r, s, v);
+        }
+        return operatorSignature;
+    }
+
+}

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -103,6 +103,7 @@ contract StakeRegistryUnitTests is Test {
 
         cheats.startPrank(registryCoordinatorOwner);
         registryCoordinator = new RegistryCoordinatorHarness(
+            delegationMock,
             slasher,
             stakeRegistry,
             IBLSApkRegistry(apkRegistry),

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -77,7 +77,7 @@ contract MockAVSDeployer is Test {
     bytes32 defaultSalt = bytes32(uint256(keccak256("defaultSalt")));
 
     address ejector = address(uint160(uint256(keccak256("ejector"))));
-
+    
     address defaultOperator = address(uint160(uint256(keccak256("defaultOperator"))));
     bytes32 defaultOperatorId;
     BN254.G1Point internal defaultPubKey =  BN254.G1Point(18260007818883133054078754218619977578772505796600400998181738095793040006897,3432351341799135763167709827653955074218841517684851694584291831827675065899);
@@ -237,6 +237,7 @@ contract MockAVSDeployer is Test {
         }
 
         registryCoordinatorImplementation = new RegistryCoordinatorHarness(
+            delegationMock,
             slasher,
             stakeRegistry,
             blsApkRegistry,
@@ -296,8 +297,9 @@ contract MockAVSDeployer is Test {
             stakeRegistry.setOperatorWeight(uint8(quorumNumbers[i]), operator, stake);
         }
 
+        ISignatureUtils.SignatureWithSaltAndExpiry memory emptySignatureAndExpiry;
         cheats.prank(operator);
-        registryCoordinator.registerOperator(quorumNumbers, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultSocket, emptySignatureAndExpiry);
     }
 
     /**
@@ -314,8 +316,9 @@ contract MockAVSDeployer is Test {
             stakeRegistry.setOperatorWeight(uint8(quorumNumbers[i]), operator, stakes[uint8(quorumNumbers[i])]);
         }
 
+        ISignatureUtils.SignatureWithSaltAndExpiry memory emptySignatureAndExpiry;
         cheats.prank(operator);
-        registryCoordinator.registerOperator(quorumNumbers, defaultSocket);
+        registryCoordinator.registerOperator(quorumNumbers, defaultSocket, emptySignatureAndExpiry);
     }
 
     function _registerRandomOperators(uint256 pseudoRandomNumber) internal returns(OperatorMetadata[] memory, uint256[][] memory) {


### PR DESCRIPTION
This PR adds AVS<>Operator registration support in the RegistryCoordinator. It calls the core contract functions added in [this core PR.](https://github.com/Layr-Labs/eigenlayer-contracts/pull/363)

Removed kickIndex in the `registerOperatorWithChurn` function as it was an unused variable. 
