### PR TITLE
Chore: cleanup for compendium changes

### DIFF
--- a/src/BLSApkRegistry.sol
+++ b/src/BLSApkRegistry.sol
@@ -97,10 +97,12 @@ contract BLSApkRegistry is BLSApkRegistryStorage {
      * @notice Called by the RegistryCoordinator register an operator as the owner of a BLS public key.
      * @param operator is the operator for whom the key is being registered
      * @param params contains the G1 & G2 public keys of the operator, and a signature proving their ownership
+     * @param pubkeyRegistrationMessageHash is a hash that the operator must sign to prove key ownership
      */
     function registerBLSPublicKey(
         address operator,
-        PubkeyRegistrationParams calldata params
+        PubkeyRegistrationParams calldata params,
+        BN254.G1Point calldata pubkeyRegistrationMessageHash
     ) external onlyRegistryCoordinator returns (bytes32 operatorId) {
         bytes32 pubkeyHash = BN254.hashG1Point(params.pubkeyG1);
         require(
@@ -115,9 +117,6 @@ contract BLSApkRegistry is BLSApkRegistryStorage {
             "BLSApkRegistry.registerBLSPublicKey: public key already registered"
         );
 
-        // H(m) 
-        BN254.G1Point memory messageHash = getMessageHash(operator);
-
         // gamma = h(sigma, P, P', H(m))
         uint256 gamma = uint256(keccak256(abi.encodePacked(
             params.pubkeyRegistrationSignature.X, 
@@ -126,15 +125,15 @@ contract BLSApkRegistry is BLSApkRegistryStorage {
             params.pubkeyG1.Y, 
             params.pubkeyG2.X, 
             params.pubkeyG2.Y, 
-            messageHash.X, 
-            messageHash.Y
+            pubkeyRegistrationMessageHash.X, 
+            pubkeyRegistrationMessageHash.Y
         ))) % BN254.FR_MODULUS;
         
         // e(sigma + P * gamma, [-1]_2) = e(H(m) + [1]_1 * gamma, P') 
         require(BN254.pairing(
             params.pubkeyRegistrationSignature.plus(params.pubkeyG1.scalar_mul(gamma)),
             BN254.negGeneratorG2(),
-            messageHash.plus(BN254.generatorG1().scalar_mul(gamma)),
+            pubkeyRegistrationMessageHash.plus(BN254.generatorG1().scalar_mul(gamma)),
             params.pubkeyG2
         ), "BLSApkRegistry.registerBLSPublicKey: either the G1 signature is wrong, or G1 and G2 private key do not match");
 
@@ -213,19 +212,6 @@ contract BLSApkRegistry is BLSApkRegistryStorage {
         );
         
         return (pubkey, pubkeyHash);
-    }
-
-    /**
-     * @notice Returns the message hash that an operator must sign to register their BLS public key.
-     * @param operator is the address of the operator registering their BLS public key
-     */
-    function getMessageHash(address operator) public view returns (BN254.G1Point memory) {
-        return BN254.hashToG1(keccak256(abi.encodePacked(
-            operator, 
-            address(this),
-            block.chainid, 
-            "EigenLayer_BN254_Pubkey_Registration"
-        )));
     }
 
     /**

--- a/src/BLSApkRegistry.sol
+++ b/src/BLSApkRegistry.sol
@@ -280,6 +280,8 @@ contract BLSApkRegistry is BLSApkRegistryStorage {
         return pubkeyHashToOperator[pubkeyHash];
     }
 
+    /// @notice returns the ID used to identify the `operator` within this AVS
+    /// @dev Returns zero in the event that the `operator` has never registered for the AVS
     function getOperatorId(address operator) public view returns (bytes32) {
         return operatorToPubkeyHash[operator];
     }

--- a/src/interfaces/IBLSApkRegistry.sol
+++ b/src/interfaces/IBLSApkRegistry.sol
@@ -99,10 +99,12 @@ interface IBLSApkRegistry is IRegistry {
      * @notice Called by the RegistryCoordinator register an operator as the owner of a BLS public key.
      * @param operator is the operator for whom the key is being registered
      * @param params contains the G1 & G2 public keys of the operator, and a signature proving their ownership
+     * @param pubkeyRegistrationMessageHash is a hash that the operator must sign to prove key ownership
      */
     function registerBLSPublicKey(
         address operator,
-        PubkeyRegistrationParams calldata params
+        PubkeyRegistrationParams calldata params,
+        BN254.G1Point calldata pubkeyRegistrationMessageHash
     ) external returns (bytes32 operatorId);
 
     /**
@@ -110,12 +112,6 @@ interface IBLSApkRegistry is IRegistry {
      * @dev Reverts if the operator has not registered a valid pubkey
      */
     function getRegisteredPubkey(address operator) external view returns (BN254.G1Point memory, bytes32);
-
-    /**
-     * @notice Returns the message hash that an operator must sign to register their BLS public key.
-     * @param operator is the address of the operator registering their BLS public key
-     */
-    function getMessageHash(address operator) external view returns (BN254.G1Point memory);
 
     /// @notice Returns the current APK for the provided `quorumNumber `
     function getApk(uint8 quorumNumber) external view returns (BN254.G1Point memory);

--- a/src/interfaces/IBLSApkRegistry.sol
+++ b/src/interfaces/IBLSApkRegistry.sol
@@ -134,5 +134,7 @@ interface IBLSApkRegistry is IRegistry {
      */
     function getApkHashAtBlockNumberAndIndex(uint8 quorumNumber, uint32 blockNumber, uint256 index) external view returns (bytes24);
 
+    /// @notice returns the ID used to identify the `operator` within this AVS.
+    /// @dev Returns zero in the event that the `operator` has never registered for the AVS
     function getOperatorId(address operator) external view returns (bytes32);
 }

--- a/src/interfaces/IRegistryCoordinator.sol
+++ b/src/interfaces/IRegistryCoordinator.sol
@@ -4,6 +4,7 @@ pragma solidity =0.8.12;
 import {IBLSApkRegistry} from "src/interfaces/IBLSApkRegistry.sol";
 import {IStakeRegistry} from "src/interfaces/IStakeRegistry.sol";
 import {IIndexRegistry} from "src/interfaces/IIndexRegistry.sol";
+import {BN254} from "src/libraries/BN254.sol";
 
 /**
  * @title Interface for a contract that coordinates between various registries for an AVS.
@@ -134,4 +135,10 @@ interface IRegistryCoordinator {
 
     /// @notice Returns the number of registries
     function numRegistries() external view returns (uint256);
+
+    /**
+     * @notice Returns the message hash that an operator must sign to register their BLS public key.
+     * @param operator is the address of the operator registering their BLS public key
+     */
+    function pubkeyRegistrationMessageHash(address operator) external view returns (BN254.G1Point memory);
 }

--- a/test/ffi/BLSPubKeyCompendiumFFI.t.sol
+++ b/test/ffi/BLSPubKeyCompendiumFFI.t.sol
@@ -30,7 +30,7 @@ contract BLSApkRegistryFFITests is G2Operations {
         pubkeyRegistrationParams.pubkeyRegistrationSignature = _signMessage(alice);
 
         vm.prank(address(registryCoordinator));
-        blsApkRegistry.registerBLSPublicKey(alice, pubkeyRegistrationParams);
+        blsApkRegistry.registerBLSPublicKey(alice, pubkeyRegistrationParams, registryCoordinator.pubkeyRegistrationMessageHash(alice));
 
         assertEq(blsApkRegistry.operatorToPubkeyHash(alice), BN254.hashG1Point(pubkeyRegistrationParams.pubkeyG1),
             "pubkey hash not stored correctly");
@@ -45,7 +45,7 @@ contract BLSApkRegistryFFITests is G2Operations {
     }
 
     function _signMessage(address signer) internal view returns(BN254.G1Point memory) {
-        BN254.G1Point memory messageHash = blsApkRegistry.getMessageHash(signer);
+        BN254.G1Point memory messageHash = registryCoordinator.pubkeyRegistrationMessageHash(signer);
         return BN254.scalar_mul(messageHash, privKey);
     }
 }

--- a/test/mocks/RegistryCoordinatorMock.sol
+++ b/test/mocks/RegistryCoordinatorMock.sol
@@ -58,4 +58,10 @@ contract RegistryCoordinatorMock is IRegistryCoordinator {
     function registerOperator(bytes memory quorumNumbers, bytes calldata) external {}
 
     function deregisterOperator(bytes calldata quorumNumbers, bytes calldata) external {}
+
+    function pubkeyRegistrationMessageHash(address operator) public view returns (BN254.G1Point memory) {
+        return BN254.hashToG1(
+                keccak256(abi.encode(operator))
+        );
+    }
 }


### PR DESCRIPTION
Aimed at addressing the last couple TODOs in https://github.com/Layr-Labs/eigenlayer-middleware/pull/97
I pulled these changes out into a separate PR because review has already been done on the existing changes in that PR / I think they are quite well-contained.
I initially thought I'd want to do more renaming, but I think the primary commit here -- https://github.com/Layr-Labs/eigenlayer-middleware/commit/630b27d394191b89d6c88e7a1b8dda07750a31db -- takes care of the worst offender, and I'm not strongly opinionated enough to fight for other naming changes right now.