### PR TITLE
fix: address multiple issues in BLSSignatureChecker, optimize, and clean

### DIFF
--- a/src/BLSApkRegistry.sol
+++ b/src/BLSApkRegistry.sol
@@ -254,7 +254,6 @@ contract BLSApkRegistry is BLSApkRegistryStorage {
          * - blockNumber should be >= the update block number
          * - the next update block number should be either 0 or strictly greater than blockNumber
          */
-        // TODO - should this fail if quorumApkUpdate.apkHash == 0? This will be the case for the first entry in each quorum
         require(
             blockNumber >= quorumApkUpdate.updateBlockNumber,
             "BLSApkRegistry._validateApkHashAtBlockNumber: index too recent"

--- a/src/BLSSignatureChecker.sol
+++ b/src/BLSSignatureChecker.sol
@@ -178,11 +178,12 @@ contract BLSSignatureChecker is IBLSSignatureChecker {
          */
         {
             uint256 withdrawalDelayBlocks = delegation.withdrawalDelayBlocks();
+            bool _staleStakesForbidden = staleStakesForbidden;
 
             for (uint256 i = 0; i < quorumNumbers.length; i++) {
                 // If we're disallowing stale stake updates, check that each quorum's last update block
                 // is within withdrawalDelayBlocks
-                if (staleStakesForbidden) {
+                if (_staleStakesForbidden) {
                     require(
                         registryCoordinator.quorumUpdateBlockNumber(uint8(quorumNumbers[i])) + withdrawalDelayBlocks >= referenceBlockNumber,
                         "BLSSignatureChecker.checkSignatures: StakeRegistry updates must be within withdrawalDelayBlocks window"

--- a/src/BLSSignatureChecker.sol
+++ b/src/BLSSignatureChecker.sol
@@ -95,7 +95,7 @@ contract BLSSignatureChecker is IBLSSignatureChecker {
         for (uint i = 0; i < quorumNumbers.length; i++) {
             if (staleStakesForbidden) {
                 require(
-                    registryCoordinator.quorumUpdateBlockNumber(uint8(quorumNumbers[i])) + delegation.withdrawalDelayBlocks() <= block.number,
+                    registryCoordinator.quorumUpdateBlockNumber(uint8(quorumNumbers[i])) + delegation.withdrawalDelayBlocks() >= block.number,
                     "BLSSignatureChecker.checkSignatures: StakeRegistry updates must be within withdrawalDelayBlocks window"
                 );
             }

--- a/src/BLSSignatureChecker.sol
+++ b/src/BLSSignatureChecker.sol
@@ -107,6 +107,8 @@ contract BLSSignatureChecker is IBLSSignatureChecker {
             "BLSSignatureChecker.checkSignatures: input nonsigner length mismatch"
         );
 
+        require(referenceBlockNumber <= uint32(block.number), "BLSSignatureChecker.checkSignatures: invalid reference block");
+
         // This method needs to calculate the aggregate pubkey for all signing operators across
         // all signing quorums. To do that, we can query the aggregate pubkey for each quorum
         // and subtract out the pubkey for each nonsigning operator registered to that quorum.
@@ -182,7 +184,7 @@ contract BLSSignatureChecker is IBLSSignatureChecker {
                 // is within withdrawalDelayBlocks
                 if (staleStakesForbidden) {
                     require(
-                        registryCoordinator.quorumUpdateBlockNumber(uint8(quorumNumbers[i])) + withdrawalDelayBlocks >= block.number,
+                        registryCoordinator.quorumUpdateBlockNumber(uint8(quorumNumbers[i])) + withdrawalDelayBlocks >= referenceBlockNumber,
                         "BLSSignatureChecker.checkSignatures: StakeRegistry updates must be within withdrawalDelayBlocks window"
                     );
                 }

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -812,7 +812,6 @@ contract RegistryCoordinator is
          * - blockNumber should be >= the update block number
          * - the next update block number should be either 0 or strictly greater than blockNumber
          */
-        // TODO - should this fail if quorumBitmapUpdate.quorumBitmap == 0? This will be the case for the first entry in each quorum
         require(
             blockNumber >= quorumBitmapUpdate.updateBlockNumber, 
             "RegistryCoordinator.getQuorumBitmapAtBlockNumberByIndex: quorumBitmapUpdate is from after blockNumber"

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -806,16 +806,22 @@ contract RegistryCoordinator is
         uint256 index
     ) external view returns (uint192) {
         QuorumBitmapUpdate memory quorumBitmapUpdate = _operatorBitmapHistory[operatorId][index];
+        
+        /**
+         * Validate that the update is valid for the given blockNumber:
+         * - blockNumber should be >= the update block number
+         * - the next update block number should be either 0 or strictly greater than blockNumber
+         */
+        // TODO - should this fail if quorumBitmapUpdate.quorumBitmap == 0? This will be the case for the first entry in each quorum
         require(
-            quorumBitmapUpdate.updateBlockNumber <= blockNumber, 
+            blockNumber >= quorumBitmapUpdate.updateBlockNumber, 
             "RegistryCoordinator.getQuorumBitmapAtBlockNumberByIndex: quorumBitmapUpdate is from after blockNumber"
         );
-        // if the next update is at or before the block number, then the quorum provided index is too early
-        // if the nex update  block number is 0, then this is the latest update
         require(
-            quorumBitmapUpdate.nextUpdateBlockNumber > blockNumber || quorumBitmapUpdate.nextUpdateBlockNumber == 0, 
+            quorumBitmapUpdate.nextUpdateBlockNumber == 0 || blockNumber < quorumBitmapUpdate.nextUpdateBlockNumber,
             "RegistryCoordinator.getQuorumBitmapAtBlockNumberByIndex: quorumBitmapUpdate is from before blockNumber"
         );
+
         return quorumBitmapUpdate.quorumBitmap;
     }
 

--- a/src/StakeRegistry.sol
+++ b/src/StakeRegistry.sol
@@ -449,7 +449,6 @@ contract StakeRegistry is StakeRegistryStorage {
          * - blockNumber should be >= the update block number
          * - the next update block number should be either 0 or strictly greater than blockNumber
          */
-        // TODO - should this fail if operatorStakeUpdate.stake == 0? This will be the case for the first entry in each quorum
         require(
             blockNumber >= operatorStakeUpdate.updateBlockNumber,
             "StakeRegistry._validateOperatorStakeAtBlockNumber: operatorStakeUpdate is from after blockNumber"

--- a/src/StakeRegistry.sol
+++ b/src/StakeRegistry.sol
@@ -444,12 +444,18 @@ contract StakeRegistry is StakeRegistryStorage {
         StakeUpdate memory operatorStakeUpdate,
         uint32 blockNumber
     ) internal pure {
+        /**
+         * Validate that the update is valid for the given blockNumber:
+         * - blockNumber should be >= the update block number
+         * - the next update block number should be either 0 or strictly greater than blockNumber
+         */
+        // TODO - should this fail if operatorStakeUpdate.stake == 0? This will be the case for the first entry in each quorum
         require(
-            operatorStakeUpdate.updateBlockNumber <= blockNumber,
+            blockNumber >= operatorStakeUpdate.updateBlockNumber,
             "StakeRegistry._validateOperatorStakeAtBlockNumber: operatorStakeUpdate is from after blockNumber"
         );
         require(
-            operatorStakeUpdate.nextUpdateBlockNumber == 0 || operatorStakeUpdate.nextUpdateBlockNumber > blockNumber,
+            operatorStakeUpdate.nextUpdateBlockNumber == 0 || blockNumber < operatorStakeUpdate.nextUpdateBlockNumber,
             "StakeRegistry._validateOperatorStakeAtBlockNumber: there is a newer operatorStakeUpdate available before blockNumber"
         );
     }

--- a/src/libraries/BN254.sol
+++ b/src/libraries/BN254.sol
@@ -268,10 +268,14 @@ library BN254 {
         return (success, out[0] != 0);
     }
 
-    /// @return the keccak256 hash of the G1 Point
+    /// @return hashedG1 the keccak256 hash of the G1 Point
     /// @dev used for BLS signatures
-    function hashG1Point(BN254.G1Point memory pk) internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked(pk.X, pk.Y));
+    function hashG1Point(BN254.G1Point memory pk) internal pure returns (bytes32 hashedG1) {
+        assembly {
+            mstore(0, mload(pk))
+            mstore(0x20, mload(add(0x20, pk)))
+            hashedG1 := keccak256(0, 0x40)
+        }
     }
 
     /// @return the keccak256 hash of the G2 Point

--- a/src/libraries/BN254.sol
+++ b/src/libraries/BN254.sol
@@ -141,7 +141,7 @@ library BN254 {
         uint8 i = 0;
 
         //loop until we reach the most significant bit
-        while(s > m){
+        while(s >= m){
             unchecked {
                 // if the  current bit is 1, add the 2^n*p to the accumulated product
                 if ((s >> i) & 1 == 1) {

--- a/test/mocks/DelegationMock.sol
+++ b/test/mocks/DelegationMock.sol
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {IDelegationManager} from "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
+import {IStrategyManager} from "eigenlayer-contracts/src/contracts/interfaces/IStrategyManager.sol";
+import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
+import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
+
+contract DelegationMock is IDelegationManager {
+    mapping(address => bool) public isOperator;
+    mapping(address => mapping(IStrategy => uint256)) public operatorShares;
+
+    function setIsOperator(address operator, bool _isOperatorReturnValue) external {
+        isOperator[operator] = _isOperatorReturnValue;
+    }
+
+    /// @notice returns the total number of shares in `strategy` that are delegated to `operator`.
+    function setOperatorShares(address operator, IStrategy strategy, uint256 shares) external {
+        operatorShares[operator][strategy] = shares;
+    }
+
+    mapping (address => address) public delegatedTo;
+
+    function registerAsOperator(OperatorDetails calldata /*registeringOperatorDetails*/, string calldata /*metadataURI*/) external pure {}
+    
+    function updateOperatorMetadataURI(string calldata /*metadataURI*/) external pure {}
+
+    function updateAVSMetadataURI(string calldata /*metadataURI*/) external pure {}
+
+    function delegateTo(address operator, SignatureWithExpiry memory /*approverSignatureAndExpiry*/, bytes32 /*approverSalt*/) external {
+        delegatedTo[msg.sender] = operator;
+    }
+
+    function modifyOperatorDetails(OperatorDetails calldata /*newOperatorDetails*/) external pure {}
+
+    function delegateToBySignature(
+        address /*staker*/,
+        address /*operator*/,
+        SignatureWithExpiry memory /*stakerSignatureAndExpiry*/,
+        SignatureWithExpiry memory /*approverSignatureAndExpiry*/,
+        bytes32 /*approverSalt*/
+    ) external pure {}
+
+    function undelegate(address staker) external returns (bytes32 withdrawalRoot) {
+        delegatedTo[staker] = address(0);
+        return withdrawalRoot;
+    }
+
+    function increaseDelegatedShares(address /*staker*/, IStrategy /*strategy*/, uint256 /*shares*/) external pure {}
+
+    function decreaseDelegatedShares(
+        address /*staker*/,
+        IStrategy /*strategy*/,
+        uint256 /*shares*/
+    ) external pure {}
+
+    function operatorDetails(address operator) external pure returns (OperatorDetails memory) {
+        OperatorDetails memory returnValue = OperatorDetails({
+            earningsReceiver: operator,
+            delegationApprover: operator,
+            stakerOptOutWindowBlocks: 0
+        });
+        return returnValue;
+    }
+
+    function earningsReceiver(address operator) external pure returns (address) {
+        return operator;
+    }
+
+    function delegationApprover(address operator) external pure returns (address) {
+        return operator;
+    }
+
+    function stakerOptOutWindowBlocks(address /*operator*/) external pure returns (uint256) {
+        return 0;
+    }
+
+    function withdrawalDelayBlocks() external pure returns (uint256) {
+        return 50400;
+    }
+
+    function isDelegated(address staker) external view returns (bool) {
+        return (delegatedTo[staker] != address(0));
+    }
+
+    function isNotDelegated(address /*staker*/) external pure returns (bool) {}
+
+    // function isOperator(address /*operator*/) external pure returns (bool) {}
+
+    function stakerNonce(address /*staker*/) external pure returns (uint256) {}
+
+    function delegationApproverSaltIsSpent(address /*delegationApprover*/, bytes32 /*salt*/) external pure returns (bool) {}
+
+    function calculateCurrentStakerDelegationDigestHash(address /*staker*/, address /*operator*/, uint256 /*expiry*/) external view returns (bytes32) {}
+
+    function calculateStakerDelegationDigestHash(address /*staker*/, uint256 /*stakerNonce*/, address /*operator*/, uint256 /*expiry*/) external view returns (bytes32) {}
+
+    function calculateDelegationApprovalDigestHash(
+        address /*staker*/,
+        address /*operator*/,
+        address /*_delegationApprover*/,
+        bytes32 /*approverSalt*/,
+        uint256 /*expiry*/
+    ) external view returns (bytes32) {}
+
+    function calculateStakerDigestHash(address /*staker*/, address /*operator*/, uint256 /*expiry*/)
+        external pure returns (bytes32 stakerDigestHash) {}
+
+    function calculateApproverDigestHash(address /*staker*/, address /*operator*/, uint256 /*expiry*/)
+        external pure returns (bytes32 approverDigestHash) {}
+
+    function calculateOperatorAVSRegistrationDigestHash(address /*operator*/, address /*avs*/, bytes32 /*salt*/, uint256 /*expiry*/)
+        external pure returns (bytes32 digestHash) {}
+
+    function DOMAIN_TYPEHASH() external view returns (bytes32) {}
+
+    function STAKER_DELEGATION_TYPEHASH() external view returns (bytes32) {}
+
+    function DELEGATION_APPROVAL_TYPEHASH() external view returns (bytes32) {}
+
+    function OPERATOR_AVS_REGISTRATION_TYPEHASH() external view returns (bytes32) {}
+
+    function domainSeparator() external view returns (bytes32) {}
+
+    function cumulativeWithdrawalsQueued(address staker) external view returns (uint256) {}
+
+    function calculateWithdrawalRoot(Withdrawal memory withdrawal) external pure returns (bytes32) {}
+
+    function registerOperatorToAVS(address operator, ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature) external {}
+
+    function deregisterOperatorFromAVS(address operator) external {}
+
+    function operatorSaltIsSpent(address avs, bytes32 salt) external view returns (bool) {}
+
+   function queueWithdrawals(
+        QueuedWithdrawalParams[] calldata queuedWithdrawalParams
+    ) external returns (bytes32[] memory) {}
+
+    function completeQueuedWithdrawal(
+        Withdrawal calldata withdrawal,
+        IERC20[] calldata tokens,
+        uint256 middlewareTimesIndex,
+        bool receiveAsTokens
+    ) external {}
+
+    function completeQueuedWithdrawals(
+        Withdrawal[] calldata withdrawals,
+        IERC20[][] calldata tokens,
+        uint256[] calldata middlewareTimesIndexes,
+        bool[] calldata receiveAsTokens
+    ) external {}
+
+    function migrateQueuedWithdrawals(IStrategyManager.DeprecatedStruct_QueuedWithdrawal[] memory withdrawalsToQueue) external {}
+    
+    // onlyDelegationManager functions in StrategyManager
+    function addShares(
+        IStrategyManager strategyManager,
+        address staker,
+        IStrategy strategy,
+        uint256 shares
+    ) external {
+        strategyManager.addShares(staker, strategy, shares);
+    }
+
+    function removeShares(
+        IStrategyManager strategyManager,
+        address staker,
+        IStrategy strategy,
+        uint256 shares
+    ) external {
+        strategyManager.removeShares(staker, strategy, shares);
+    }
+
+    function withdrawSharesAsTokens(
+        IStrategyManager strategyManager,
+        address recipient,
+        IStrategy strategy,
+        uint256 shares,
+        IERC20 token
+    ) external {
+        strategyManager.withdrawSharesAsTokens(recipient, strategy, shares, token);
+    }
+}

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -26,7 +26,7 @@ import {IRegistryCoordinator} from "src/interfaces/IRegistryCoordinator.sol";
 
 import {StrategyManagerMock} from "eigenlayer-contracts/src/test/mocks/StrategyManagerMock.sol";
 import {EigenPodManagerMock} from "eigenlayer-contracts/src/test/mocks/EigenPodManagerMock.sol";
-import {DelegationManagerMock} from "eigenlayer-contracts/src/test/mocks/DelegationManagerMock.sol";
+import {DelegationMock} from "test/mocks/DelegationMock.sol";
 import {BLSApkRegistryHarness} from "test/harnesses/BLSApkRegistryHarness.sol";
 import {EmptyContract} from "eigenlayer-contracts/src/test/mocks/EmptyContract.sol";
 
@@ -59,7 +59,7 @@ contract MockAVSDeployer is Test {
     IIndexRegistry public indexRegistry;
 
     StrategyManagerMock public strategyManagerMock;
-    DelegationManagerMock public delegationMock;
+    DelegationMock public delegationMock;
     EigenPodManagerMock public eigenPodManagerMock;
 
     address public proxyAdminOwner = address(uint160(uint256(keccak256("proxyAdminOwner"))));
@@ -120,7 +120,7 @@ contract MockAVSDeployer is Test {
         pausers[0] = pauser;
         pauserRegistry = new PauserRegistry(pausers, unpauser);
 
-        delegationMock = new DelegationManagerMock();
+        delegationMock = new DelegationMock();
         eigenPodManagerMock = new EigenPodManagerMock();
         strategyManagerMock = new StrategyManagerMock();
         slasherImplementation = new Slasher(strategyManagerMock, delegationMock);


### PR DESCRIPTION
Fixes:
- swap sign on withdrawal delay check
- adjust withdrawal delay check so that it checks against `referenceBlockNumber` rather than `block.number`
- add fix for `BN254.scalar_mul_tiny` from #76 

Other changes:
- comments, clarity, and renaming
- adds input validation for all parameters
- cache state to avoid lookups in loop
- remove an uneeded loop from checkSignatures
- only negate pubkeys a single time, rather than each time a nonsigner pk is added