### PR TITLE
feat: concentrate eigenlayer avs interactions into service manager

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,6 +7,6 @@ fs_permissions = [{ access = "read-write", path = "./" }]
 ffi = true
 
 # The number of optimizer runs
-optimizer_runs = 100
+optimizer_runs = 200
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/src/ServiceManagerBase.sol
+++ b/src/ServiceManagerBase.sol
@@ -3,11 +3,13 @@ pragma solidity =0.8.12;
 
 import {OwnableUpgradeable} from "@openzeppelin-upgrades/contracts/access/OwnableUpgradeable.sol";
 
+import {BitmapUtils} from "src/libraries/BitmapUtils.sol"; 
 import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
 import {IDelegationManager} from "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
 
 import {IServiceManager} from "src/interfaces/IServiceManager.sol";
 import {IRegistryCoordinator} from "src/interfaces/IRegistryCoordinator.sol";
+import {IStakeRegistry} from "src/interfaces/IStakeRegistry.sol";
 
 /**
  * @title Minimal implementation of a ServiceManager-type contract.
@@ -15,8 +17,11 @@ import {IRegistryCoordinator} from "src/interfaces/IRegistryCoordinator.sol";
  * @author Layr Labs, Inc.
  */
 contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
-    address immutable registryCoordinator;
+    using BitmapUtils for *;
+
+    IRegistryCoordinator immutable registryCoordinator;
     IDelegationManager immutable delegationManager;
+    IStakeRegistry immutable stakeRegistry;
 
     /// @notice when applied to a function, only allows the RegistryCoordinator to call it
     modifier onlyRegistryCoordinator() {
@@ -30,10 +35,12 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
     /// @notice Sets the (immutable) `registryCoordinator` address
     constructor(
         IDelegationManager _delegationManager,
-        IRegistryCoordinator _registryCoordinator
+        IRegistryCoordinator _registryCoordinator,
+        IStakeRegistry _stakeRegistry
     ) {
         delegationManager = _delegationManager;
-        registryCoordinator = address(_registryCoordinator);
+        registryCoordinator = _registryCoordinator;
+        stakeRegistry = _stakeRegistry;
         _disableInitializers();
     }
 
@@ -68,5 +75,41 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
      */
     function deregisterOperatorFromAVS(address operator) public virtual onlyRegistryCoordinator {
         delegationManager.deregisterOperatorFromAVS(operator);
+    }
+
+    /**
+     * @notice Returns the list of strategies that the operator has potentially restaked on the AVS
+     * @param operator The address of the operator to get restaked strategies for
+     * @dev This function is intended to be called off-chain
+     * @dev No guarantee is made on whether the operator has shares for a strategy in a quorum or uniqueness 
+     *      of each element in the returned array. The off-chain service should do that validation separately
+     */
+    function getOperatorRestakedStrategies(address operator) external view returns (address[] memory) {
+        bytes32 operatorId = registryCoordinator.getOperatorId(operator);
+        uint192 operatorBitmap = registryCoordinator.getCurrentQuorumBitmap(operatorId);
+
+        if (operatorBitmap == 0 || registryCoordinator.quorumCount() == 0) {
+            return new address[](0);
+        }
+
+        // Get number of strategies for each quorum in operator bitmap
+        bytes memory operatorRestakedQuorums = BitmapUtils.bitmapToBytesArray(operatorBitmap);
+        uint256 strategyCount;
+        for(uint256 i = 0; i < operatorRestakedQuorums.length; i++) {
+            strategyCount += stakeRegistry.strategyParamsLength(uint8(operatorRestakedQuorums[i]));
+        }
+
+        // Get strategies for each quorum in operator bitmap
+        address[] memory restakedStrategies = new address[](strategyCount);
+        uint256 index = 0;
+        for(uint256 i = 0; i < operatorRestakedQuorums.length; i++) {
+            uint8 quorum = uint8(operatorRestakedQuorums[i]);
+            uint256 strategyParamsLength = stakeRegistry.strategyParamsLength(quorum);
+            for (uint256 j = 0; j < strategyParamsLength; j++) {
+                restakedStrategies[index] = address(stakeRegistry.strategyParamsByIndex(quorum, j).strategy);
+                index++;
+            }
+        }
+        return restakedStrategies;        
     }
 }

--- a/src/ServiceManagerBase.sol
+++ b/src/ServiceManagerBase.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import {OwnableUpgradeable} from "@openzeppelin-upgrades/contracts/access/OwnableUpgradeable.sol";
+
+import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
+import {IDelegationManager} from "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
+
+import {IServiceManager} from "src/interfaces/IServiceManager.sol";
+import {IRegistryCoordinator} from "src/interfaces/IRegistryCoordinator.sol";
+
+/**
+ * @title Minimal implementation of a ServiceManager-type contract.
+ * This contract can inherited from or simply used as a point-of-reference.
+ * @author Layr Labs, Inc.
+ */
+contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
+    address immutable registryCoordinator;
+    IDelegationManager immutable delegationManager;
+
+    /// @notice when applied to a function, only allows the RegistryCoordinator to call it
+    modifier onlyRegistryCoordinator() {
+        require(
+            msg.sender == address(registryCoordinator),
+            "ServiceManagerBase.onlyRegistryCoordinator: caller is not the registry coordinator"
+        );
+        _;
+    }
+
+    /// @notice Sets the (immutable) `registryCoordinator` address
+    constructor(
+        IDelegationManager _delegationManager,
+        IRegistryCoordinator _registryCoordinator
+    ) {
+        delegationManager = _delegationManager;
+        registryCoordinator = address(_registryCoordinator);
+        _disableInitializers();
+    }
+
+
+    /**
+     * @notice Sets the metadata URI for the AVS
+     * @param _metadataURI is the metadata URI for the AVS
+     * @dev only callable by the owner
+     */
+    function setMetadataURI(string memory _metadataURI) public virtual onlyOwner {
+        delegationManager.updateAVSMetadataURI(_metadataURI);
+    }
+
+    /**
+     * @notice Forwards a call to EigenLayer's DelegationManager contract to confirm operator registration with the AVS
+     * @param operator The address of the operator to register.
+     * @param operatorSignature The signature, salt, and expiry of the operator's signature.
+     */
+    function registerOperatorToAVS(
+        address operator,
+        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
+    ) public virtual onlyOwner {
+        delegationManager.registerOperatorToAVS(operator, operatorSignature);
+    }
+
+    /**
+     * @notice Forwards a call to EigenLayer's DelegationManager contract to confirm operator deregistration from the AVS
+     * @param operator The address of the operator to deregister.
+     */
+    function deregisterOperatorFromAVS(address operator) public virtual onlyOwner {
+        delegationManager.deregisterOperatorFromAVS(operator);
+    }
+}

--- a/src/ServiceManagerBase.sol
+++ b/src/ServiceManagerBase.sol
@@ -37,6 +37,9 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
         _disableInitializers();
     }
 
+    function initialize(address initialOwner) external initializer {
+        _transferOwnership(initialOwner);
+    }
 
     /**
      * @notice Sets the metadata URI for the AVS
@@ -55,7 +58,7 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
     function registerOperatorToAVS(
         address operator,
         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
-    ) public virtual onlyOwner {
+    ) public virtual onlyRegistryCoordinator {
         delegationManager.registerOperatorToAVS(operator, operatorSignature);
     }
 
@@ -63,7 +66,7 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
      * @notice Forwards a call to EigenLayer's DelegationManager contract to confirm operator deregistration from the AVS
      * @param operator The address of the operator to deregister.
      */
-    function deregisterOperatorFromAVS(address operator) public virtual onlyOwner {
+    function deregisterOperatorFromAVS(address operator) public virtual onlyRegistryCoordinator {
         delegationManager.deregisterOperatorFromAVS(operator);
     }
 }

--- a/src/StakeRegistry.sol
+++ b/src/StakeRegistry.sol
@@ -516,7 +516,7 @@ contract StakeRegistry is StakeRegistryStorage {
     ) public view returns (StrategyParams memory)
     {
         return strategyParams[quorumNumber][index];
-    } 
+    }
 
     /*******************************************************************************
                       VIEW FUNCTIONS - Operator Stake History

--- a/src/interfaces/IServiceManager.sol
+++ b/src/interfaces/IServiceManager.sol
@@ -10,6 +10,12 @@ import {IDelegationManager} from "eigenlayer-contracts/src/contracts/interfaces/
  */
 interface IServiceManager {
     /**
+     * @notice Sets the metadata URI for the AVS
+     * @param _metadataURI is the metadata URI for the AVS
+     */
+    function setMetadataURI(string memory _metadataURI) external;
+
+    /**
      * @notice Forwards a call to EigenLayer's DelegationManager contract to confirm operator registration with the AVS
      * @param operator The address of the operator to register.
      * @param operatorSignature The signature, salt, and expiry of the operator's signature.

--- a/src/interfaces/IServiceManager.sol
+++ b/src/interfaces/IServiceManager.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.5.0;
+
+import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
+import {IDelegationManager} from "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
+
+/**
+ * @title Minimal interface for a ServiceManager-type contract that forms the single point for an AVS to push updates to EigenLayer
+ * @author Layr Labs, Inc.
+ */
+interface IServiceManager {
+    /**
+     * @notice Forwards a call to EigenLayer's DelegationManager contract to confirm operator registration with the AVS
+     * @param operator The address of the operator to register.
+     * @param operatorSignature The signature, salt, and expiry of the operator's signature.
+     */
+    function registerOperatorToAVS(
+        address operator,
+        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
+    ) external;
+
+    /**
+     * @notice Forwards a call to EigenLayer's DelegationManager contract to confirm operator deregistration from the AVS
+     * @param operator The address of the operator to deregister.
+     */
+    function deregisterOperatorFromAVS(address operator) external;
+}

--- a/src/interfaces/IServiceManager.sol
+++ b/src/interfaces/IServiceManager.sol
@@ -30,4 +30,13 @@ interface IServiceManager {
      * @param operator The address of the operator to deregister.
      */
     function deregisterOperatorFromAVS(address operator) external;
+
+    /**
+     * @notice Returns the list of strategies that the operator has potentially restaked on the AVS
+     * @param operator The address of the operator to get restaked strategies for
+     * @dev This function is intended to be called off-chain
+     * @dev No guarantee is made on whether the operator has shares for a strategy in a quorum or uniqueness 
+     *      of each element in the returned array. The off-chain service should do that validation separately
+     */
+    function getOperatorRestakedStrategies(address operator) external view returns (address[] memory);
 }

--- a/test/harnesses/RegistryCoordinatorHarness.t.sol
+++ b/test/harnesses/RegistryCoordinatorHarness.t.sol
@@ -8,12 +8,11 @@ import "forge-std/Test.sol";
 // wrapper around the RegistryCoordinator contract that exposes the internal functions for unit testing.
 contract RegistryCoordinatorHarness is RegistryCoordinator, Test {
     constructor(
-        IDelegationManager _delegationManager,
-        ISlasher _slasher,
+        IServiceManager _serviceManager,
         IStakeRegistry _stakeRegistry,
         IBLSApkRegistry _blsApkRegistry,
         IIndexRegistry _indexRegistry
-    ) RegistryCoordinator(_delegationManager, _slasher, _stakeRegistry, _blsApkRegistry, _indexRegistry) {
+    ) RegistryCoordinator(_serviceManager, _stakeRegistry, _blsApkRegistry, _indexRegistry) {
         _transferOwnership(msg.sender);
     }
 

--- a/test/integration/CoreRegistration.t.sol
+++ b/test/integration/CoreRegistration.t.sol
@@ -42,7 +42,8 @@ contract Test_CoreRegistration is MockAVSDeployer {
         // Deploy New ServiceManager & RegistryCoordinator implementations
         serviceManagerImplementation = new ServiceManagerBase(
             delegationManager,
-            registryCoordinator
+            registryCoordinator,
+            stakeRegistry
         );
 
         registryCoordinatorImplementation = new RegistryCoordinatorHarness(

--- a/test/integration/CoreRegistration.t.sol
+++ b/test/integration/CoreRegistration.t.sol
@@ -39,20 +39,29 @@ contract Test_CoreRegistration is MockAVSDeployer {
             )
         );
 
-        // Deploy New RegistryCoordinator
+        // Deploy New ServiceManager & RegistryCoordinator implementations
+        serviceManagerImplementation = new ServiceManagerBase(
+            delegationMock,
+            registryCoordinator
+        );
+
         registryCoordinatorImplementation = new RegistryCoordinatorHarness(
-            delegationManager,
-            slasher,
+            serviceManager,
             stakeRegistry,
             blsApkRegistry,
             indexRegistry
         );
 
-        // Upgrade Registry Coordinator
+        // Upgrade Registry Coordinator & ServiceManager
         cheats.prank(proxyAdminOwner);
         proxyAdmin.upgrade(
             TransparentUpgradeableProxy(payable(address(registryCoordinator))),
             address(registryCoordinatorImplementation)
+        );
+
+        proxyAdmin.upgrade(
+            TransparentUpgradeableProxy(payable(address(serviceManager))),
+            address(serviceManagerImplementation)
         );
 
         // Set operator address
@@ -94,7 +103,7 @@ contract Test_CoreRegistration is MockAVSDeployer {
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, operatorSignature);
 
         // Check operator is registered
-        IDelegationManager.OperatorAVSRegistrationStatus operatorStatus = delegationManager.avsOperatorStatus(address(registryCoordinator), operator);
+        IDelegationManager.OperatorAVSRegistrationStatus operatorStatus = delegationManager.avsOperatorStatus(address(serviceManager), operator);
         assertEq(uint8(operatorStatus), uint8(IDelegationManager.OperatorAVSRegistrationStatus.REGISTERED));
     }
 
@@ -108,7 +117,7 @@ contract Test_CoreRegistration is MockAVSDeployer {
         registryCoordinator.deregisterOperator(quorumNumbers);
 
         // Check operator is deregistered
-        IDelegationManager.OperatorAVSRegistrationStatus operatorStatus = delegationManager.avsOperatorStatus(address(registryCoordinator), operator);
+        IDelegationManager.OperatorAVSRegistrationStatus operatorStatus = delegationManager.avsOperatorStatus(address(serviceManager), operator);
         assertEq(uint8(operatorStatus), uint8(IDelegationManager.OperatorAVSRegistrationStatus.UNREGISTERED));
     }
 
@@ -129,14 +138,17 @@ contract Test_CoreRegistration is MockAVSDeployer {
     }
 
     function test_setMetadataURI_fail_notServiceManagerOwner() public {
+        require(operator != serviceManager.owner(), "bad test setup");
         cheats.prank(operator);
         cheats.expectRevert("Ownable: caller is not the owner");
-        registryCoordinator.setMetadataURI("Test MetadataURI");
+        serviceManager.setMetadataURI("Test MetadataURI");
     }
 
-    function test_setMetadataURI() public {        
-        cheats.prank(registryCoordinatorOwner);
-        registryCoordinator.setMetadataURI("Test MetadataURI");
+    function test_setMetadataURI() public {  
+        address toPrankFrom = serviceManager.owner();      
+        cheats.prank(toPrankFrom);
+        serviceManager.setMetadataURI("Test MetadataURI");
+        // TODO: check effects here
     }
 
     // Utils

--- a/test/integration/CoreRegistration.t.sol
+++ b/test/integration/CoreRegistration.t.sol
@@ -41,7 +41,7 @@ contract Test_CoreRegistration is MockAVSDeployer {
 
         // Deploy New ServiceManager & RegistryCoordinator implementations
         serviceManagerImplementation = new ServiceManagerBase(
-            delegationMock,
+            delegationManager,
             registryCoordinator
         );
 
@@ -53,16 +53,16 @@ contract Test_CoreRegistration is MockAVSDeployer {
         );
 
         // Upgrade Registry Coordinator & ServiceManager
-        cheats.prank(proxyAdminOwner);
+        cheats.startPrank(proxyAdminOwner);
         proxyAdmin.upgrade(
             TransparentUpgradeableProxy(payable(address(registryCoordinator))),
             address(registryCoordinatorImplementation)
         );
-
         proxyAdmin.upgrade(
             TransparentUpgradeableProxy(payable(address(serviceManager))),
             address(serviceManagerImplementation)
         );
+        cheats.stopPrank();
 
         // Set operator address
         operator = cheats.addr(operatorPrivateKey);
@@ -93,7 +93,7 @@ contract Test_CoreRegistration is MockAVSDeployer {
         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = _getOperatorSignature(
             operatorPrivateKey,
             operator,
-            address(registryCoordinator),
+            address(serviceManager),
             emptySalt,
             maxExpiry
         );
@@ -133,7 +133,7 @@ contract Test_CoreRegistration is MockAVSDeployer {
         registryCoordinator.deregisterOperator(quorumNumbers);
 
         // Check operator is still registered
-        IDelegationManager.OperatorAVSRegistrationStatus operatorStatus = delegationManager.avsOperatorStatus(address(registryCoordinator), operator);
+        IDelegationManager.OperatorAVSRegistrationStatus operatorStatus = delegationManager.avsOperatorStatus(address(serviceManager), operator);
         assertEq(uint8(operatorStatus), uint8(IDelegationManager.OperatorAVSRegistrationStatus.REGISTERED));
     }
 
@@ -157,7 +157,7 @@ contract Test_CoreRegistration is MockAVSDeployer {
         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = _getOperatorSignature(
             operatorPrivateKey,
             operator,
-            address(registryCoordinator),
+            address(serviceManager),
             emptySalt,
             maxExpiry
         );

--- a/test/unit/RegistryCoordinatorUnit.t.sol
+++ b/test/unit/RegistryCoordinatorUnit.t.sol
@@ -47,7 +47,7 @@ contract RegistryCoordinatorUnit is MockAVSDeployer {
         assertEq(address(registryCoordinator.stakeRegistry()), address(stakeRegistry));
         assertEq(address(registryCoordinator.blsApkRegistry()), address(blsApkRegistry));
         assertEq(address(registryCoordinator.indexRegistry()), address(indexRegistry));
-        assertEq(address(registryCoordinator.slasher()), address(slasher));
+        assertEq(address(registryCoordinator.serviceManager()), address(serviceManager));
 
         for (uint i = 0; i < numQuorums; i++) {
             assertEq(

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -2,26 +2,23 @@
 pragma solidity =0.8.12;
 
 import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
-import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 import {Slasher} from "eigenlayer-contracts/src/contracts/core/Slasher.sol";
 import {PauserRegistry} from "eigenlayer-contracts/src/contracts/permissions/PauserRegistry.sol";
-import {IStrategyManager} from "eigenlayer-contracts/src/contracts/interfaces/IStrategyManager.sol";
 import {ISlasher} from "eigenlayer-contracts/src/contracts/interfaces/ISlasher.sol";
 import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
 import {IStakeRegistry} from "src/interfaces/IStakeRegistry.sol";
 import {IIndexRegistry} from "src/interfaces/IIndexRegistry.sol";
 import {IRegistryCoordinator} from "src/interfaces/IRegistryCoordinator.sol";
 import {IBLSApkRegistry} from "src/interfaces/IBLSApkRegistry.sol";
+import {IServiceManager} from "src/interfaces/IServiceManager.sol";
 
 import {BitmapUtils} from "src/libraries/BitmapUtils.sol";
 
 import {StrategyManagerMock} from "eigenlayer-contracts/src/test/mocks/StrategyManagerMock.sol";
 import {EigenPodManagerMock} from "eigenlayer-contracts/src/test/mocks/EigenPodManagerMock.sol";
-import {OwnableMock} from "eigenlayer-contracts/src/test/mocks/OwnableMock.sol";
 import {DelegationManagerMock} from "eigenlayer-contracts/src/test/mocks/DelegationManagerMock.sol";
-import {SlasherMock} from "eigenlayer-contracts/src/test/mocks/SlasherMock.sol";
 
 import {StakeRegistryHarness} from "test/harnesses/StakeRegistryHarness.sol";
 import {StakeRegistry} from "src/StakeRegistry.sol";
@@ -41,6 +38,7 @@ contract StakeRegistryUnitTests is Test {
     StakeRegistryHarness public stakeRegistryImplementation;
     StakeRegistryHarness public stakeRegistry;
     RegistryCoordinatorHarness public registryCoordinator;
+    IServiceManager public serviceManager;
 
     StrategyManagerMock public strategyManagerMock;
     DelegationManagerMock public delegationMock;
@@ -103,8 +101,7 @@ contract StakeRegistryUnitTests is Test {
 
         cheats.startPrank(registryCoordinatorOwner);
         registryCoordinator = new RegistryCoordinatorHarness(
-            delegationMock,
-            slasher,
+            serviceManager,
             stakeRegistry,
             IBLSApkRegistry(apkRegistry),
             IIndexRegistry(indexRegistry)

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -228,7 +228,8 @@ contract MockAVSDeployer is Test {
 
         serviceManagerImplementation = new ServiceManagerBase(
             delegationMock,
-            registryCoordinator
+            registryCoordinator,
+            stakeRegistry
         );
 
         proxyAdmin.upgrade(


### PR DESCRIPTION
# Summary
Reintroduce an IServiceManager interface and ServiceManagerBase, but including only on the very minimal interactions we are requiring from AVSs (the other one was very slashing-focused, so there really isn’t overlap between the old interface and this new one)

## Why?
We clearly aren’t going to be able to jam that much more into the RegistryCoordinator, and setting EigenLayer up to have to worry about multiple AVS contracts is a recipe for headaches down the line.
We know we’ll be adding more interactions where AVSs push data to EigenLayer in the future, and it seems highly unlikely we can fit these into the RegistryCoordinator, or that these would be the right place even if we could.
I also feel like this is better separation of concerns. Hopefully AVS developers have less to worry about here — if they don’t want to change the Registries we have, they can just worry about customizing the ServiceManager / adding more functionality there down the line, rather than needing to fit things into the RegistryCoordinator.
We are making the clear decision of “one contract per AVS for pushing info to EigenLayer” which we had tried to stick with before for good reason. It places a bit of a constraint on AVS architecture (one kind of central router for calls to EigenLayer) but I think less than saying “you need to follow this registry structure” which it feels like we’re implicitly heading into without doing something like this.

## Open Questions
Do we need the IServiceManager interface at all?
~~If so, should we perhaps add the `setMetadataURI` function to it?~~ (added in https://github.com/Layr-Labs/eigenlayer-middleware/pull/109/commits/a8008a07656c082ab9e2df0d8c9543b3d0734392)