### PR TITLE
Feat: Add Operator Strategy Indexing to Service Manager

### DIFF
--- a/src/ServiceManagerBase.sol
+++ b/src/ServiceManagerBase.sol
@@ -3,11 +3,13 @@ pragma solidity =0.8.12;
 
 import {OwnableUpgradeable} from "@openzeppelin-upgrades/contracts/access/OwnableUpgradeable.sol";
 
+import {BitmapUtils} from "src/libraries/BitmapUtils.sol"; 
 import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
 import {IDelegationManager} from "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
 
 import {IServiceManager} from "src/interfaces/IServiceManager.sol";
 import {IRegistryCoordinator} from "src/interfaces/IRegistryCoordinator.sol";
+import {IStakeRegistry} from "src/interfaces/IStakeRegistry.sol";
 
 /**
  * @title Minimal implementation of a ServiceManager-type contract.
@@ -15,8 +17,11 @@ import {IRegistryCoordinator} from "src/interfaces/IRegistryCoordinator.sol";
  * @author Layr Labs, Inc.
  */
 contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
-    address immutable registryCoordinator;
+    using BitmapUtils for *;
+
+    IRegistryCoordinator immutable registryCoordinator;
     IDelegationManager immutable delegationManager;
+    IStakeRegistry immutable stakeRegistry;
 
     /// @notice when applied to a function, only allows the RegistryCoordinator to call it
     modifier onlyRegistryCoordinator() {
@@ -30,10 +35,12 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
     /// @notice Sets the (immutable) `registryCoordinator` address
     constructor(
         IDelegationManager _delegationManager,
-        IRegistryCoordinator _registryCoordinator
+        IRegistryCoordinator _registryCoordinator,
+        IStakeRegistry _stakeRegistry
     ) {
         delegationManager = _delegationManager;
-        registryCoordinator = address(_registryCoordinator);
+        registryCoordinator = _registryCoordinator;
+        stakeRegistry = _stakeRegistry;
         _disableInitializers();
     }
 
@@ -68,5 +75,41 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
      */
     function deregisterOperatorFromAVS(address operator) public virtual onlyRegistryCoordinator {
         delegationManager.deregisterOperatorFromAVS(operator);
+    }
+
+    /**
+     * @notice Returns the list of strategies that the operator has potentially restaked on the AVS
+     * @param operator The address of the operator to get restaked strategies for
+     * @dev This function is intended to be called off-chain
+     * @dev No guarantee is made on whether the operator has shares for a strategy in a quorum or uniqueness 
+     *      of each element in the returned array. The off-chain service should do that validation separately
+     */
+    function getOperatorRestakedStrategies(address operator) external view returns (address[] memory) {
+        bytes32 operatorId = registryCoordinator.getOperatorId(operator);
+        uint192 operatorBitmap = registryCoordinator.getCurrentQuorumBitmap(operatorId);
+
+        if (operatorBitmap == 0 || registryCoordinator.quorumCount() == 0) {
+            return new address[](0);
+        }
+
+        // Get number of strategies for each quorum in operator bitmap
+        bytes memory operatorRestakedQuorums = BitmapUtils.bitmapToBytesArray(operatorBitmap);
+        uint256 strategyCount;
+        for(uint256 i = 0; i < operatorRestakedQuorums.length; i++) {
+            strategyCount += stakeRegistry.strategyParamsLength(uint8(operatorRestakedQuorums[i]));
+        }
+
+        // Get strategies for each quorum in operator bitmap
+        address[] memory restakedStrategies = new address[](strategyCount);
+        uint256 index = 0;
+        for(uint256 i = 0; i < operatorRestakedQuorums.length; i++) {
+            uint8 quorum = uint8(operatorRestakedQuorums[i]);
+            uint256 strategyParamsLength = stakeRegistry.strategyParamsLength(quorum);
+            for (uint256 j = 0; j < strategyParamsLength; j++) {
+                restakedStrategies[index] = address(stakeRegistry.strategyParamsByIndex(quorum, j).strategy);
+                index++;
+            }
+        }
+        return restakedStrategies;        
     }
 }

--- a/src/StakeRegistry.sol
+++ b/src/StakeRegistry.sol
@@ -516,7 +516,7 @@ contract StakeRegistry is StakeRegistryStorage {
     ) public view returns (StrategyParams memory)
     {
         return strategyParams[quorumNumber][index];
-    } 
+    }
 
     /*******************************************************************************
                       VIEW FUNCTIONS - Operator Stake History

--- a/src/interfaces/IServiceManager.sol
+++ b/src/interfaces/IServiceManager.sol
@@ -30,4 +30,13 @@ interface IServiceManager {
      * @param operator The address of the operator to deregister.
      */
     function deregisterOperatorFromAVS(address operator) external;
+
+    /**
+     * @notice Returns the list of strategies that the operator has potentially restaked on the AVS
+     * @param operator The address of the operator to get restaked strategies for
+     * @dev This function is intended to be called off-chain
+     * @dev No guarantee is made on whether the operator has shares for a strategy in a quorum or uniqueness 
+     *      of each element in the returned array. The off-chain service should do that validation separately
+     */
+    function getOperatorRestakedStrategies(address operator) external view returns (address[] memory);
 }

--- a/test/integration/CoreRegistration.t.sol
+++ b/test/integration/CoreRegistration.t.sol
@@ -42,7 +42,8 @@ contract Test_CoreRegistration is MockAVSDeployer {
         // Deploy New ServiceManager & RegistryCoordinator implementations
         serviceManagerImplementation = new ServiceManagerBase(
             delegationManager,
-            registryCoordinator
+            registryCoordinator,
+            stakeRegistry
         );
 
         registryCoordinatorImplementation = new RegistryCoordinatorHarness(

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -228,7 +228,8 @@ contract MockAVSDeployer is Test {
 
         serviceManagerImplementation = new ServiceManagerBase(
             delegationMock,
-            registryCoordinator
+            registryCoordinator,
+            stakeRegistry
         );
 
         proxyAdmin.upgrade(


### PR DESCRIPTION
We need to index operators restaked on each AVS to support our user stories for [V1 AVS Marketplace](https://docs.google.com/document/d/17PStsH5qXFNWUzjzr-vyzASy_6bjMd_tuf234bkejkg/edit). 