### PR TITLE
Test: bitmap utils unit tests

### DIFF
--- a/src/libraries/BitmapUtils.sol
+++ b/src/libraries/BitmapUtils.sol
@@ -15,44 +15,6 @@ library BitmapUtils {
     uint256 internal constant MAX_BYTE_ARRAY_LENGTH = 256;
 
     /**
-     * @notice Converts an array of bytes into a bitmap.
-     * @param bytesArray The array of bytes to convert/compress into a bitmap.
-     * @return The resulting bitmap.
-     * @dev Each byte in the input is processed as indicating a single bit to flip in the bitmap
-     * @dev This function will also revert if the `bytesArray` input contains any duplicate entries (i.e. duplicate bytes).
-     */
-    function bytesArrayToBitmap(bytes memory bytesArray) internal pure returns (uint256) {
-        // sanity-check on input. a too-long input would fail later on due to having duplicate entry(s)
-        require(bytesArray.length <= MAX_BYTE_ARRAY_LENGTH,
-            "BitmapUtils.bytesArrayToBitmap: bytesArray is too long");
-
-        // return empty bitmap early if length of array is 0
-        if (bytesArray.length == 0) {
-            return uint256(0);
-        }
-
-        // initialize the empty bitmap, to be built inside the loop
-        uint256 bitmap;
-        // initialize an empty uint256 to be used as a bitmask inside the loop
-        uint256 bitMask;
-
-        // perform the 0-th loop iteration with the duplicate check *omitted* (since it is unnecessary / will always pass)
-        // construct a single-bit mask from the numerical value of the 0th byte of the array, and immediately add it to the bitmap
-        bitmap = uint256(1 << uint8(bytesArray[0]));
-
-        // loop through each byte in the array to construct the bitmap
-        for (uint256 i = 1; i < bytesArray.length; ++i) {
-            // construct a single-bit mask from the numerical value of the next byte out of the array
-            bitMask = uint256(1 << uint8(bytesArray[i]));
-            // check that the entry is not a repeat
-            require(bitmap & bitMask == 0, "BitmapUtils.bytesArrayToBitmap: repeat entry in bytesArray");
-            // add the entry to the bitmap
-            bitmap = (bitmap | bitMask);
-        }
-        return bitmap;
-    }
-
-    /**
      * @notice Converts an ordered array of bytes into a bitmap.
      * @param orderedBytesArray The array of bytes to convert/compress into a bitmap. Must be in strictly ascending order.
      * @return The resulting bitmap.
@@ -108,122 +70,6 @@ library BitmapUtils {
         }
 
         return bitmap;
-    }
-
-    /**
-     * @notice Converts an ordered array of bytes into a bitmap. Optimized, Yul-heavy version of `orderedBytesArrayToBitmap`.
-     * @param orderedBytesArray The array of bytes to convert/compress into a bitmap. Must be in strictly ascending order.
-     * @return bitmap The resulting bitmap.
-     * @dev Each byte in the input is processed as indicating a single bit to flip in the bitmap.
-     * @dev This function will eventually revert in the event that the `orderedBytesArray` is not properly ordered (in ascending order).
-     * @dev This function will also revert if the `orderedBytesArray` input contains any duplicate entries (i.e. duplicate bytes).
-     */
-    function orderedBytesArrayToBitmap_Yul(bytes calldata orderedBytesArray) internal pure returns (uint256 bitmap) {
-        // sanity-check on input. a too-long input would fail later on due to having duplicate entry(s)
-        require(orderedBytesArray.length <= MAX_BYTE_ARRAY_LENGTH,
-            "BitmapUtils.orderedBytesArrayToBitmap: orderedBytesArray is too long");
-
-        // return empty bitmap early if length of array is 0
-        if (orderedBytesArray.length == 0) {
-            return uint256(0);
-        }
-
-        assembly {
-            // get first entry in bitmap (single byte => single-bit mask)
-            bitmap :=
-                shl(
-                    // extract single byte to get the correct value for the left shift
-                    shr(
-                        248,
-                        calldataload(
-                            orderedBytesArray.offset
-                        )
-                    ),
-                    1
-                )
-            // loop through other entries (byte by byte)
-            for { let i := 1 } lt(i, orderedBytesArray.length) { i := add(i, 1) } {
-                // first construct the single-bit mask by left-shifting a '1'
-                let bitMask := 
-                    shl(
-                        // extract single byte to get the correct value for the left shift
-                        shr(
-                            248,
-                            calldataload(
-                                add(
-                                    orderedBytesArray.offset,
-                                    i
-                                )
-                            )
-                        ),
-                        1
-                    )
-                // check strictly ascending ordering by comparing the mask to the bitmap so far (revert if mask isn't greater than bitmap)
-                // TODO: revert with a good message instead of using `revert(0, 0)`
-                // REFERENCE: require(bitMask > bitmap, "BitmapUtils.orderedBytesArrayToBitmap: orderedBytesArray is not ordered");
-                if iszero(gt(bitMask, bitmap)) { revert(0, 0) }
-                // update the bitmap by adding the single bit in the mask
-                bitmap := or(bitmap, bitMask)
-            }
-        }
-    }
-
-    /**
-     * @notice Converts an array of bytes into a bitmap. Optimized, Yul-heavy version of `bytesArrayToBitmap`.
-     * @param bytesArray The array of bytes to convert/compress into a bitmap.
-     * @return bitmap The resulting bitmap.
-     * @dev Each byte in the input is processed as indicating a single bit to flip in the bitmap.
-     * @dev This function will eventually revert in the event that the `bytesArray` is not properly ordered (in ascending order).
-     * @dev This function will also revert if the `bytesArray` input contains any duplicate entries (i.e. duplicate bytes).
-     */
-    function bytesArrayToBitmap_Yul(bytes calldata bytesArray) internal pure returns (uint256 bitmap) {
-        // sanity-check on input. a too-long input would fail later on due to having duplicate entry(s)
-        require(bytesArray.length <= MAX_BYTE_ARRAY_LENGTH,
-            "BitmapUtils.bytesArrayToBitmap: bytesArray is too long");
-
-        // return empty bitmap early if length of array is 0
-        if (bytesArray.length == 0) {
-            return uint256(0);
-        }
-
-        assembly {
-            // get first entry in bitmap (single byte => single-bit mask)
-            bitmap :=
-                shl(
-                    // extract single byte to get the correct value for the left shift
-                    shr(
-                        248,
-                        calldataload(
-                            bytesArray.offset
-                        )
-                    ),
-                    1
-                )
-            // loop through other entries (byte by byte)
-            for { let i := 1 } lt(i, bytesArray.length) { i := add(i, 1) } {
-                // first construct the single-bit mask by left-shifting a '1'
-                let bitMask := 
-                    shl(
-                        // extract single byte to get the correct value for the left shift
-                        shr(
-                            248,
-                            calldataload(
-                                add(
-                                    bytesArray.offset,
-                                    i
-                                )
-                            )
-                        ),
-                        1
-                    )
-                // check against duplicates by comparing the bitmask and bitmap (revert if the bitmap already contains the entry, i.e. bitmap & bitMask != 0)
-                // TODO: revert with a good message instead of using `revert(0, 0)`
-                // REFERENCE: require(bitmap & bitMask == 0, "BitmapUtils.bytesArrayToBitmap: repeat entry in bytesArray");
-                if gt(and(bitmap, bitMask), 0) { revert(0, 0) }
-                // update the bitmap by adding the single bit in the mask
-                bitmap := or(bitmap, bitMask)
-            }
-        }
     }
 
     /**
@@ -308,14 +154,6 @@ library BitmapUtils {
      */
     function setBit(uint256 bitmap, uint8 bit) internal pure returns (uint256) {
         return bitmap | (1 << bit);
-    }
-
-    /**
-     * @notice Sets the bit at `numberToAdd` in `bitmap` to 1 and returns the result.
-     * Note that if the bit is already set, this function will return the same bitmap.
-     */
-    function addNumberToBitmap(uint256 bitmap, uint8 numberToAdd) internal pure returns (uint256) {
-        return bitmap | (1 << numberToAdd);
     }
 
     /**

--- a/src/libraries/BitmapUtils.sol
+++ b/src/libraries/BitmapUtils.sol
@@ -289,10 +289,10 @@ library BitmapUtils {
     function countNumOnes(uint256 n) internal pure returns (uint16) {
         uint16 count = 0;
         while (n > 0) {
-            n &= (n - 1);
-            count++;
+            n &= (n - 1); // Clear the least significant bit (turn off the rightmost set bit).
+            count++; // Increment the count for each cleared bit (each one encountered).
         }
-        return count;
+        return count; // Return the total count of ones in the binary representation of n.
     }
 
     /// @notice Returns `true` if `bit` is in `bitmap`. Returns `false` otherwise.

--- a/src/libraries/BitmapUtils.sol
+++ b/src/libraries/BitmapUtils.sol
@@ -311,6 +311,14 @@ library BitmapUtils {
     }
 
     /**
+     * @notice Sets the bit at `numberToAdd` in `bitmap` to 1 and returns the result.
+     * Note that if the bit is already set, this function will return the same bitmap.
+     */
+    function addNumberToBitmap(uint256 bitmap, uint8 numberToAdd) internal pure returns (uint256) {
+        return bitmap | (1 << numberToAdd);
+    }
+
+    /**
      * @notice Returns true if `bitmap` has no set bits
      */
     function isEmpty(uint256 bitmap) internal pure returns (bool) {

--- a/test/harnesses/BitmapUtilsWrapper.sol
+++ b/test/harnesses/BitmapUtilsWrapper.sol
@@ -36,4 +36,24 @@ contract BitmapUtilsWrapper {
     function isSet(uint256 bitmap, uint8 numberToCheckForInclusion) external pure returns (bool) {
         return BitmapUtils.isSet(bitmap, numberToCheckForInclusion);
     }
+
+    function isEmpty(uint256 bitmap) external pure returns (bool) {
+        return BitmapUtils.isEmpty(bitmap);
+    }
+
+    function noBitsInCommon(uint256 a, uint256 b) external pure returns (bool) {
+        return BitmapUtils.noBitsInCommon(a, b);
+    }
+
+    function isSubsetOf(uint256 a, uint256 b) external pure returns (bool) {
+        return BitmapUtils.isSubsetOf(a, b);
+    }
+
+    function plus(uint256 a, uint256 b) external pure returns (uint256) {
+        return BitmapUtils.plus(a, b);
+    }
+
+    function minus(uint256 a, uint256 b) external pure returns (uint256) {
+        return BitmapUtils.minus(a, b);
+    }
 }

--- a/test/harnesses/BitmapUtilsWrapper.sol
+++ b/test/harnesses/BitmapUtilsWrapper.sol
@@ -5,10 +5,6 @@ import "../../src/libraries/BitmapUtils.sol";
 
 // wrapper around the BitmapUtils library that exposes the internal functions
 contract BitmapUtilsWrapper {
-    function bytesArrayToBitmap(bytes calldata bytesArray) external pure returns (uint256) {
-        return BitmapUtils.bytesArrayToBitmap(bytesArray);
-    }
-
     function orderedBytesArrayToBitmap(bytes calldata orderedBytesArray) external pure returns (uint256) {
         return BitmapUtils.orderedBytesArrayToBitmap(orderedBytesArray);
     }
@@ -21,14 +17,6 @@ contract BitmapUtilsWrapper {
         return BitmapUtils.bitmapToBytesArray(bitmap);
     }
 
-    function orderedBytesArrayToBitmap_Yul(bytes calldata orderedBytesArray) external pure returns (uint256) {
-        return BitmapUtils.orderedBytesArrayToBitmap_Yul(orderedBytesArray);
-    }
-
-    function bytesArrayToBitmap_Yul(bytes calldata bytesArray) external pure returns (uint256) {
-        return BitmapUtils.bytesArrayToBitmap_Yul(bytesArray);
-    }
-
     function countNumOnes(uint256 n) external pure returns (uint16) {
         return BitmapUtils.countNumOnes(n);
     }
@@ -37,8 +25,8 @@ contract BitmapUtilsWrapper {
         return BitmapUtils.isSet(bitmap, numberToCheckForInclusion);
     }
 
-    function addNumberToBitmap(uint256 bitmap, uint8 numberToAdd) external pure returns (uint256) {
-        return BitmapUtils.addNumberToBitmap(bitmap, numberToAdd);
+    function setBit(uint256 bitmap, uint8 bit) external pure returns (uint256) {
+        return BitmapUtils.setBit(bitmap, bit);
     }
 
     function isEmpty(uint256 bitmap) external pure returns (bool) {

--- a/test/harnesses/BitmapUtilsWrapper.sol
+++ b/test/harnesses/BitmapUtilsWrapper.sol
@@ -37,6 +37,10 @@ contract BitmapUtilsWrapper {
         return BitmapUtils.isSet(bitmap, numberToCheckForInclusion);
     }
 
+    function addNumberToBitmap(uint256 bitmap, uint8 numberToAdd) external pure returns (uint256) {
+        return BitmapUtils.addNumberToBitmap(bitmap, numberToAdd);
+    }
+
     function isEmpty(uint256 bitmap) external pure returns (bool) {
         return BitmapUtils.isEmpty(bitmap);
     }

--- a/test/unit/BitmapUtils.t.sol
+++ b/test/unit/BitmapUtils.t.sol
@@ -30,24 +30,24 @@ contract BitmapUtilsUnitTests_bitwiseOperations is BitmapUtilsUnitTests {
         assertEq(libraryOutput, numOnes, "inconsistency in countNumOnes function");
     }
 
-    /// @notice some simple sanity checks on the `numberIsInBitmap` function
-    function test_numberIsInBitmap() public {
-        assertTrue(bitmapUtilsWrapper.numberIsInBitmap(2 ** 6, 6), "numberIsInBitmap function is broken 0");
-        assertTrue(bitmapUtilsWrapper.numberIsInBitmap(1, 0), "numberIsInBitmap function is broken 1");
-        assertTrue(bitmapUtilsWrapper.numberIsInBitmap(255, 7), "numberIsInBitmap function is broken 2");
-        assertTrue(bitmapUtilsWrapper.numberIsInBitmap(1024, 10), "numberIsInBitmap function is broken 3");
+    /// @notice some simple sanity checks on the `isSet` function
+    function test_isSet() public {
+        assertTrue(bitmapUtilsWrapper.isSet(2 ** 6, 6), "isSet function is broken 0");
+        assertTrue(bitmapUtilsWrapper.isSet(1, 0), "isSet function is broken 1");
+        assertTrue(bitmapUtilsWrapper.isSet(255, 7), "isSet function is broken 2");
+        assertTrue(bitmapUtilsWrapper.isSet(1024, 10), "isSet function is broken 3");
         for (uint256 i = 0; i < 256; ++i) {
-            assertTrue(bitmapUtilsWrapper.numberIsInBitmap(type(uint256).max, uint8(i)), "numberIsInBitmap function is broken 4");
-            assertFalse(bitmapUtilsWrapper.numberIsInBitmap(0, uint8(i)), "numberIsInBitmap function is broken 5");
+            assertTrue(bitmapUtilsWrapper.isSet(type(uint256).max, uint8(i)), "isSet function is broken 4");
+            assertFalse(bitmapUtilsWrapper.isSet(0, uint8(i)), "isSet function is broken 5");
         }
     }
 
-    function test_addNumberToBitmap(uint256 bitmap, uint8 numberToAdd) public {
+    function test_setBit(uint256 bitmap, uint8 bitToSet) public {
         // Ensure that numberToAdd isn't already in the bitmap
-        cheats.assume(bitmap | (1 << numberToAdd) != bitmap);
-        uint256 updatedBitmap = bitmapUtilsWrapper.addNumberToBitmap(bitmap, numberToAdd);
+        cheats.assume(bitmap | (1 << bitToSet) != bitmap);
+        uint256 updatedBitmap = bitmapUtilsWrapper.setBit(bitmap, bitToSet);
         assertTrue(
-            bitmapUtilsWrapper.numberIsInBitmap(updatedBitmap, numberToAdd), "addNumberToBitmap function is broken"
+            bitmapUtilsWrapper.isSet(updatedBitmap, bitToSet), "setBit function is broken"
         );
     }
 
@@ -122,7 +122,7 @@ contract BitmapUtilsUnitTests_bytesArrayToBitmap is BitmapUtilsUnitTests {
     // ensure that the bitmap encoding of an empty bytes array is an empty bitmap (function doesn't revert and approriately returns uint256(0))
     function test_EmptyArrayEncoding() public {
         bytes memory emptyBytesArray;
-        uint256 returnedBitMap = bitmapUtilsWrapper.bytesArrayToBitmap(emptyBytesArray);
+        uint256 returnedBitMap = bitmapUtilsWrapper.orderedBytesArrayToBitmap(emptyBytesArray);
         assertEq(returnedBitMap, 0, "BitmapUtilsUnitTests.testEmptyArrayEncoding: empty array not encoded to empty bitmap");
     }
 
@@ -130,21 +130,22 @@ contract BitmapUtilsUnitTests_bytesArrayToBitmap is BitmapUtilsUnitTests {
     function testFuzz_SingleByteEncoding(uint8 fuzzedNumber) public {
         bytes1 singleByte = bytes1(fuzzedNumber);
         bytes memory bytesArray = abi.encodePacked(singleByte);
-        uint256 returnedBitMap = bitmapUtilsWrapper.bytesArrayToBitmap(bytesArray);
+        uint256 returnedBitMap = bitmapUtilsWrapper.orderedBytesArrayToBitmap(bytesArray);
         uint256 bitMask = uint256(1 << fuzzedNumber);
         assertEq(returnedBitMap, bitMask, "BitmapUtilsUnitTests.testSingleByteEncoding: non-equivalence");
     }
 
     // ensure that the bitmap encoding of a two uint8's (i.e. a two byte array) matches the expected output
     function testFuzz_TwoByteEncoding(uint8 firstFuzzedNumber, uint8 secondFuzzedNumber) public {
+        cheats.assume(secondFuzzedNumber > firstFuzzedNumber);
         bytes1 firstSingleByte = bytes1(firstFuzzedNumber);
         bytes1 secondSingleByte = bytes1(secondFuzzedNumber);
         bytes memory bytesArray = abi.encodePacked(firstSingleByte, secondSingleByte);
         if (firstFuzzedNumber == secondFuzzedNumber) {
-            cheats.expectRevert(bytes("BitmapUtils.bytesArrayToBitmap: repeat entry in bytesArray"));
-            bitmapUtilsWrapper.bytesArrayToBitmap(bytesArray);
+            cheats.expectRevert(bytes("BitmapUtils.orderedBytesArrayToBitmap: repeat entry in bytesArray"));
+            bitmapUtilsWrapper.orderedBytesArrayToBitmap(bytesArray);
         } else {
-            uint256 returnedBitMap = bitmapUtilsWrapper.bytesArrayToBitmap(bytesArray);
+            uint256 returnedBitMap = bitmapUtilsWrapper.orderedBytesArrayToBitmap(bytesArray);
             uint256 firstBitMask = uint256(1 << firstFuzzedNumber);
             uint256 secondBitMask = uint256(1 << secondFuzzedNumber);
             uint256 combinedBitMask = firstBitMask | secondBitMask;
@@ -157,26 +158,12 @@ contract BitmapUtilsUnitTests_bytesArrayToBitmap is BitmapUtilsUnitTests {
     function testFuzz_BytesArrayToBitmapToBytesArray(bytes memory originalBytesArray) public {
         // filter down to only ordered inputs
         cheats.assume(bitmapUtilsWrapper.isArrayStrictlyAscendingOrdered(originalBytesArray));
-        uint256 bitmap = bitmapUtilsWrapper.bytesArrayToBitmap(originalBytesArray);
+        uint256 bitmap = bitmapUtilsWrapper.orderedBytesArrayToBitmap(originalBytesArray);
         bytes memory returnedBytesArray = bitmapUtilsWrapper.bitmapToBytesArray(bitmap);
         assertEq(
             keccak256(abi.encodePacked(originalBytesArray)),
             keccak256(abi.encodePacked(returnedBytesArray)),
             "BitmapUtilsUnitTests.testBytesArrayToBitmapToBytesArray: output does not match input"
-        );
-    }
-
-    // ensure that converting bytes array => bitmap => bytes array returns the original bytes array (i.e. is lossless and artifactless)
-    // note that this only works on ordered arrays, because unordered arrays will be returned ordered
-    function testFuzz_BytesArrayToBitmapToBytesArray_Yul(bytes memory originalBytesArray) public {
-        // filter down to only ordered inputs
-        cheats.assume(bitmapUtilsWrapper.isArrayStrictlyAscendingOrdered(originalBytesArray));
-        uint256 bitmap = bitmapUtilsWrapper.bytesArrayToBitmap_Yul(originalBytesArray);
-        bytes memory returnedBytesArray = bitmapUtilsWrapper.bitmapToBytesArray(bitmap);
-        assertEq(
-            keccak256(abi.encodePacked(originalBytesArray)),
-            keccak256(abi.encodePacked(returnedBytesArray)),
-            "BitmapUtilsUnitTests.testBytesArrayToBitmapToBytesArray_Yul: output does not match input"
         );
     }
 
@@ -217,19 +204,6 @@ contract BitmapUtilsUnitTests_bytesArrayToBitmap is BitmapUtilsUnitTests {
     }
 
     // testing one function for a specific input. used for comparing gas costs
-    function test_BytesArrayToBitmap_OrderedVersion_Yul_SpecificInput() public {
-        bytes memory originalBytesArray = abi.encodePacked(
-            bytes1(uint8(5)), bytes1(uint8(6)), bytes1(uint8(7)), bytes1(uint8(8)), bytes1(uint8(9)), bytes1(uint8(10)), bytes1(uint8(11)), bytes1(uint8(12))
-        );
-        uint256 gasLeftBefore = gasleft();
-        uint256 bitmap = bitmapUtilsWrapper.orderedBytesArrayToBitmap_Yul(originalBytesArray);
-        uint256 gasLeftAfter = gasleft();
-        uint256 gasSpent = gasLeftBefore - gasLeftAfter;
-        assertEq(bitmap, 8160);
-        emit log_named_uint("gasSpent", gasSpent);
-    }
-
-    // testing one function for a specific input. used for comparing gas costs
     function test_BytesArrayToBitmap_OrderedVersion_SpecificInput() public {
         bytes memory originalBytesArray = abi.encodePacked(
             bytes1(uint8(5)), bytes1(uint8(6)), bytes1(uint8(7)), bytes1(uint8(8)), bytes1(uint8(9)), bytes1(uint8(10)), bytes1(uint8(11)), bytes1(uint8(12))
@@ -248,33 +222,11 @@ contract BitmapUtilsUnitTests_bytesArrayToBitmap is BitmapUtilsUnitTests {
             bytes1(uint8(5)), bytes1(uint8(6)), bytes1(uint8(7)), bytes1(uint8(8)), bytes1(uint8(9)), bytes1(uint8(10)), bytes1(uint8(11)), bytes1(uint8(12))
         );
         uint256 gasLeftBefore = gasleft();
-        uint256 bitmap = bitmapUtilsWrapper.bytesArrayToBitmap(originalBytesArray);
+        uint256 bitmap = bitmapUtilsWrapper.orderedBytesArrayToBitmap(originalBytesArray);
         uint256 gasLeftAfter = gasleft();
         uint256 gasSpent = gasLeftBefore - gasLeftAfter;
         assertEq(bitmap, 8160);
         emit log_named_uint("gasSpent", gasSpent);
-    }
-
-    // testing one function for a specific input. used for comparing gas costs
-    function test_BytesArrayToBitmap_Yul_SpecificInput() public {
-        bytes memory originalBytesArray = abi.encodePacked(
-            bytes1(uint8(5)), bytes1(uint8(6)), bytes1(uint8(7)), bytes1(uint8(8)), bytes1(uint8(9)), bytes1(uint8(10)), bytes1(uint8(11)), bytes1(uint8(12))
-        );
-        uint256 gasLeftBefore = gasleft();
-        uint256 bitmap = bitmapUtilsWrapper.bytesArrayToBitmap_Yul(originalBytesArray);
-        uint256 gasLeftAfter = gasleft();
-        uint256 gasSpent = gasLeftBefore - gasLeftAfter;
-        assertEq(bitmap, 8160);
-        emit log_named_uint("gasSpent", gasSpent);
-    }
-}
-
-contract BitmapUtilsUnitTests_bitmapToBytesArray is BitmapUtilsUnitTests {
-    // ensure that converting bitmap => bytes array => bitmap is returns the original bitmap (i.e. is lossless and artifactless)
-    function testFuzz_BitMapToBytesArrayToBitmap(uint256 originalBitmap) public {
-        bytes memory bytesArray = bitmapUtilsWrapper.bitmapToBytesArray(originalBitmap);
-        uint256 returnedBitMap = bitmapUtilsWrapper.bytesArrayToBitmap(bytesArray);
-        assertEq(returnedBitMap, originalBitmap, "BitmapUtilsUnitTests.testBitMapToArrayToBitmap: output does not match input");
     }
 }
 

--- a/test/unit/BitmapUtils.t.sol
+++ b/test/unit/BitmapUtils.t.sol
@@ -14,9 +14,11 @@ contract BitmapUtilsUnitTests is Test {
     function setUp() public {
         bitmapUtilsWrapper = new BitmapUtilsWrapper();
     }
+}
 
-    // @notice check for consistency of `countNumOnes` function
-    function testCountNumOnes(uint256 input) public view {
+contract BitmapUtilsUnitTests_bitwiseOperations is BitmapUtilsUnitTests {
+    /// @notice check for consistency of `countNumOnes` function
+    function testFuzz_countNumOnes(uint256 input) public {
         uint16 libraryOutput = bitmapUtilsWrapper.countNumOnes(input);
         // run dumb routine
         uint16 numOnes = 0;
@@ -25,37 +27,103 @@ contract BitmapUtilsUnitTests is Test {
                 ++numOnes; 
             }
         }
-        require(libraryOutput == numOnes, "inconsistency in countNumOnes function");
+        assertEq(libraryOutput, numOnes, "inconsistency in countNumOnes function");
     }
 
-    // @notice some simple sanity checks on the `numberIsInBitmap` function
-    function testNumberIsInBitmap() public view {
-        require(bitmapUtilsWrapper.numberIsInBitmap(2 ** 6, 6), "numberIsInBitmap function is broken 0");
-        require(bitmapUtilsWrapper.numberIsInBitmap(1, 0), "numberIsInBitmap function is broken 1");
-        require(bitmapUtilsWrapper.numberIsInBitmap(255, 7), "numberIsInBitmap function is broken 2");
-        require(bitmapUtilsWrapper.numberIsInBitmap(1024, 10), "numberIsInBitmap function is broken 3");
+    /// @notice some simple sanity checks on the `numberIsInBitmap` function
+    function test_NumberIsInBitmap() public {
+        assertTrue(bitmapUtilsWrapper.numberIsInBitmap(2 ** 6, 6), "numberIsInBitmap function is broken 0");
+        assertTrue(bitmapUtilsWrapper.numberIsInBitmap(1, 0), "numberIsInBitmap function is broken 1");
+        assertTrue(bitmapUtilsWrapper.numberIsInBitmap(255, 7), "numberIsInBitmap function is broken 2");
+        assertTrue(bitmapUtilsWrapper.numberIsInBitmap(1024, 10), "numberIsInBitmap function is broken 3");
         for (uint256 i = 0; i < 256; ++i) {
-            require(bitmapUtilsWrapper.numberIsInBitmap(type(uint256).max, uint8(i)), "numberIsInBitmap function is broken 4");
-            require(!bitmapUtilsWrapper.numberIsInBitmap(0, uint8(i)), "numberIsInBitmap function is broken 5");
+            assertTrue(bitmapUtilsWrapper.numberIsInBitmap(type(uint256).max, uint8(i)), "numberIsInBitmap function is broken 4");
+            assertFalse(bitmapUtilsWrapper.numberIsInBitmap(0, uint8(i)), "numberIsInBitmap function is broken 5");
+        }
+    }
+
+    function testFuzz_isEmpty(uint256 input) public {
+        if (input == 0) {
+            // assertTrue(bitmapUtilsWrapper.isEmpty(input), "isEmpty function is broken");
+            assertTrue(bitmapUtilsWrapper.isEmpty(input), "isEmpty function is broken");
+        } else {
+            assertFalse(bitmapUtilsWrapper.isEmpty(input), "isEmpty function is broken");
+        }
+    }
+
+    function testFuzz_noBitsInCommon(uint256 a, uint256 b) public {
+        // 1000 and 0111 have no bits in common
+        assertTrue(bitmapUtilsWrapper.noBitsInCommon(8, 7), "noBitsInCommon function is broken");
+        // 1101 and 0010 have no bits in common
+        assertTrue(bitmapUtilsWrapper.noBitsInCommon(13, 2), "noBitsInCommon function is broken");
+        // 11010 and 00101 have no bits in common
+        assertTrue(bitmapUtilsWrapper.noBitsInCommon(26, 5), "noBitsInCommon function is broken");
+        // 1000 and 1000 have bits in common
+        assertFalse(bitmapUtilsWrapper.noBitsInCommon(8, 8), "noBitsInCommon function is broken");
+        // 1000001 and 0000001 have bits in common
+        assertFalse(bitmapUtilsWrapper.noBitsInCommon(65, 1), "noBitsInCommon function is broken");
+        // 11010 and 100 have bits in common
+        assertFalse(bitmapUtilsWrapper.noBitsInCommon(26, 9), "noBitsInCommon function is broken");
+        // performing bitwise subtraction should always return true for noBitsInCommon
+        a = a & ~b;
+        assertTrue(bitmapUtilsWrapper.noBitsInCommon(a, b), "noBitsInCommon function is broken");
+    }
+
+    function testFuzz_isSubsetOf(uint256 a, uint256 b) public {
+        // 1000 is a subset of 1000
+        assertTrue(bitmapUtilsWrapper.isSubsetOf(8, 8), "isSubsetOf function is broken");
+        // 1000 is a subset of 1001
+        assertTrue(bitmapUtilsWrapper.isSubsetOf(8, 15), "isSubsetOf function is broken");
+        // 10000111 is a subset of 11100111
+        assertTrue(bitmapUtilsWrapper.isSubsetOf(135, 231), "isSubsetOf function is broken");
+
+        // a cannot be a subset of b if its > b
+        if (a > b) {
+            assertFalse(bitmapUtilsWrapper.isSubsetOf(a, b), "isSubsetOf function is broken");
+        } else if (a == b) {
+            assertTrue(bitmapUtilsWrapper.isSubsetOf(a, b), "isSubsetOf function is broken");
+        }
+    }
+
+    function testFuzz_plus(uint256 a, uint256 b) public {
+        uint256 bitwisePlus = bitmapUtilsWrapper.plus(a, b);
+        for (uint256 i = 0; i < 256; ++i) {
+            if ((a >> i) & 1 == 1 || (b >> i) & 1 == 1) {
+                // If either of the bits of a or b are set, then bitwisePlus should have that bit set
+                assertTrue((bitwisePlus >> i) & 1 == 1, "plus function is broken");
+            }
+        }
+    }
+
+    function testFuzz_minus(uint256 a, uint256 b) public {
+        uint256 bitwiseMinus = bitmapUtilsWrapper.minus(a, b);
+        for (uint256 i = 0; i < 256; ++i) {
+            if ((a >> i) & 1 == 1 && (b >> i) & 1 == 0) {
+                // If the ith bit of a is set and the ith bit of b is not set, then bitwiseMinus should have that bit set
+                assertTrue((bitwiseMinus >> i) & 1 == 1, "minus function is broken");
+            } else {
+                // Otherwise, the ith bit of bitwiseMinus should not be set
+                assertTrue((bitwiseMinus >> i) & 1 == 0, "minus function is broken");
+            }
         }
     }
 }
 
 contract BitmapUtilsUnitTests_bytesArrayToBitmap is BitmapUtilsUnitTests {
     // ensure that the bitmap encoding of an empty bytes array is an empty bitmap (function doesn't revert and approriately returns uint256(0))
-    function test_EmptyArrayEncoding() public view {
+    function test_EmptyArrayEncoding() public {
         bytes memory emptyBytesArray;
         uint256 returnedBitMap = bitmapUtilsWrapper.bytesArrayToBitmap(emptyBytesArray);
-        require(returnedBitMap == 0, "BitmapUtilsUnitTests.testEmptyArrayEncoding: empty array not encoded to empty bitmap");
+        assertEq(returnedBitMap, 0, "BitmapUtilsUnitTests.testEmptyArrayEncoding: empty array not encoded to empty bitmap");
     }
 
     // ensure that the bitmap encoding of a single uint8 (i.e. a single byte) matches the expected output
-    function testFuzz_SingleByteEncoding(uint8 fuzzedNumber) public view {
+    function testFuzz_SingleByteEncoding(uint8 fuzzedNumber) public {
         bytes1 singleByte = bytes1(fuzzedNumber);
         bytes memory bytesArray = abi.encodePacked(singleByte);
         uint256 returnedBitMap = bitmapUtilsWrapper.bytesArrayToBitmap(bytesArray);
         uint256 bitMask = uint256(1 << fuzzedNumber);
-        require(returnedBitMap == bitMask, "BitmapUtilsUnitTests.testSingleByteEncoding: non-equivalence");
+        assertEq(returnedBitMap, bitMask, "BitmapUtilsUnitTests.testSingleByteEncoding: non-equivalence");
     }
 
     // ensure that the bitmap encoding of a two uint8's (i.e. a two byte array) matches the expected output
@@ -71,115 +139,133 @@ contract BitmapUtilsUnitTests_bytesArrayToBitmap is BitmapUtilsUnitTests {
             uint256 firstBitMask = uint256(1 << firstFuzzedNumber);
             uint256 secondBitMask = uint256(1 << secondFuzzedNumber);
             uint256 combinedBitMask = firstBitMask | secondBitMask;
-            require(returnedBitMap == combinedBitMask, "BitmapUtilsUnitTests.testTwoByteEncoding: non-equivalence");
+            assertEq(returnedBitMap, combinedBitMask, "BitmapUtilsUnitTests.testTwoByteEncoding: non-equivalence");
         }
     }
 
     // ensure that converting bytes array => bitmap => bytes array returns the original bytes array (i.e. is lossless and artifactless)
     // note that this only works on ordered arrays, because unordered arrays will be returned ordered
-    function testFuzz_BytesArrayToBitmapToBytesArray(bytes memory originalBytesArray) public view {
+    function testFuzz_BytesArrayToBitmapToBytesArray(bytes memory originalBytesArray) public {
         // filter down to only ordered inputs
         cheats.assume(bitmapUtilsWrapper.isArrayStrictlyAscendingOrdered(originalBytesArray));
         uint256 bitmap = bitmapUtilsWrapper.bytesArrayToBitmap(originalBytesArray);
         bytes memory returnedBytesArray = bitmapUtilsWrapper.bitmapToBytesArray(bitmap);
-        // emit log_named_bytes("originalBytesArray", originalBytesArray);
-        // emit log_named_uint("bitmap", bitmap);
-        // emit log_named_bytes("returnedBytesArray", returnedBytesArray);
-        require(keccak256(abi.encodePacked(originalBytesArray)) == keccak256(abi.encodePacked(returnedBytesArray)),
-            "BitmapUtilsUnitTests.testBytesArrayToBitmapToBytesArray: output doesn't match input");
+        assertEq(
+            keccak256(abi.encodePacked(originalBytesArray)),
+            keccak256(abi.encodePacked(returnedBytesArray)),
+            "BitmapUtilsUnitTests.testBytesArrayToBitmapToBytesArray: output doesn't match input"
+        );
     }
 
-    // ensure that converting bytes array => bitmap => bytes array is returns the original bytes array (i.e. is lossless and artifactless)
+    // ensure that converting bytes array => bitmap => bytes array returns the original bytes array (i.e. is lossless and artifactless)
     // note that this only works on ordered arrays, because unordered arrays will be returned ordered
-    function testBytesArrayToBitmapToBytesArray_Yul(bytes memory originalBytesArray) public view {
+    function testFuzz_BytesArrayToBitmapToBytesArray_Yul(bytes memory originalBytesArray) public {
         // filter down to only ordered inputs
         cheats.assume(bitmapUtilsWrapper.isArrayStrictlyAscendingOrdered(originalBytesArray));
         uint256 bitmap = bitmapUtilsWrapper.bytesArrayToBitmap_Yul(originalBytesArray);
         bytes memory returnedBytesArray = bitmapUtilsWrapper.bitmapToBytesArray(bitmap);
-        // emit log_named_bytes("originalBytesArray", originalBytesArray);
-        // emit log_named_uint("bitmap", bitmap);
-        // emit log_named_bytes("returnedBytesArray", returnedBytesArray);
-        require(keccak256(abi.encodePacked(originalBytesArray)) == keccak256(abi.encodePacked(returnedBytesArray)),
-            "BitmapUtilsUnitTests.testBytesArrayToBitmapToBytesArray: output doesn't match input");
+        assertEq(
+            keccak256(abi.encodePacked(originalBytesArray)),
+            keccak256(abi.encodePacked(returnedBytesArray)),
+            "BitmapUtilsUnitTests.testBytesArrayToBitmapToBytesArray_Yul: output doesn't match input"
+        );
     }
 
-    // ensure that converting bytes array => bitmap => bytes array is returns the original bytes array (i.e. is lossless and artifactless)
+    // ensure that converting bytes array => bitmap => bytes array returns the original bytes array (i.e. is lossless and artifactless)
     // note that this only works on ordered arrays
-    function testBytesArrayToBitmapToBytesArray_OrderedVersion(bytes memory originalBytesArray) public view {
+    function testFuzz_BytesArrayToBitmapToBytesArray_OrderedVersion(bytes memory originalBytesArray) public {
         // filter down to only ordered inputs
         cheats.assume(bitmapUtilsWrapper.isArrayStrictlyAscendingOrdered(originalBytesArray));
         uint256 bitmap = bitmapUtilsWrapper.orderedBytesArrayToBitmap(originalBytesArray);
         bytes memory returnedBytesArray = bitmapUtilsWrapper.bitmapToBytesArray(bitmap);
-        require(keccak256(abi.encodePacked(originalBytesArray)) == keccak256(abi.encodePacked(returnedBytesArray)),
-            "BitmapUtilsUnitTests.testBytesArrayToBitmapToBytesArray: output doesn't match input");
+        assertEq(
+            keccak256(abi.encodePacked(originalBytesArray)),
+            keccak256(abi.encodePacked(returnedBytesArray)),
+            "BitmapUtilsUnitTests.testBytesArrayToBitmapToBytesArray: output doesn't match input"
+        );
     }
 
-    // ensure that converting bytes array => bitmap => bytes array is returns the original bytes array (i.e. is lossless and artifactless)
-    // note that this only works on ordered arrays
-    function testBytesArrayToBitmapToBytesArray_OrderedVersion_Yul(bytes memory originalBytesArray) public view {
-        // filter down to only ordered inputs
-        cheats.assume(bitmapUtilsWrapper.isArrayStrictlyAscendingOrdered(originalBytesArray));
-        uint256 bitmap = bitmapUtilsWrapper.orderedBytesArrayToBitmap(originalBytesArray);
-        bytes memory returnedBytesArray = bitmapUtilsWrapper.bitmapToBytesArray(bitmap);
-        require(keccak256(abi.encodePacked(originalBytesArray)) == keccak256(abi.encodePacked(returnedBytesArray)),
-            "BitmapUtilsUnitTests.testBytesArrayToBitmapToBytesArray: output doesn't match input");
-    }
-
-    // testing one function for a specific input. used for comparing gas costs
-    function testBytesArrayToBitmap_OrderedVersion_Yul_SpecificInput(/*bytes memory originalBytesArray*/) public {
-        bytes memory originalBytesArray =
-            abi.encodePacked(bytes1(uint8(5)), bytes1(uint8(6)), bytes1(uint8(7)), bytes1(uint8(8)), bytes1(uint8(9)), bytes1(uint8(10)), bytes1(uint8(11)), bytes1(uint8(12)));
-        // bytes memory originalBytesArray = abi.encodePacked(bytes1(uint8(5)));
-        uint256 gasLeftBefore = gasleft();
-        bitmapUtilsWrapper.orderedBytesArrayToBitmap_Yul(originalBytesArray);
-        uint256 gasLeftAfter = gasleft();
-        uint256 gasSpent = gasLeftBefore - gasLeftAfter;
-        emit log_named_uint("gasSpent", gasSpent);
-    }
-
-    // testing one function for a specific input. used for comparing gas costs
-    function testBytesArrayToBitmap_OrderedVersion_SpecificInput(/*bytes memory originalBytesArray*/) public {
-        bytes memory originalBytesArray =
-            abi.encodePacked(bytes1(uint8(5)), bytes1(uint8(6)), bytes1(uint8(7)), bytes1(uint8(8)), bytes1(uint8(9)), bytes1(uint8(10)), bytes1(uint8(11)), bytes1(uint8(12)));
-        // bytes memory originalBytesArray = abi.encodePacked(bytes1(uint8(5)));
-        uint256 gasLeftBefore = gasleft();
+    /// @notice Test that for non-strictly ascending bytes array ordering always reverts
+    /// when calling orderedBytesArrayToBitmap
+    function testFuzz_OrderedBytesArrayToBitmap_Revert_WhenNotOrdered(bytes memory originalBytesArray) public {
+        cheats.assume(!bitmapUtilsWrapper.isArrayStrictlyAscendingOrdered(originalBytesArray));
+        cheats.expectRevert("BitmapUtils.orderedBytesArrayToBitmap: orderedBytesArray is not ordered");
         bitmapUtilsWrapper.orderedBytesArrayToBitmap(originalBytesArray);
+    }
+
+    // ensure that converting bytes array => bitmap => bytes array returns the original bytes array (i.e. is lossless and artifactless)
+    // note that this only works on ordered arrays
+    function testFuzz_BytesArrayToBitmapToBytesArray_OrderedVersion_Yul(bytes memory originalBytesArray) public {
+        // filter down to only ordered inputs
+        cheats.assume(bitmapUtilsWrapper.isArrayStrictlyAscendingOrdered(originalBytesArray));
+        uint256 bitmap = bitmapUtilsWrapper.orderedBytesArrayToBitmap(originalBytesArray);
+        bytes memory returnedBytesArray = bitmapUtilsWrapper.bitmapToBytesArray(bitmap);
+        assertEq(
+            keccak256(abi.encodePacked(originalBytesArray)),
+            keccak256(abi.encodePacked(returnedBytesArray)),
+            "BitmapUtilsUnitTests.testBytesArrayToBitmapToBytesArray: output doesn't match input"
+        );
+    }
+
+    // testing one function for a specific input. used for comparing gas costs
+    function test_BytesArrayToBitmap_OrderedVersion_Yul_SpecificInput() public {
+        bytes memory originalBytesArray = abi.encodePacked(
+            bytes1(uint8(5)), bytes1(uint8(6)), bytes1(uint8(7)), bytes1(uint8(8)), bytes1(uint8(9)), bytes1(uint8(10)), bytes1(uint8(11)), bytes1(uint8(12))
+        );
+        uint256 gasLeftBefore = gasleft();
+        uint256 bitmap = bitmapUtilsWrapper.orderedBytesArrayToBitmap_Yul(originalBytesArray);
         uint256 gasLeftAfter = gasleft();
         uint256 gasSpent = gasLeftBefore - gasLeftAfter;
+        assertEq(bitmap, 8160);
         emit log_named_uint("gasSpent", gasSpent);
     }
 
     // testing one function for a specific input. used for comparing gas costs
-    function testBytesArrayToBitmap_SpecificInput(/*bytes memory originalBytesArray*/) public {
-        bytes memory originalBytesArray =
-            abi.encodePacked(bytes1(uint8(5)), bytes1(uint8(6)), bytes1(uint8(7)), bytes1(uint8(8)), bytes1(uint8(9)), bytes1(uint8(10)), bytes1(uint8(11)), bytes1(uint8(12)));
-        // bytes memory originalBytesArray = abi.encodePacked(bytes1(uint8(5)));
+    function test_BytesArrayToBitmap_OrderedVersion_SpecificInput() public {
+        bytes memory originalBytesArray = abi.encodePacked(
+            bytes1(uint8(5)), bytes1(uint8(6)), bytes1(uint8(7)), bytes1(uint8(8)), bytes1(uint8(9)), bytes1(uint8(10)), bytes1(uint8(11)), bytes1(uint8(12))
+        );
         uint256 gasLeftBefore = gasleft();
-        bitmapUtilsWrapper.bytesArrayToBitmap(originalBytesArray);
+        uint256 bitmap = bitmapUtilsWrapper.orderedBytesArrayToBitmap(originalBytesArray);
         uint256 gasLeftAfter = gasleft();
         uint256 gasSpent = gasLeftBefore - gasLeftAfter;
+        assertEq(bitmap, 8160);
         emit log_named_uint("gasSpent", gasSpent);
     }
 
     // testing one function for a specific input. used for comparing gas costs
-    function testBytesArrayToBitmap_Yul_SpecificInput(/*bytes memory originalBytesArray*/) public {
-        bytes memory originalBytesArray =
-            abi.encodePacked(bytes1(uint8(5)), bytes1(uint8(6)), bytes1(uint8(7)), bytes1(uint8(8)), bytes1(uint8(9)), bytes1(uint8(10)), bytes1(uint8(11)), bytes1(uint8(12)));
-        // bytes memory originalBytesArray = abi.encodePacked(bytes1(uint8(5)));
+    function test_BytesArrayToBitmap_SpecificInput() public {
+        bytes memory originalBytesArray = abi.encodePacked(
+            bytes1(uint8(5)), bytes1(uint8(6)), bytes1(uint8(7)), bytes1(uint8(8)), bytes1(uint8(9)), bytes1(uint8(10)), bytes1(uint8(11)), bytes1(uint8(12))
+        );
         uint256 gasLeftBefore = gasleft();
-        bitmapUtilsWrapper.bytesArrayToBitmap_Yul(originalBytesArray);
+        uint256 bitmap = bitmapUtilsWrapper.bytesArrayToBitmap(originalBytesArray);
         uint256 gasLeftAfter = gasleft();
         uint256 gasSpent = gasLeftBefore - gasLeftAfter;
+        assertEq(bitmap, 8160);
+        emit log_named_uint("gasSpent", gasSpent);
+    }
+
+    // testing one function for a specific input. used for comparing gas costs
+    function test_BytesArrayToBitmap_Yul_SpecificInput() public {
+        bytes memory originalBytesArray = abi.encodePacked(
+            bytes1(uint8(5)), bytes1(uint8(6)), bytes1(uint8(7)), bytes1(uint8(8)), bytes1(uint8(9)), bytes1(uint8(10)), bytes1(uint8(11)), bytes1(uint8(12))
+        );
+        uint256 gasLeftBefore = gasleft();
+        uint256 bitmap = bitmapUtilsWrapper.bytesArrayToBitmap_Yul(originalBytesArray);
+        uint256 gasLeftAfter = gasleft();
+        uint256 gasSpent = gasLeftBefore - gasLeftAfter;
+        assertEq(bitmap, 8160);
         emit log_named_uint("gasSpent", gasSpent);
     }
 }
 
 contract BitmapUtilsUnitTests_bitmapToBytesArray is BitmapUtilsUnitTests {
     // ensure that converting bitmap => bytes array => bitmap is returns the original bitmap (i.e. is lossless and artifactless)
-    function testBitMapToBytesArrayToBitmap(uint256 originalBitmap) public view {
+    function testFuzz_BitMapToBytesArrayToBitmap(uint256 originalBitmap) public {
         bytes memory bytesArray = bitmapUtilsWrapper.bitmapToBytesArray(originalBitmap);
         uint256 returnedBitMap = bitmapUtilsWrapper.bytesArrayToBitmap(bytesArray);
-        require(returnedBitMap == originalBitmap, "BitmapUtilsUnitTests.testBitMapToArrayToBitmap: output doesn't match input");
+        assertEq(returnedBitMap, originalBitmap, "BitmapUtilsUnitTests.testBitMapToArrayToBitmap: output doesn't match input");
     }
 }
 

--- a/test/unit/BitmapUtils.t.sol
+++ b/test/unit/BitmapUtils.t.sol
@@ -153,7 +153,7 @@ contract BitmapUtilsUnitTests_bytesArrayToBitmap is BitmapUtilsUnitTests {
         assertEq(
             keccak256(abi.encodePacked(originalBytesArray)),
             keccak256(abi.encodePacked(returnedBytesArray)),
-            "BitmapUtilsUnitTests.testBytesArrayToBitmapToBytesArray: output doesn't match input"
+            "BitmapUtilsUnitTests.testBytesArrayToBitmapToBytesArray: output does not match input"
         );
     }
 
@@ -167,7 +167,7 @@ contract BitmapUtilsUnitTests_bytesArrayToBitmap is BitmapUtilsUnitTests {
         assertEq(
             keccak256(abi.encodePacked(originalBytesArray)),
             keccak256(abi.encodePacked(returnedBytesArray)),
-            "BitmapUtilsUnitTests.testBytesArrayToBitmapToBytesArray_Yul: output doesn't match input"
+            "BitmapUtilsUnitTests.testBytesArrayToBitmapToBytesArray_Yul: output does not match input"
         );
     }
 
@@ -181,7 +181,7 @@ contract BitmapUtilsUnitTests_bytesArrayToBitmap is BitmapUtilsUnitTests {
         assertEq(
             keccak256(abi.encodePacked(originalBytesArray)),
             keccak256(abi.encodePacked(returnedBytesArray)),
-            "BitmapUtilsUnitTests.testBytesArrayToBitmapToBytesArray: output doesn't match input"
+            "BitmapUtilsUnitTests.testBytesArrayToBitmapToBytesArray: output does not match input"
         );
     }
 
@@ -203,7 +203,7 @@ contract BitmapUtilsUnitTests_bytesArrayToBitmap is BitmapUtilsUnitTests {
         assertEq(
             keccak256(abi.encodePacked(originalBytesArray)),
             keccak256(abi.encodePacked(returnedBytesArray)),
-            "BitmapUtilsUnitTests.testBytesArrayToBitmapToBytesArray: output doesn't match input"
+            "BitmapUtilsUnitTests.testBytesArrayToBitmapToBytesArray: output does not match input"
         );
     }
 
@@ -265,7 +265,7 @@ contract BitmapUtilsUnitTests_bitmapToBytesArray is BitmapUtilsUnitTests {
     function testFuzz_BitMapToBytesArrayToBitmap(uint256 originalBitmap) public {
         bytes memory bytesArray = bitmapUtilsWrapper.bitmapToBytesArray(originalBitmap);
         uint256 returnedBitMap = bitmapUtilsWrapper.bytesArrayToBitmap(bytesArray);
-        assertEq(returnedBitMap, originalBitmap, "BitmapUtilsUnitTests.testBitMapToArrayToBitmap: output doesn't match input");
+        assertEq(returnedBitMap, originalBitmap, "BitmapUtilsUnitTests.testBitMapToArrayToBitmap: output does not match input");
     }
 }
 

--- a/test/unit/BitmapUtils.t.sol
+++ b/test/unit/BitmapUtils.t.sol
@@ -31,7 +31,7 @@ contract BitmapUtilsUnitTests_bitwiseOperations is BitmapUtilsUnitTests {
     }
 
     /// @notice some simple sanity checks on the `numberIsInBitmap` function
-    function test_NumberIsInBitmap() public {
+    function test_numberIsInBitmap() public {
         assertTrue(bitmapUtilsWrapper.numberIsInBitmap(2 ** 6, 6), "numberIsInBitmap function is broken 0");
         assertTrue(bitmapUtilsWrapper.numberIsInBitmap(1, 0), "numberIsInBitmap function is broken 1");
         assertTrue(bitmapUtilsWrapper.numberIsInBitmap(255, 7), "numberIsInBitmap function is broken 2");
@@ -40,6 +40,15 @@ contract BitmapUtilsUnitTests_bitwiseOperations is BitmapUtilsUnitTests {
             assertTrue(bitmapUtilsWrapper.numberIsInBitmap(type(uint256).max, uint8(i)), "numberIsInBitmap function is broken 4");
             assertFalse(bitmapUtilsWrapper.numberIsInBitmap(0, uint8(i)), "numberIsInBitmap function is broken 5");
         }
+    }
+
+    function test_addNumberToBitmap(uint256 bitmap, uint8 numberToAdd) public {
+        // Ensure that numberToAdd isn't already in the bitmap
+        cheats.assume(bitmap | (1 << numberToAdd) != bitmap);
+        uint256 updatedBitmap = bitmapUtilsWrapper.addNumberToBitmap(bitmap, numberToAdd);
+        assertTrue(
+            bitmapUtilsWrapper.numberIsInBitmap(updatedBitmap, numberToAdd), "addNumberToBitmap function is broken"
+        );
     }
 
     function testFuzz_isEmpty(uint256 input) public {

--- a/test/unit/BitmapUtils.t.sol
+++ b/test/unit/BitmapUtils.t.sol
@@ -15,15 +15,42 @@ contract BitmapUtilsUnitTests is Test {
         bitmapUtilsWrapper = new BitmapUtilsWrapper();
     }
 
-    // ensure that the bitmap encoding of an emtpy bytes array is an emtpy bitmap (function doesn't revert and approriately returns uint256(0))
-    function testEmptyArrayEncoding() public view {
+    // @notice check for consistency of `countNumOnes` function
+    function testCountNumOnes(uint256 input) public view {
+        uint16 libraryOutput = bitmapUtilsWrapper.countNumOnes(input);
+        // run dumb routine
+        uint16 numOnes = 0;
+        for (uint256 i = 0; i < 256; ++i) {
+            if ((input >> i) & 1 == 1) {
+                ++numOnes; 
+            }
+        }
+        require(libraryOutput == numOnes, "inconsistency in countNumOnes function");
+    }
+
+    // @notice some simple sanity checks on the `numberIsInBitmap` function
+    function testNumberIsInBitmap() public view {
+        require(bitmapUtilsWrapper.numberIsInBitmap(2 ** 6, 6), "numberIsInBitmap function is broken 0");
+        require(bitmapUtilsWrapper.numberIsInBitmap(1, 0), "numberIsInBitmap function is broken 1");
+        require(bitmapUtilsWrapper.numberIsInBitmap(255, 7), "numberIsInBitmap function is broken 2");
+        require(bitmapUtilsWrapper.numberIsInBitmap(1024, 10), "numberIsInBitmap function is broken 3");
+        for (uint256 i = 0; i < 256; ++i) {
+            require(bitmapUtilsWrapper.numberIsInBitmap(type(uint256).max, uint8(i)), "numberIsInBitmap function is broken 4");
+            require(!bitmapUtilsWrapper.numberIsInBitmap(0, uint8(i)), "numberIsInBitmap function is broken 5");
+        }
+    }
+}
+
+contract BitmapUtilsUnitTests_bytesArrayToBitmap is BitmapUtilsUnitTests {
+    // ensure that the bitmap encoding of an empty bytes array is an empty bitmap (function doesn't revert and approriately returns uint256(0))
+    function test_EmptyArrayEncoding() public view {
         bytes memory emptyBytesArray;
         uint256 returnedBitMap = bitmapUtilsWrapper.bytesArrayToBitmap(emptyBytesArray);
         require(returnedBitMap == 0, "BitmapUtilsUnitTests.testEmptyArrayEncoding: empty array not encoded to empty bitmap");
     }
 
     // ensure that the bitmap encoding of a single uint8 (i.e. a single byte) matches the expected output
-    function testSingleByteEncoding(uint8 fuzzedNumber) public view {
+    function testFuzz_SingleByteEncoding(uint8 fuzzedNumber) public view {
         bytes1 singleByte = bytes1(fuzzedNumber);
         bytes memory bytesArray = abi.encodePacked(singleByte);
         uint256 returnedBitMap = bitmapUtilsWrapper.bytesArrayToBitmap(bytesArray);
@@ -32,7 +59,7 @@ contract BitmapUtilsUnitTests is Test {
     }
 
     // ensure that the bitmap encoding of a two uint8's (i.e. a two byte array) matches the expected output
-    function testTwoByteEncoding(uint8 firstFuzzedNumber, uint8 secondFuzzedNumber) public {
+    function testFuzz_TwoByteEncoding(uint8 firstFuzzedNumber, uint8 secondFuzzedNumber) public {
         bytes1 firstSingleByte = bytes1(firstFuzzedNumber);
         bytes1 secondSingleByte = bytes1(secondFuzzedNumber);
         bytes memory bytesArray = abi.encodePacked(firstSingleByte, secondSingleByte);
@@ -48,9 +75,9 @@ contract BitmapUtilsUnitTests is Test {
         }
     }
 
-    // ensure that converting bytes array => bitmap => bytes array is returns the original bytes array (i.e. is lossless and artifactless)
+    // ensure that converting bytes array => bitmap => bytes array returns the original bytes array (i.e. is lossless and artifactless)
     // note that this only works on ordered arrays, because unordered arrays will be returned ordered
-    function testBytesArrayToBitmapToBytesArray(bytes memory originalBytesArray) public view {
+    function testFuzz_BytesArrayToBitmapToBytesArray(bytes memory originalBytesArray) public view {
         // filter down to only ordered inputs
         cheats.assume(bitmapUtilsWrapper.isArrayStrictlyAscendingOrdered(originalBytesArray));
         uint256 bitmap = bitmapUtilsWrapper.bytesArrayToBitmap(originalBytesArray);
@@ -96,13 +123,6 @@ contract BitmapUtilsUnitTests is Test {
         bytes memory returnedBytesArray = bitmapUtilsWrapper.bitmapToBytesArray(bitmap);
         require(keccak256(abi.encodePacked(originalBytesArray)) == keccak256(abi.encodePacked(returnedBytesArray)),
             "BitmapUtilsUnitTests.testBytesArrayToBitmapToBytesArray: output doesn't match input");
-    }
-
-    // ensure that converting bitmap => bytes array => bitmap is returns the original bitmap (i.e. is lossless and artifactless)
-    function testBitMapToBytesArrayToBitmap(uint256 originalBitmap) public view {
-        bytes memory bytesArray = bitmapUtilsWrapper.bitmapToBytesArray(originalBitmap);
-        uint256 returnedBitMap = bitmapUtilsWrapper.bytesArrayToBitmap(bytesArray);
-        require(returnedBitMap == originalBitmap, "BitmapUtilsUnitTests.testBitMapToArrayToBitmap: output doesn't match input");
     }
 
     // testing one function for a specific input. used for comparing gas costs
@@ -152,29 +172,37 @@ contract BitmapUtilsUnitTests is Test {
         uint256 gasSpent = gasLeftBefore - gasLeftAfter;
         emit log_named_uint("gasSpent", gasSpent);
     }
+}
 
-    // @notice check for consistency of `countNumOnes` function
-    function testCountNumOnes(uint256 input) public view {
-        uint16 libraryOutput = bitmapUtilsWrapper.countNumOnes(input);
-        // run dumb routine
-        uint16 numOnes = 0;
-        for (uint256 i = 0; i < 256; ++i) {
-            if ((input >> i) & 1 == 1) {
-                ++numOnes; 
-            }
-        }
-        require(libraryOutput == numOnes, "inconsistency in countNumOnes function");
+contract BitmapUtilsUnitTests_bitmapToBytesArray is BitmapUtilsUnitTests {
+    // ensure that converting bitmap => bytes array => bitmap is returns the original bitmap (i.e. is lossless and artifactless)
+    function testBitMapToBytesArrayToBitmap(uint256 originalBitmap) public view {
+        bytes memory bytesArray = bitmapUtilsWrapper.bitmapToBytesArray(originalBitmap);
+        uint256 returnedBitMap = bitmapUtilsWrapper.bytesArrayToBitmap(bytesArray);
+        require(returnedBitMap == originalBitmap, "BitmapUtilsUnitTests.testBitMapToArrayToBitmap: output doesn't match input");
     }
+}
 
-    // @notice some simple sanity checks on the `isSet` function
-    function testNumberIsInBitmap() public view {
-        require(bitmapUtilsWrapper.isSet(2 ** 6, 6), "isSet function is broken 0");
-        require(bitmapUtilsWrapper.isSet(1, 0), "isSet function is broken 1");
-        require(bitmapUtilsWrapper.isSet(255, 7), "isSet function is broken 2");
-        require(bitmapUtilsWrapper.isSet(1024, 10), "isSet function is broken 3");
-        for (uint256 i = 0; i < 256; ++i) {
-            require(bitmapUtilsWrapper.isSet(type(uint256).max, uint8(i)), "isSet function is broken 4");
-            require(!bitmapUtilsWrapper.isSet(0, uint8(i)), "isSet function is broken 5");
-        }
+contract BitmapUtilsUnitTests_isArrayStrictlyAscendingOrdered is BitmapUtilsUnitTests {
+    function test_DifferentBytesArrayOrdering() public {
+        // Descending order and duplicate element bytes arrays should return false
+        bytes memory descendingBytesArray = abi.encodePacked(
+            bytes1(uint8(12)), bytes1(uint8(11)), bytes1(uint8(10)), bytes1(uint8(9)), bytes1(uint8(8)), bytes1(uint8(7)), bytes1(uint8(6)), bytes1(uint8(5))
+        );
+        assertFalse(bitmapUtilsWrapper.isArrayStrictlyAscendingOrdered(descendingBytesArray));
+        bytes memory duplicateBytesArray = abi.encodePacked(
+            bytes1(uint8(5)), bytes1(uint8(5)), bytes1(uint8(5)), bytes1(uint8(5)), bytes1(uint8(5)), bytes1(uint8(5)), bytes1(uint8(5)), bytes1(uint8(5))
+        );
+        assertFalse(bitmapUtilsWrapper.isArrayStrictlyAscendingOrdered(duplicateBytesArray));
+        // Strictly ascending returns true
+        bytes memory ascendingBytesArray = abi.encodePacked(
+            bytes1(uint8(5)), bytes1(uint8(6)), bytes1(uint8(7)), bytes1(uint8(8)), bytes1(uint8(9)), bytes1(uint8(10)), bytes1(uint8(11)), bytes1(uint8(12))
+        );
+        assertTrue(bitmapUtilsWrapper.isArrayStrictlyAscendingOrdered(ascendingBytesArray));
+        // Empty bytes array and single element bytes array returns true
+        bytes memory emptyBytesArray;
+        assertTrue(bitmapUtilsWrapper.isArrayStrictlyAscendingOrdered(emptyBytesArray));
+        bytes memory singleBytesArray = abi.encodePacked(bytes1(uint8(1)));
+        assertTrue(bitmapUtilsWrapper.isArrayStrictlyAscendingOrdered(singleBytesArray));
     }
 }


### PR DESCRIPTION
Remove unused functions from BitmapUtils.sol, `bytesArrayToBitmap`, `orderedBytesArrayToBitmap_Yul`, `bytesArrayToBitmap_Yul`.
`bytesArrayToBitmap` is used only once in the sigchecker and replaced with `orderedBytesArrayToBitmap`, need to confirm this small change is fine in terms of gas increase and quorumNumbers ordering.
Added some additional unit tests for functions to `BitmapUtils` library.
