### PR TITLE
test: apk registry unit tests and foundry config update

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ This repository uses Foundry. See the [Foundry docs](https://book.getfoundry.sh/
 foundryup
 
 forge build
-# FFI tests are currently broken; working on it! for now, run the tests without them
-forge test --no-match-contracts FFI
+forge test
 ```
 
 ## Deployments

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,7 @@ libs = ["lib"]
 fs_permissions = [{ access = "read-write", path = "./" }]
 
 ffi = true
+no-match-contract = "FFI"
 
 # The number of optimizer runs
 optimizer_runs = 200

--- a/foundry.toml
+++ b/foundry.toml
@@ -9,4 +9,13 @@ ffi = true
 # The number of optimizer runs
 optimizer_runs = 200
 
+[fmt]
+bracket_spacing = false
+int_types = "long"
+line_length = 100
+multiline_func_header = "params_first"
+number_underscore = "thousands"
+quote_style = "double"
+tab_width = 4
+
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/test/events/IBLSApkRegistryEvents.sol
+++ b/test/events/IBLSApkRegistryEvents.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import {BN254} from "../../src/libraries/BN254.sol";
+
+interface IBLSApkRegistryEvents {
+    // EVENTS
+    /// @notice Emitted when `operator` registers with the public keys `pubkeyG1` and `pubkeyG2`.
+    event NewPubkeyRegistration(address indexed operator, BN254.G1Point pubkeyG1, BN254.G2Point pubkeyG2);
+
+    // @notice Emitted when a new operator pubkey is registered for a set of quorums
+    event OperatorAddedToQuorums(
+        address operator,
+        bytes quorumNumbers
+    );
+
+    // @notice Emitted when an operator pubkey is removed from a set of quorums
+    event OperatorRemovedFromQuorums(
+        address operator, 
+        bytes quorumNumbers
+    );
+}

--- a/test/tree/BLSApkRegistryUnit.tree
+++ b/test/tree/BLSApkRegistryUnit.tree
@@ -49,7 +49,7 @@
 ├── initializeQuorum()
 │   ├── given caller is not the registry coordinator
 │   │   └── it should revert
-│   ├── given a quorum does not exist (apkHistory[quorumNumber] == 0)
+│   ├── given a quorum already exists (apkHistory[quorumNumber] != 0)
 │   │   └── it should revert
 │   └── given all above conditions are met
 │       └── it should push the first ApkUpdate with the zero apkHash

--- a/test/tree/BLSApkRegistryUnit.tree
+++ b/test/tree/BLSApkRegistryUnit.tree
@@ -49,7 +49,16 @@
 ├── initializeQuorum()
 │   ├── given caller is not the registry coordinator
 │   │   └── it should revert
-│   └── given a quorum does not exist (apkHistory[quorumNumber] == 0)
-│       └── it should revert
+│   ├── given a quorum does not exist (apkHistory[quorumNumber] == 0)
+│   │   └── it should revert
+│   └── given all above conditions are met
+│       └── it should push the first ApkUpdate with the zero apkHash
 │
 └── getApkIndicesAtBlockNumber()
+    ├── given a quorum does not exist (apkHistory[quorumNumber] == 0)
+    │   └── it should revert
+    ├── given for any passed in quorum,the input blocknumber is < the quorum's first ApkUpdate.updateBlockNumber
+    │   └── it should revert
+    └── given all above conditions are met
+        └── it should return the apk indices at the block number for each quorum
+

--- a/test/tree/BLSApkRegistryUnit.tree
+++ b/test/tree/BLSApkRegistryUnit.tree
@@ -1,0 +1,55 @@
+.
+├── BLSApkRegistry tree (*** denotes that integration tests are needed to validate path)
+├── registerOperator()
+│   ├── given caller is not the registry coordinator
+│   │   └── it should revert
+│   ├── given caller has not registered a pubkey
+│   │   └── it should revert
+│   └── given all above conditions are met
+│       └── it should call _processQuorumApkUpdate() with the operator pubkey and emit OperatorAddedToQuorums
+│
+├── deregisterOperator()
+│   ├── given caller is not the registry coordinator
+│   │   └── it should revert
+│   ├── given caller has not registered a pubkey
+│   │   └── it should revert
+│   └── given all above conditions are met
+│       └── it should call _processQuorumApkUpdate() with the negated operator pubkey and emit OperatorRemovedFromQuorums
+│
+├── _processQuorumApkUpdate() (internal function)
+│   ├── given a quorum does not exist (apkHistory[quorumNumber] == 0)
+│   │   └── it should revert
+│   ├── given the latest quorum ApkUpdate occurred in the current block
+│   │   ├── it should add the operator pubkey to the quorum apk
+│   │   └── it should update the latest quorum ApkUpdate with the updated apkHash
+│   └── given the latest quorum ApkUpdate occurred in a previous block
+│       ├── it should update the latest quorum ApkUpdate's nextUpdateBlockNumber to current blocknumber
+│       ├── it should add the operator pubkey to the quorum apk
+│       └── it should push a new quorum ApkUpdate with the updated apkHash
+│
+├── registerBLSPublicKey()
+│   ├── given caller is not the registry coordinator
+│   │   └── it should revert
+│   ├── given operator address has already registered a pubkey
+│   │   └── it should revert
+│   ├── given pubkey input is the zero pubkey
+│   │   └── it should revert
+│   ├── given pubkey input is already registered
+│   │   └── it should revert
+│   ├── given pubkey signature verification fails
+│   │   └── it should revert
+│   ├── given G1 or G2 private key do not match
+│   │   └── it should revert
+│   └── given all above conditions are met
+│       ├── it should map the operator address to the pubkey
+│       ├── it should map the operator address to the pubkey hash
+│       ├── it should map the pubkey hash to the operator address
+│       └── it should emit NewPubkeyRegistration and return the pubkey hash
+│
+├── initializeQuorum()
+│   ├── given caller is not the registry coordinator
+│   │   └── it should revert
+│   └── given a quorum does not exist (apkHistory[quorumNumber] == 0)
+│       └── it should revert
+│
+└── getApkIndicesAtBlockNumber()

--- a/test/unit/BLSApkRegistryUnit.t.sol
+++ b/test/unit/BLSApkRegistryUnit.t.sol
@@ -1,7 +1,6 @@
 //SPDX-License-Identifier: BUSL-1.1
 pragma solidity =0.8.12;
 
-
 import "forge-std/Test.sol";
 import "../harnesses/BLSApkRegistryHarness.sol";
 import "../mocks/RegistryCoordinatorMock.sol";
@@ -16,15 +15,11 @@ contract BLSApkRegistryUnitTests is BLSMockAVSDeployer, IBLSApkRegistryEvents {
 
     BitmapUtilsWrapper bitmapUtilsWrapper;
 
-    bytes32 internal constant ZERO_PK_HASH = hex"ad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5";
+    bytes32 internal constant ZERO_PK_HASH =
+        hex"ad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5";
 
-    // BN254.G1Point internal defaultPubKey =  BN254.G1Point(18260007818883133054078754218619977578772505796600400998181738095793040006897,3432351341799135763167709827653955074218841517684851694584291831827675065899);
     BN254.G1Point defaultPubkey;
     bytes32 defaultPubkeyHash;
-
-    address alice = address(1);
-    address bob = address(2);
-
     uint256 privKey = 69;
 
     uint8 nextQuorum = 0;
@@ -42,9 +37,11 @@ contract BLSApkRegistryUnitTests is BLSMockAVSDeployer, IBLSApkRegistryEvents {
     // Track addresses that are excluded from fuzzed inputs such as defaultOperator, proxyAdminOwner, etc.
     mapping(address => bool) public addressIsExcludedFromFuzzedInputs;
 
-    /*******************************************************************************
-                            HELPERS AND MODIFIERS
-    *******************************************************************************/
+    /**
+     *
+     *                         HELPERS AND MODIFIERS
+     *
+     */
 
     modifier filterFuzzedAddressInputs(address fuzzedAddress) {
         cheats.assume(!addressIsExcludedFromFuzzedInputs[fuzzedAddress]);
@@ -53,9 +50,9 @@ contract BLSApkRegistryUnitTests is BLSMockAVSDeployer, IBLSApkRegistryEvents {
 
     function setUp() external {
         _setUpBLSMockAVSDeployer(0);
-        
+
         bitmapUtilsWrapper = new BitmapUtilsWrapper();
-        
+
         // exclude defaultOperator
         addressIsExcludedFromFuzzedInputs[defaultOperator] = true;
         addressIsExcludedFromFuzzedInputs[address(proxyAdmin)] = true;
@@ -64,13 +61,16 @@ contract BLSApkRegistryUnitTests is BLSMockAVSDeployer, IBLSApkRegistryEvents {
 
         defaultPubkey = pubkeyRegistrationParams.pubkeyG1;
         defaultPubkeyHash = BN254.hashG1Point(defaultPubkey);
-        
-        //privKey*G2
-        pubkeyRegistrationParams.pubkeyG2.X[1] = 19101821850089705274637533855249918363070101489527618151493230256975900223847;
-        pubkeyRegistrationParams.pubkeyG2.X[0] = 5334410886741819556325359147377682006012228123419628681352847439302316235957;
-        pubkeyRegistrationParams.pubkeyG2.Y[1] = 354176189041917478648604979334478067325821134838555150300539079146482658331;
-        pubkeyRegistrationParams.pubkeyG2.Y[0] = 4185483097059047421902184823581361466320657066600218863748375739772335928910;
 
+        //privKey*G2
+        pubkeyRegistrationParams.pubkeyG2.X[1] =
+            19_101_821_850_089_705_274_637_533_855_249_918_363_070_101_489_527_618_151_493_230_256_975_900_223_847;
+        pubkeyRegistrationParams.pubkeyG2.X[0] =
+            5_334_410_886_741_819_556_325_359_147_377_682_006_012_228_123_419_628_681_352_847_439_302_316_235_957;
+        pubkeyRegistrationParams.pubkeyG2.Y[1] =
+            354_176_189_041_917_478_648_604_979_334_478_067_325_821_134_838_555_150_300_539_079_146_482_658_331;
+        pubkeyRegistrationParams.pubkeyG2.Y[0] =
+            4_185_483_097_059_047_421_902_184_823_581_361_466_320_657_066_600_218_863_748_375_739_772_335_928_910;
 
         // Initialize 3 quorums
         _initializeQuorum();
@@ -107,40 +107,48 @@ contract BLSApkRegistryUnitTests is BLSMockAVSDeployer, IBLSApkRegistryEvents {
     function _initializeFuzzedQuorums(uint192 bitmap) internal {
         bytes memory quorumNumbers = bitmapUtilsWrapper.bitmapToBytesArray(bitmap);
 
-        for (uint i = 0; i < quorumNumbers.length; i++) {
+        for (uint256 i = 0; i < quorumNumbers.length; i++) {
             uint8 quorumNumber = uint8(quorumNumbers[i]);
             _initializeQuorum(quorumNumber);
         }
     }
 
-    function _initializeFuzzedQuorum(
-        uint8 quorumNumber
-    ) internal {
+    function _initializeFuzzedQuorum(uint8 quorumNumber) internal {
         cheats.assume(!initializedQuorums[quorumNumber]);
         _initializeQuorum(quorumNumber);
+    }
+
+    /// @dev Return a new, unique operator/operatorId pair, guaranteed to be
+    /// unregistered from all quorums
+    function _selectNewOperator() internal returns (address) {
+        address operator = nextOperator;
+        nextOperator = _incrementAddress(nextOperator, 1);
+        return operator;
     }
 
     function _getRandomPk(uint256 seed) internal view returns (bytes32) {
         return keccak256(abi.encodePacked(block.timestamp, seed));
     }
 
-    function _generateRandomNumber(uint256 seed) internal view returns (uint256) {
+    function _getRandBool(uint256 seed) internal view returns (bool) {
         uint256 randomNumber = uint256(keccak256(abi.encodePacked(block.timestamp, seed)));
-        return (randomNumber % 100) + 1; 
+        return randomNumber % 2 == 0;
     }
 
-    /*******************************************************************************
-                        Helpers using the default preset BLS key
-    *******************************************************************************/
+    /**
+     *
+     *                     Helpers using the default preset BLS key
+     *
+     */
 
-    function _signMessage(address signer) internal view returns(BN254.G1Point memory) {
+    function _signMessage(address signer) internal view returns (BN254.G1Point memory) {
         BN254.G1Point memory messageHash = registryCoordinator.pubkeyRegistrationMessageHash(signer);
         return BN254.scalar_mul(messageHash, privKey);
     }
 
     /**
      * @dev registering operator with a random BLS pubkey, note this is a random pubkey without a known
-     *  private key and is only used for fuzzing purposes. We use the harness function `setBLSPublicKey` 
+     *  private key and is only used for fuzzing purposes. We use the harness function `setBLSPublicKey`
      * here to set the operator BLS public key.
      */
     function _registerRandomBLSPubkey(
@@ -159,7 +167,8 @@ contract BLSApkRegistryUnitTests is BLSMockAVSDeployer, IBLSApkRegistryEvents {
      */
     function _registerDefaultBLSPubkey(address operator) internal returns (bytes32) {
         pubkeyRegistrationParams.pubkeyRegistrationSignature = _signMessage(operator);
-        BN254.G1Point memory messageHash = registryCoordinator.pubkeyRegistrationMessageHash(operator);
+        BN254.G1Point memory messageHash =
+            registryCoordinator.pubkeyRegistrationMessageHash(operator);
 
         cheats.prank(address(registryCoordinator));
         return blsApkRegistry.registerBLSPublicKey(operator, pubkeyRegistrationParams, messageHash);
@@ -170,19 +179,79 @@ contract BLSApkRegistryUnitTests is BLSMockAVSDeployer, IBLSApkRegistryEvents {
      */
     function _registerOperator(address operator, bytes memory quorumNumbers) internal {
         cheats.prank(address(registryCoordinator));
+        cheats.expectEmit(true, true, true, true, address(blsApkRegistry));
+        emit OperatorAddedToQuorums(operator, quorumNumbers);
         blsApkRegistry.registerOperator(operator, quorumNumbers);
     }
 
-    function _deregisterOperator() internal {
-        bytes memory quorumNumbers = new bytes(1);
-        quorumNumbers[0] = bytes1(defaultQuorumNumber);
+    /**
+     * @dev deregister operator, assumes operator has a registered BLS public key and that quorumNumbers are valid
+     */
+    function _deregisterOperator(address operator, bytes memory quorumNumbers) internal {
         cheats.prank(address(registryCoordinator));
-        blsApkRegistry.deregisterOperator(defaultOperator, quorumNumbers);
+        cheats.expectEmit(true, true, true, true, address(blsApkRegistry));
+        emit OperatorRemovedFromQuorums(operator, quorumNumbers);
+        blsApkRegistry.deregisterOperator(operator, quorumNumbers);
     }
 
-    /*******************************************************************************
-                        Helpers for 
-    *******************************************************************************/
+    /**
+     *
+     *                     Helpers for assertions
+     *
+     */
+
+    function _getApks(bytes memory quorumNumbers) internal view returns (BN254.G1Point[] memory) {
+        BN254.G1Point[] memory quorumApks = new BN254.G1Point[](quorumNumbers.length);
+        for (uint8 i = 0; i < quorumNumbers.length; i++) {
+            quorumApks[i] = blsApkRegistry.getApk(uint8(quorumNumbers[i]));
+        }
+        return quorumApks;
+    }
+
+    function _assertQuorumApkUpdates(
+        bytes memory quorumNumbers,
+        BN254.G1Point[] memory apksBefore,
+        BN254.G1Point[] memory apksAfter,
+        BN254.G1Point memory operatorPubkey
+    ) internal {
+        assertEq(
+            apksBefore.length,
+            quorumNumbers.length,
+            "apksBefore and quorumNumbers must be the same length"
+        );
+        assertEq(
+            apksBefore.length, apksAfter.length, "apksBefore and apksAfter must be the same length"
+        );
+        for (uint256 i = 0; i < apksBefore.length; i++) {
+            uint8 quorumNumber = uint8(quorumNumbers[i]);
+            BN254.G1Point memory apkBefore = apksBefore[i];
+            BN254.G1Point memory apkAfter = apksAfter[i];
+            assertEq(
+                BN254.hashG1Point(apkAfter),
+                BN254.hashG1Point(apkBefore.plus(operatorPubkey)),
+                "quorum apk not updated correctly adding the operator pubkey"
+            );
+
+            uint32 quorumHistoryLength = blsApkRegistry.getApkHistoryLength(quorumNumber);
+            IBLSApkRegistry.ApkUpdate memory latestApkUpdate =
+                blsApkRegistry.getApkUpdateAtIndex(quorumNumber, quorumHistoryLength - 1);
+            assertEq(
+                latestApkUpdate.apkHash,
+                bytes24(BN254.hashG1Point(apkAfter)),
+                "apkHash does not match"
+            );
+            assertEq(
+                latestApkUpdate.updateBlockNumber,
+                uint32(block.number),
+                "updateBlockNumber not set correctly"
+            );
+            assertEq(
+                latestApkUpdate.nextUpdateBlockNumber,
+                uint32(0),
+                "nextUpdateBlockNumber should be 0 as this is the latest ApkUpdate"
+            );
+        }
+    }
 }
 
 contract BLSApkRegistryUnitTests_configAndGetters is BLSApkRegistryUnitTests {
@@ -194,57 +263,73 @@ contract BLSApkRegistryUnitTests_configAndGetters is BLSApkRegistryUnitTests {
         );
     }
 
-    function test_initializeQuorum_Revert_WhenNotRegistryCoordinator(
+    function testFuzz_initializeQuorum_Revert_WhenNotRegistryCoordinator(
         address nonCoordinatorAddress
     ) public filterFuzzedAddressInputs(nonCoordinatorAddress) {
         cheats.assume(nonCoordinatorAddress != address(registryCoordinator));
 
         cheats.prank(address(nonCoordinatorAddress));
-        cheats.expectRevert("BLSApkRegistry.onlyRegistryCoordinator: caller is not the registry coordinator");
+        cheats.expectRevert(
+            "BLSApkRegistry.onlyRegistryCoordinator: caller is not the registry coordinator"
+        );
         blsApkRegistry.initializeQuorum(defaultQuorumNumber);
     }
 }
 
+/// @notice test for BLSApkRegistry.registerBLSPublicKey()
 contract BLSApkRegistryUnitTests_registerBLSPublicKey is BLSApkRegistryUnitTests {
     using BN254 for BN254.G1Point;
 
-    function test_registerOperator_Revert_WhenNotRegistryCoordinator(
+    function testFuzz_registerOperator_Revert_WhenNotRegistryCoordinator(
         address nonCoordinatorAddress
     ) public filterFuzzedAddressInputs(nonCoordinatorAddress) {
         cheats.assume(nonCoordinatorAddress != address(registryCoordinator));
 
-        pubkeyRegistrationParams.pubkeyRegistrationSignature = _signMessage(alice);
-        BN254.G1Point memory messageHash = registryCoordinator.pubkeyRegistrationMessageHash(alice);
+        pubkeyRegistrationParams.pubkeyRegistrationSignature = _signMessage(defaultOperator);
+        BN254.G1Point memory messageHash =
+            registryCoordinator.pubkeyRegistrationMessageHash(defaultOperator);
 
         cheats.prank(address(nonCoordinatorAddress));
-        cheats.expectRevert("BLSApkRegistry.onlyRegistryCoordinator: caller is not the registry coordinator");
-        blsApkRegistry.registerBLSPublicKey(alice, pubkeyRegistrationParams, messageHash);
+        cheats.expectRevert(
+            "BLSApkRegistry.onlyRegistryCoordinator: caller is not the registry coordinator"
+        );
+        blsApkRegistry.registerBLSPublicKey(defaultOperator, pubkeyRegistrationParams, messageHash);
     }
 
-    function test_registerOperator_Revert_WhenZeroPubkeyHash(address operator) public {
+    function testFuzz_registerOperator_Revert_WhenZeroPubkeyHash(address operator) public {
         pubkeyRegistrationParams.pubkeyG1.X = 0;
         pubkeyRegistrationParams.pubkeyG1.Y = 0;
-        BN254.G1Point memory messageHash = registryCoordinator.pubkeyRegistrationMessageHash(operator);
+        BN254.G1Point memory messageHash =
+            registryCoordinator.pubkeyRegistrationMessageHash(operator);
 
         cheats.prank(address(registryCoordinator));
         cheats.expectRevert("BLSApkRegistry.registerBLSPublicKey: cannot register zero pubkey");
         blsApkRegistry.registerBLSPublicKey(operator, pubkeyRegistrationParams, messageHash);
     }
 
-    function test_registerOperator_Revert_WhenOperatorAlreadyRegistered(address operator) public {
+    function testFuzz_registerOperator_Revert_WhenOperatorAlreadyRegistered(address operator)
+        public
+    {
         pubkeyRegistrationParams.pubkeyRegistrationSignature = _signMessage(operator);
-        BN254.G1Point memory messageHash = registryCoordinator.pubkeyRegistrationMessageHash(operator);
+        BN254.G1Point memory messageHash =
+            registryCoordinator.pubkeyRegistrationMessageHash(operator);
 
         cheats.startPrank(address(registryCoordinator));
         blsApkRegistry.registerBLSPublicKey(operator, pubkeyRegistrationParams, messageHash);
 
-        cheats.expectRevert("BLSApkRegistry.registerBLSPublicKey: operator already registered pubkey");
+        cheats.expectRevert(
+            "BLSApkRegistry.registerBLSPublicKey: operator already registered pubkey"
+        );
         blsApkRegistry.registerBLSPublicKey(operator, pubkeyRegistrationParams, messageHash);
     }
 
-    function test_registerOperator_Revert_WhenPubkeyAlreadyRegistered(address operator, address operator2) public {
+    function testFuzz_registerOperator_Revert_WhenPubkeyAlreadyRegistered(
+        address operator,
+        address operator2
+    ) public {
         cheats.assume(operator != operator2);
-        BN254.G1Point memory messageHash = registryCoordinator.pubkeyRegistrationMessageHash(operator);
+        BN254.G1Point memory messageHash =
+            registryCoordinator.pubkeyRegistrationMessageHash(operator);
         pubkeyRegistrationParams.pubkeyRegistrationSignature = _signMessage(operator);
 
         cheats.startPrank(address(registryCoordinator));
@@ -258,35 +343,42 @@ contract BLSApkRegistryUnitTests_registerBLSPublicKey is BLSApkRegistryUnitTests
      * @dev operator is registering their public key but signing on the wrong message hash
      * results in the wrong signature. This should revert.
      */
-    function test_registerOperator_Revert_WhenInvalidSignature(
+    function testFuzz_registerOperator_Revert_WhenInvalidSignature(
         address operator,
         address invalidOperator
     ) public {
         cheats.assume(invalidOperator != operator);
-        BN254.G1Point memory messageHash = registryCoordinator.pubkeyRegistrationMessageHash(operator);
+        BN254.G1Point memory messageHash =
+            registryCoordinator.pubkeyRegistrationMessageHash(operator);
 
         BN254.G1Point memory invalidSignature = _signMessage(invalidOperator);
         pubkeyRegistrationParams.pubkeyRegistrationSignature = invalidSignature;
 
         cheats.startPrank(address(registryCoordinator));
-        cheats.expectRevert("BLSApkRegistry.registerBLSPublicKey: either the G1 signature is wrong, or G1 and G2 private key do not match");
+        cheats.expectRevert(
+            "BLSApkRegistry.registerBLSPublicKey: either the G1 signature is wrong, or G1 and G2 private key do not match"
+        );
         blsApkRegistry.registerBLSPublicKey(operator, pubkeyRegistrationParams, messageHash);
     }
 
     /**
      * @dev operator is registering their public key but G1 and G2 private keys do not match
      */
-    function test_registerOperator_Revert_WhenInvalidSignatureMismatchKey(
-        address operator
-    ) public filterFuzzedAddressInputs(operator) {
+    function testFuzz_registerOperator_Revert_WhenInvalidSignatureMismatchKey(address operator)
+        public
+        filterFuzzedAddressInputs(operator)
+    {
         pubkeyRegistrationParams.pubkeyRegistrationSignature = _signMessage(operator);
         BN254.G1Point memory badPubkeyG1 = BN254.generatorG1().scalar_mul(420); // mismatch public keys
 
         pubkeyRegistrationParams.pubkeyG1 = badPubkeyG1;
 
-        BN254.G1Point memory messageHash = registryCoordinator.pubkeyRegistrationMessageHash(operator);
+        BN254.G1Point memory messageHash =
+            registryCoordinator.pubkeyRegistrationMessageHash(operator);
         cheats.prank(address(registryCoordinator));
-        cheats.expectRevert("BLSApkRegistry.registerBLSPublicKey: either the G1 signature is wrong, or G1 and G2 private key do not match");
+        cheats.expectRevert(
+            "BLSApkRegistry.registerBLSPublicKey: either the G1 signature is wrong, or G1 and G2 private key do not match"
+        );
         blsApkRegistry.registerBLSPublicKey(operator, pubkeyRegistrationParams, messageHash);
     }
 
@@ -294,32 +386,26 @@ contract BLSApkRegistryUnitTests_registerBLSPublicKey is BLSApkRegistryUnitTests
      * @dev fuzz tests for different operator addresses but uses the same BLS key for each.
      * Checks for storage mappings being set correctly.
      */
-    function test_registerBLSPublicKey(
-        address operator
-    ) public filterFuzzedAddressInputs(operator) {
+    function testFuzz_registerBLSPublicKey(address operator)
+        public
+        filterFuzzedAddressInputs(operator)
+    {
         // sign messagehash for operator with private key
         pubkeyRegistrationParams.pubkeyRegistrationSignature = _signMessage(operator);
-        BN254.G1Point memory messageHash = registryCoordinator.pubkeyRegistrationMessageHash(operator);
+        BN254.G1Point memory messageHash =
+            registryCoordinator.pubkeyRegistrationMessageHash(operator);
         cheats.prank(address(registryCoordinator));
         cheats.expectEmit(true, true, true, true, address(blsApkRegistry));
-        emit NewPubkeyRegistration(operator, pubkeyRegistrationParams.pubkeyG1, pubkeyRegistrationParams.pubkeyG2);
+        emit NewPubkeyRegistration(
+            operator, pubkeyRegistrationParams.pubkeyG1, pubkeyRegistrationParams.pubkeyG2
+        );
         blsApkRegistry.registerBLSPublicKey(operator, pubkeyRegistrationParams, messageHash);
 
-        (BN254.G1Point memory registeredPubkey, bytes32 registeredpkHash) = blsApkRegistry.getRegisteredPubkey(operator);
-        assertEq(
-            registeredPubkey.X,
-            defaultPubkey.X,
-            "registeredPubkey not set correctly"
-        );
-        assertEq(
-            registeredPubkey.Y,
-            defaultPubkey.Y,
-            "registeredPubkey not set correctly"
-        );
-        assertEq(
-            registeredpkHash,
-            defaultPubkeyHash,
-            "registeredpkHash not set correctly");
+        (BN254.G1Point memory registeredPubkey, bytes32 registeredpkHash) =
+            blsApkRegistry.getRegisteredPubkey(operator);
+        assertEq(registeredPubkey.X, defaultPubkey.X, "registeredPubkey not set correctly");
+        assertEq(registeredPubkey.Y, defaultPubkey.Y, "registeredPubkey not set correctly");
+        assertEq(registeredpkHash, defaultPubkeyHash, "registeredpkHash not set correctly");
         assertEq(
             blsApkRegistry.pubkeyHashToOperator(BN254.hashG1Point(defaultPubkey)),
             operator,
@@ -328,6 +414,7 @@ contract BLSApkRegistryUnitTests_registerBLSPublicKey is BLSApkRegistryUnitTests
     }
 }
 
+/// @notice test for BLSApkRegistry.registerOperator()
 contract BLSApkRegistryUnitTests_registerOperator is BLSApkRegistryUnitTests {
     using BN254 for BN254.G1Point;
     using BitmapUtils for *;
@@ -338,13 +425,16 @@ contract BLSApkRegistryUnitTests_registerOperator is BLSApkRegistryUnitTests {
         cheats.assume(nonCoordinatorAddress != address(registryCoordinator));
 
         cheats.prank(nonCoordinatorAddress);
-        cheats.expectRevert("BLSApkRegistry.onlyRegistryCoordinator: caller is not the registry coordinator");
+        cheats.expectRevert(
+            "BLSApkRegistry.onlyRegistryCoordinator: caller is not the registry coordinator"
+        );
         blsApkRegistry.registerOperator(nonCoordinatorAddress, new bytes(0));
     }
 
-    function testFuzz_registerOperator_Revert_WhenOperatorDoesNotOwnPubkey(
-        address operator
-    ) public filterFuzzedAddressInputs(operator) {
+    function testFuzz_registerOperator_Revert_WhenOperatorDoesNotOwnPubkey(address operator)
+        public
+        filterFuzzedAddressInputs(operator)
+    {
         cheats.prank(address(registryCoordinator));
         cheats.expectRevert("BLSApkRegistry.getRegisteredPubkey: operator is not registered");
         blsApkRegistry.registerOperator(operator, new bytes(1));
@@ -361,7 +451,7 @@ contract BLSApkRegistryUnitTests_registerOperator is BLSApkRegistryUnitTests {
         bytes memory quorumNumbers = bitmapUtilsWrapper.bitmapToBytesArray(quorumBitmap);
 
         _registerDefaultBLSPubkey(operator);
-        
+
         cheats.prank(address(registryCoordinator));
         cheats.expectRevert("BLSApkRegistry._processQuorumApkUpdate: quorum does not exist");
         blsApkRegistry.registerOperator(operator, quorumNumbers);
@@ -382,13 +472,11 @@ contract BLSApkRegistryUnitTests_registerOperator is BLSApkRegistryUnitTests {
         uint192 initializingBitmap = uint192(quorumBitmap.minus(uint256(initializedQuorumBitmap)));
         _initializeFuzzedQuorums(initializingBitmap);
         bytes memory quorumNumbers = bitmapUtilsWrapper.bitmapToBytesArray(quorumBitmap);
-        (
-            BN254.G1Point memory pubkey,
-        ) = _registerRandomBLSPubkey(operator, randomSeed);
+        (BN254.G1Point memory pubkey,) = _registerRandomBLSPubkey(operator, randomSeed);
 
         // get before values
         BN254.G1Point[] memory quorumApksBefore = new BN254.G1Point[](quorumNumbers.length);
-        for(uint8 i = 0; i < quorumNumbers.length; i++){
+        for (uint8 i = 0; i < quorumNumbers.length; i++) {
             quorumApksBefore[i] = blsApkRegistry.getApk(uint8(quorumNumbers[i]));
         }
 
@@ -399,7 +487,7 @@ contract BLSApkRegistryUnitTests_registerOperator is BLSApkRegistryUnitTests {
         blsApkRegistry.registerOperator(operator, quorumNumbers);
 
         // check updated storage values for each quorum
-        for(uint8 i = 0; i < quorumNumbers.length; i++){
+        for (uint8 i = 0; i < quorumNumbers.length; i++) {
             // Check currentApk[quorumNumber] values
             uint8 quorumNumber = uint8(quorumNumbers[i]);
             BN254.G1Point memory quorumApkAfter = blsApkRegistry.getApk(uint8(quorumNumbers[i]));
@@ -410,7 +498,8 @@ contract BLSApkRegistryUnitTests_registerOperator is BLSApkRegistryUnitTests {
             );
             // Check the latest ApkUpdate values
             uint32 quorumHistoryLength = blsApkRegistry.getApkHistoryLength(quorumNumber);
-            IBLSApkRegistry.ApkUpdate memory latestApkUpdate = blsApkRegistry.getApkUpdateAtIndex(quorumNumber, quorumHistoryLength - 1);
+            IBLSApkRegistry.ApkUpdate memory latestApkUpdate =
+                blsApkRegistry.getApkUpdateAtIndex(quorumNumber, quorumHistoryLength - 1);
             assertEq(
                 latestApkUpdate.apkHash,
                 bytes24(BN254.hashG1Point(quorumApkAfter)),
@@ -441,13 +530,16 @@ contract BLSApkRegistryUnitTests_deregisterOperator is BLSApkRegistryUnitTests {
         cheats.assume(nonCoordinatorAddress != address(registryCoordinator));
 
         cheats.prank(nonCoordinatorAddress);
-        cheats.expectRevert("BLSApkRegistry.onlyRegistryCoordinator: caller is not the registry coordinator");
+        cheats.expectRevert(
+            "BLSApkRegistry.onlyRegistryCoordinator: caller is not the registry coordinator"
+        );
         blsApkRegistry.deregisterOperator(nonCoordinatorAddress, new bytes(0));
     }
 
-    function testFuzz_deregisterOperator_Revert_WhenOperatorDoesNotOwnPubkey(
-        address operator
-    ) public filterFuzzedAddressInputs(operator) {
+    function testFuzz_deregisterOperator_Revert_WhenOperatorDoesNotOwnPubkey(address operator)
+        public
+        filterFuzzedAddressInputs(operator)
+    {
         cheats.prank(address(registryCoordinator));
         cheats.expectRevert("BLSApkRegistry.getRegisteredPubkey: operator is not registered");
         blsApkRegistry.registerOperator(operator, new bytes(1));
@@ -461,12 +553,13 @@ contract BLSApkRegistryUnitTests_deregisterOperator is BLSApkRegistryUnitTests {
         cheats.assume(quorumBitmap > initializedQuorumBitmap);
         // mask out quorums that are already initialized
         quorumBitmap = uint192(quorumBitmap.minus(uint256(initializedQuorumBitmap)));
-        bytes memory validQuorumNumbers = bitmapUtilsWrapper.bitmapToBytesArray(initializedQuorumBitmap);
+        bytes memory validQuorumNumbers =
+            bitmapUtilsWrapper.bitmapToBytesArray(initializedQuorumBitmap);
         bytes memory invalidQuorumNumbers = bitmapUtilsWrapper.bitmapToBytesArray(quorumBitmap);
 
         _registerDefaultBLSPubkey(operator);
         _registerOperator(operator, validQuorumNumbers);
-        
+
         cheats.prank(address(registryCoordinator));
         cheats.expectRevert("BLSApkRegistry._processQuorumApkUpdate: quorum does not exist");
         blsApkRegistry.deregisterOperator(operator, invalidQuorumNumbers);
@@ -487,14 +580,12 @@ contract BLSApkRegistryUnitTests_deregisterOperator is BLSApkRegistryUnitTests {
         uint192 initializingBitmap = uint192(quorumBitmap.minus(uint256(initializedQuorumBitmap)));
         _initializeFuzzedQuorums(initializingBitmap);
         bytes memory quorumNumbers = bitmapUtilsWrapper.bitmapToBytesArray(quorumBitmap);
-        (
-            BN254.G1Point memory pubkey,
-        ) = _registerRandomBLSPubkey(operator, randomSeed);
+        (BN254.G1Point memory pubkey,) = _registerRandomBLSPubkey(operator, randomSeed);
         _registerOperator(operator, quorumNumbers);
 
         // get before values
         BN254.G1Point[] memory quorumApksBefore = new BN254.G1Point[](quorumNumbers.length);
-        for(uint8 i = 0; i < quorumNumbers.length; i++){
+        for (uint8 i = 0; i < quorumNumbers.length; i++) {
             quorumApksBefore[i] = blsApkRegistry.getApk(uint8(quorumNumbers[i]));
         }
 
@@ -505,7 +596,7 @@ contract BLSApkRegistryUnitTests_deregisterOperator is BLSApkRegistryUnitTests {
         blsApkRegistry.deregisterOperator(operator, quorumNumbers);
 
         // check updated storage values for each quorum
-        for(uint8 i = 0; i < quorumNumbers.length; i++){
+        for (uint8 i = 0; i < quorumNumbers.length; i++) {
             // Check currentApk[quorumNumber] values
             uint8 quorumNumber = uint8(quorumNumbers[i]);
             BN254.G1Point memory quorumApkAfter = blsApkRegistry.getApk(uint8(quorumNumbers[i]));
@@ -516,7 +607,8 @@ contract BLSApkRegistryUnitTests_deregisterOperator is BLSApkRegistryUnitTests {
             );
             // Check the latest ApkUpdate values
             uint32 quorumHistoryLength = blsApkRegistry.getApkHistoryLength(quorumNumber);
-            IBLSApkRegistry.ApkUpdate memory latestApkUpdate = blsApkRegistry.getApkUpdateAtIndex(quorumNumber, quorumHistoryLength - 1);
+            IBLSApkRegistry.ApkUpdate memory latestApkUpdate =
+                blsApkRegistry.getApkUpdateAtIndex(quorumNumber, quorumHistoryLength - 1);
             assertEq(
                 latestApkUpdate.apkHash,
                 bytes24(BN254.hashG1Point(quorumApkAfter)),
@@ -536,159 +628,300 @@ contract BLSApkRegistryUnitTests_deregisterOperator is BLSApkRegistryUnitTests {
     }
 }
 
+/**
+ * @notice test for _processQuorumApkUpdate() internal function
+ * Called by both registerOperator and deregisterOperator functions
+ */
 contract BLSApkRegistryUnitTests_quorumApkUpdates is BLSApkRegistryUnitTests {
     using BN254 for BN254.G1Point;
     using BitmapUtils for *;
-//     function testQuorumApkUpdates(uint8 quorumNumber1, uint8 quorumNumber2) public {
-//         cheats.assume(quorumNumber1 != quorumNumber2);
 
-//         bytes memory quorumNumbers = new bytes(2);
-//         quorumNumbers[0] = bytes1(quorumNumber1);
-//         quorumNumbers[1] = bytes1(quorumNumber2);
-//         if (!initializedQuorums[quorumNumber1]) {
-//             _initializeFuzzedQuorum(quorumNumber1);
-//         }
-//         if (!initializedQuorums[quorumNumber2]) {
-//             _initializeFuzzedQuorum(quorumNumber2);
-//         }
+    /**
+     * @dev register/deregister up to 200 operators and check quorum apk updates
+     * Test uses only the defaultQuorumNumber
+     */
+    function testFuzz_quorumApkUpdates(uint256 numOperators, uint256[200] memory randSeed) public {
+        cheats.assume(0 < numOperators && numOperators <= 200);
+        bytes memory quorumNumbers = new bytes(1);
+        quorumNumbers[0] = bytes1(defaultQuorumNumber);
 
-//         BN254.G1Point[] memory quorumApksBefore = new BN254.G1Point[](quorumNumbers.length);
-//         for(uint8 i = 0; i < quorumNumbers.length; i++){
-//             quorumApksBefore[i] = blsApkRegistry.getApk(uint8(quorumNumbers[i]));
-//         }
+        /**
+         * For each operator, randomly proceed with either registering/deregistering an operator
+         * If registering, we add to quorum apk the operator pubkey and check the quorum apk updates
+         * Else if deregistering, we add to quorum apk the negated operator pubkey and check the quorum apk updates
+         */
+        for (uint256 i = 0; i < numOperators; i++) {
+            // register and check quorum apk updates
+            BN254.G1Point[] memory quorumApksBefore = _getApks(quorumNumbers);
+            address operator = _selectNewOperator();
+            (BN254.G1Point memory operatorPubkey,) = _registerRandomBLSPubkey(operator, randSeed[i]);
+            _registerOperator(operator, quorumNumbers);
+            BN254.G1Point[] memory quorumApksAfter = _getApks(quorumNumbers);
+            _assertQuorumApkUpdates(
+                quorumNumbers, quorumApksBefore, quorumApksAfter, operatorPubkey
+            );
 
-//         // use harnessed function to directly set the pubkey, bypassing the ordinary checks
-//         blsApkRegistry.setBLSPublicKey(defaultOperator, defaultPubKey);
-        
-//         cheats.prank(address(registryCoordinator));
-//         blsApkRegistry.registerOperator(defaultOperator, quorumNumbers);
+            // deregister and check quorum apk updates
+            bool isDeregistering = _getRandBool(randSeed[i]);
+            if (isDeregistering) {
+                quorumApksBefore = _getApks(quorumNumbers);
+                _deregisterOperator(operator, quorumNumbers);
+                quorumApksAfter = _getApks(quorumNumbers);
+                _assertQuorumApkUpdates(
+                    quorumNumbers, quorumApksBefore, quorumApksAfter, operatorPubkey.negate()
+                );
+            }
+        }
+    }
 
-//         //check quorum apk updates
-//         for(uint8 i = 0; i < quorumNumbers.length; i++){
-//             BN254.G1Point memory quorumApkAfter = blsApkRegistry.getApk(uint8(quorumNumbers[i]));
-//             bytes32 temp = BN254.hashG1Point(BN254.plus(quorumApkAfter, BN254.negate(quorumApksBefore[i])));
-//             require(temp == BN254.hashG1Point(defaultPubKey), "quorum apk not updated correctly");
-//         }
-//     }
+    /**
+     * @dev register/deregister up to 50 operators fuzzing the quorumNumbers
+     * and checking quorum apk updates
+     */
+    function testFuzz_quorumApkUpdates_MultiQuorums(
+        uint32 quorumBitmap,
+        uint256 numOperators,
+        uint256[50] memory randSeed
+    ) public {
+        cheats.assume(0 < numOperators && numOperators <= 50);
+        cheats.assume(quorumBitmap > initializedQuorumBitmap);
+        // mask out quorums that are already initialized
+        uint192 initializingBitmap = uint192(quorumBitmap.minus(uint256(initializedQuorumBitmap)));
+        _initializeFuzzedQuorums(initializingBitmap);
+        bytes memory quorumNumbers = bitmapUtilsWrapper.bitmapToBytesArray(quorumBitmap);
 
-//     function testRegisterWithNegativeQuorumApk(address operator, bytes32 x) external {
-//         testRegisterOperatorBLSPubkey(defaultOperator, x);
+        /**
+         * For each operator, randomly proceed with either registering/deregistering an operator
+         * If registering, we add to quorum apk the operator pubkey and check the quorum apk updates
+         * Else if deregistering, we add to quorum apk the negated operator pubkey and check the quorum apk updates
+         */
+        for (uint256 i = 0; i < numOperators; i++) {
+            // register and check quorum apk updates
+            BN254.G1Point[] memory quorumApksBefore = _getApks(quorumNumbers);
+            address operator = _selectNewOperator();
+            (BN254.G1Point memory operatorPubkey,) = _registerRandomBLSPubkey(operator, randSeed[i]);
+            _registerOperator(operator, quorumNumbers);
+            BN254.G1Point[] memory quorumApksAfter = _getApks(quorumNumbers);
+            _assertQuorumApkUpdates(
+                quorumNumbers, quorumApksBefore, quorumApksAfter, operatorPubkey
+            );
 
-//         BN254.G1Point memory quorumApk = blsApkRegistry.getApk(defaultQuorumNumber);
+            // deregister and check quorum apk updates
+            bool isDeregistering = _getRandBool(randSeed[i]);
+            if (isDeregistering) {
+                quorumApksBefore = _getApks(quorumNumbers);
+                _deregisterOperator(operator, quorumNumbers);
+                quorumApksAfter = _getApks(quorumNumbers);
+                _assertQuorumApkUpdates(
+                    quorumNumbers, quorumApksBefore, quorumApksAfter, operatorPubkey.negate()
+                );
+            }
+        }
+    }
 
-//         BN254.G1Point memory negatedQuorumApk = BN254.negate(quorumApk);
+    function testFuzz_quorumApkUpdates_DualQuorum(
+        uint8 quorumNumber1,
+        uint8 quorumNumber2
+    ) public {
+        cheats.assume(quorumNumber1 != quorumNumber2);
 
-//         //register for one quorum
-//         bytes memory quorumNumbers = new bytes(1);
-//         quorumNumbers[0] = bytes1(defaultQuorumNumber);
+        bytes memory quorumNumbers = new bytes(2);
+        quorumNumbers[0] = bytes1(quorumNumber1);
+        quorumNumbers[1] = bytes1(quorumNumber2);
+        if (!initializedQuorums[quorumNumber1]) {
+            _initializeFuzzedQuorum(quorumNumber1);
+        }
+        if (!initializedQuorums[quorumNumber2]) {
+            _initializeFuzzedQuorum(quorumNumber2);
+        }
 
-//         // use harnessed function to directly set the pubkey, bypassing the ordinary checks
-//         blsApkRegistry.setBLSPublicKey(operator, negatedQuorumApk);
-//         cheats.stopPrank();
+        BN254.G1Point[] memory quorumApksBefore = new BN254.G1Point[](quorumNumbers.length);
+        for (uint8 i = 0; i < quorumNumbers.length; i++) {
+            quorumApksBefore[i] = blsApkRegistry.getApk(uint8(quorumNumbers[i]));
+        }
 
-//         cheats.startPrank(address(registryCoordinator));
-//         blsApkRegistry.registerOperator(operator, quorumNumbers);
-//         cheats.stopPrank();
+        // use harnessed function to directly set the pubkey, bypassing the ordinary checks
+        blsApkRegistry.setBLSPublicKey(defaultOperator, defaultPubKey);
 
-//         require(BN254.hashG1Point(blsApkRegistry.getApk(defaultQuorumNumber)) == ZERO_PK_HASH, "quorumApk not set correctly");
-//     }
+        cheats.prank(address(registryCoordinator));
+        blsApkRegistry.registerOperator(defaultOperator, quorumNumbers);
 
-//     function testQuorumApkUpdatesAtBlockNumber(uint256 numRegistrants, uint256 blockGap) external{
-//         cheats.assume(numRegistrants > 0 && numRegistrants <  100);
-//         cheats.assume(blockGap < 100);
+        //check quorum apk updates
+        for (uint8 i = 0; i < quorumNumbers.length; i++) {
+            BN254.G1Point memory quorumApkAfter = blsApkRegistry.getApk(uint8(quorumNumbers[i]));
+            assertEq(
+                BN254.hashG1Point(BN254.plus(quorumApkAfter, BN254.negate(quorumApksBefore[i]))),
+                BN254.hashG1Point(defaultPubKey),
+                "quorum apk not updated correctly"
+            );
+        }
+    }
 
-//         BN254.G1Point memory quorumApk = BN254.G1Point(0,0);
-//         bytes24 quorumApkHash;
-//         for (uint256 i = 0; i < numRegistrants; i++) {
-//             bytes32 pk = _getRandomPk(i);
-//             testRegisterOperatorBLSPubkey(defaultOperator, pk);
-//             quorumApk = quorumApk.plus(BN254.hashToG1(pk));
-//             quorumApkHash = bytes24(BN254.hashG1Point(quorumApk));
-//             uint historyLength = blsApkRegistry.getApkHistoryLength(defaultQuorumNumber);
-//             assertEq(quorumApkHash, blsApkRegistry.getApkHashAtBlockNumberAndIndex(defaultQuorumNumber, uint32(block.number + blockGap), historyLength-1), "incorrect quorum apk update");
-//             cheats.roll(block.number + 100);
-//             if(_generateRandomNumber(i) % 2 == 0){
-//                 _deregisterOperator();
-//                 quorumApk = quorumApk.plus(BN254.hashToG1(pk).negate());
-//                 quorumApkHash = bytes24(BN254.hashG1Point(quorumApk));
-//                 historyLength = blsApkRegistry.getApkHistoryLength(defaultQuorumNumber);
-//                 assertEq(quorumApkHash, blsApkRegistry.getApkHashAtBlockNumberAndIndex(defaultQuorumNumber, uint32(block.number + blockGap), historyLength-1), "incorrect quorum apk update");
-//                 cheats.roll(block.number + 100);
-//                 i++;
-//             }
-//         }
-//     }
+    /**
+     * @dev register operator BLS pubkey with the negated quorumApk, the quorum apk hash
+     * should now be the ZERO_PK_HASH
+     */
+    function testFuzz_quorumApkUpdates_RegisterWithNegativeQuorumApk(
+        address operator,
+        uint256 randSeed
+    ) public filterFuzzedAddressInputs(operator) {
+        bytes memory quorumNumbers = new bytes(1);
+        quorumNumbers[0] = bytes1(defaultQuorumNumber);
+        _registerRandomBLSPubkey(defaultOperator, randSeed);
+        _registerOperator(defaultOperator, quorumNumbers);
 
-//         /// TODO - fix test
-//     function testIncorrectBlockNumberForQuorumApkUpdates(uint256 numRegistrants, uint32 indexToCheck, uint32 wrongBlockNumber) external {
-//         cheats.assume(numRegistrants > 0 && numRegistrants <  100);
-//         cheats.assume(indexToCheck < numRegistrants - 1);
+        BN254.G1Point memory quorumApk = blsApkRegistry.getApk(defaultQuorumNumber);
+        BN254.G1Point memory negatedQuorumApk = BN254.negate(quorumApk);
 
-//         uint256 startingBlockNumber = block.number;
+        //register for one quorum with negative quorum apk
+        // use harnessed function to directly set the pubkey, bypassing the ordinary checks
+        blsApkRegistry.setBLSPublicKey(operator, negatedQuorumApk);
+        cheats.prank(address(registryCoordinator));
+        blsApkRegistry.registerOperator(operator, quorumNumbers);
 
-//         for (uint256 i = 0; i < numRegistrants; i++) {
-//             bytes32 pk = _getRandomPk(i);
-//             testRegisterOperatorBLSPubkey(defaultOperator, pk);
-//             cheats.roll(block.number + 100);
-//         }
-//         if(wrongBlockNumber < startingBlockNumber + indexToCheck*100){
-//             emit log_named_uint("index too recent: ", indexToCheck);
-//             cheats.expectRevert("BLSApkRegistry._validateApkHashAtBlockNumber: index too recent");
-//             blsApkRegistry.getApkHashAtBlockNumberAndIndex(defaultQuorumNumber, wrongBlockNumber, indexToCheck);
-//         } 
-//         if (wrongBlockNumber >= startingBlockNumber + (indexToCheck+1)*100){
-//             emit log_named_uint("index not latest: ", indexToCheck);
-//             cheats.expectRevert("BLSApkRegistry._validateApkHashAtBlockNumber: not latest apk update");
-//             blsApkRegistry.getApkHashAtBlockNumberAndIndex(defaultQuorumNumber, wrongBlockNumber, indexToCheck);
-//         }
-//     }
+        assertEq(
+            BN254.hashG1Point(blsApkRegistry.getApk(defaultQuorumNumber)),
+            ZERO_PK_HASH,
+            "quorumApk not set correctly"
+        );
+    }
 
-    // function testQuorumApkUpdatesDeregistration(uint8 quorumNumber1, uint8 quorumNumber2) external {
-    //     cheats.assume(quorumNumber1 != quorumNumber2);
-    //     bytes memory quorumNumbers = new bytes(2);
-    //     quorumNumbers[0] = bytes1(quorumNumber1);
-    //     quorumNumbers[1] = bytes1(quorumNumber2);
-    //     _initializeFuzzedQuorum(quorumNumber1);
-    //     _initializeFuzzedQuorum(quorumNumber2);
+    /**
+     * @dev fuzz test for quorum apk updates at a specific block number while randomly
+     * register/deregistering operators for the defaultQuorumNumber
+     */
+    function testFuzz_quorumApkUpdates_AtBlockNumber(
+        uint256 numRegistrants,
+        uint256 blockGap,
+        uint256 randSeed
+    ) external {
+        cheats.assume(numRegistrants > 0 && numRegistrants < 100);
+        cheats.assume(blockGap < 100);
 
-    //     testQuorumApkUpdates(quorumNumber1, quorumNumber2);
+        bytes memory quorumNumbers = new bytes(1);
+        quorumNumbers[0] = bytes1(defaultQuorumNumber);
 
-    //     BN254.G1Point[] memory quorumApksBefore = new BN254.G1Point[](2);
-    //     for(uint8 i = 0; i < quorumNumbers.length; i++){
-    //         quorumApksBefore[i] = blsApkRegistry.getApk(uint8(quorumNumbers[i]));
-    //     }
+        BN254.G1Point memory quorumApk = BN254.G1Point(0, 0);
+        bytes24 quorumApkHash;
+        for (uint256 i = 0; i < numRegistrants; i++) {
+            // generate operator and register them with BLS pubkey
+            address operator = _selectNewOperator();
+            (BN254.G1Point memory operatorPubkey,) = _registerRandomBLSPubkey(
+                operator, uint256(keccak256(abi.encodePacked(operator, randSeed)))
+            );
+            _registerOperator(operator, quorumNumbers);
 
-    //     cheats.startPrank(address(registryCoordinator));
-    //     blsApkRegistry.deregisterOperator(defaultOperator, quorumNumbers);
-    //     cheats.stopPrank();
+            quorumApk = quorumApk.plus(operatorPubkey);
+            quorumApkHash = bytes24(BN254.hashG1Point(quorumApk));
+            uint256 historyLength = blsApkRegistry.getApkHistoryLength(defaultQuorumNumber);
+            assertEq(
+                quorumApkHash,
+                blsApkRegistry.getApkHashAtBlockNumberAndIndex(
+                    defaultQuorumNumber, uint32(block.number + blockGap), historyLength - 1
+                ),
+                "incorrect quorum apk update"
+            );
+            cheats.roll(block.number + 100);
+            if (_getRandBool(i)) {
+                _deregisterOperator(operator, quorumNumbers);
+                quorumApk = quorumApk.plus(operatorPubkey.negate());
+                quorumApkHash = bytes24(BN254.hashG1Point(quorumApk));
+                historyLength = blsApkRegistry.getApkHistoryLength(defaultQuorumNumber);
+                assertEq(
+                    quorumApkHash,
+                    blsApkRegistry.getApkHashAtBlockNumberAndIndex(
+                        defaultQuorumNumber, uint32(block.number + blockGap), historyLength - 1
+                    ),
+                    "incorrect quorum apk update"
+                );
+                cheats.roll(block.number + 100);
+                i++;
+            }
+        }
+    }
 
-        
-    //     BN254.G1Point memory quorumApkAfter;
-    //     for(uint8 i = 0; i < quorumNumbers.length; i++){
-    //         quorumApkAfter = blsApkRegistry.getApk(uint8(quorumNumbers[i]));
-    //         require(BN254.hashG1Point(quorumApksBefore[i].plus(defaultPubKey.negate())) == BN254.hashG1Point(quorumApkAfter), "quorum apk not updated correctly");
-    //     }
-    // }
- 
+    /**
+     * @dev fuzz testing for quorum apk updates at a specific block number and index
+     * and checking the correct revert messages are emitted for wrong blocknumber inputs
+     */
+    function testFuzz_quorumApkUpdates_IncorrectBlockNumber(
+        uint256 numRegistrants,
+        uint32 indexToCheck,
+        uint32 wrongBlockNumber,
+        uint256 randSeed
+    ) external {
+        cheats.assume(numRegistrants > 0 && numRegistrants < 100);
+        cheats.assume(indexToCheck < numRegistrants - 1);
+        bytes memory quorumNumbers = new bytes(1);
+        quorumNumbers[0] = bytes1(defaultQuorumNumber);
 
-    // function testDeregisterOperatorWithQuorumApk(bytes32 x1, bytes32 x2) external {
-    //     testRegisterOperatorBLSPubkey(defaultOperator, x1);
-    //     testRegisterOperatorBLSPubkey(defaultOperator2, x2);
+        uint256 startingBlockNumber = block.number;
 
-    //     BN254.G1Point memory quorumApksBefore= blsApkRegistry.getApk(defaultQuorumNumber);
+        for (uint256 i = 0; i < numRegistrants; i++) {
+            address operator = _selectNewOperator();
+            _registerRandomBLSPubkey(
+                operator, uint256(keccak256(abi.encodePacked(operator, randSeed)))
+            );
+            _registerOperator(operator, quorumNumbers);
+            cheats.roll(block.number + 100);
+        }
+        if (wrongBlockNumber < startingBlockNumber + indexToCheck * 100) {
+            emit log_named_uint("index too recent: ", indexToCheck);
+            cheats.expectRevert("BLSApkRegistry._validateApkHashAtBlockNumber: index too recent");
+            blsApkRegistry.getApkHashAtBlockNumberAndIndex(
+                defaultQuorumNumber, wrongBlockNumber, indexToCheck
+            );
+        }
+        if (wrongBlockNumber >= startingBlockNumber + (indexToCheck + 1) * 100) {
+            emit log_named_uint("index not latest: ", indexToCheck);
+            cheats.expectRevert(
+                "BLSApkRegistry._validateApkHashAtBlockNumber: not latest apk update"
+            );
+            blsApkRegistry.getApkHashAtBlockNumberAndIndex(
+                defaultQuorumNumber, wrongBlockNumber, indexToCheck
+            );
+        }
+    }
 
-    //     bytes memory quorumNumbers = new bytes(1);
-    //     quorumNumbers[0] = bytes1(defaultQuorumNumber);
+    /**
+     * @dev fuzz test an operator address and register for 2 quorums, and deregister for those quorums
+     * checking the quorum apk updates for each quorum after deregistering
+     */
+    function testFuzz_quorumApkUpdates_Deregistration(
+        uint8 quorumNumber1,
+        uint8 quorumNumber2
+    ) external {
+        cheats.assume(quorumNumber1 != quorumNumber2);
+        bytes memory quorumNumbers = new bytes(2);
+        quorumNumbers[0] = bytes1(quorumNumber1);
+        quorumNumbers[1] = bytes1(quorumNumber2);
+        _initializeFuzzedQuorum(quorumNumber1);
+        _initializeFuzzedQuorum(quorumNumber2);
 
-    //     // use harnessed function to directly set the pubkey, bypassing the ordinary checks
-    //     blsApkRegistry.setBLSPublicKey(defaultOperator, quorumApksBefore);
-    //     cheats.stopPrank();
+        address operator = _selectNewOperator();
+        _registerDefaultBLSPubkey(operator);
+        _registerOperator(operator, quorumNumbers);
 
-    //     cheats.prank(address(registryCoordinator));
-    //     blsApkRegistry.deregisterOperator(defaultOperator, quorumNumbers);
+        BN254.G1Point[] memory quorumApksBefore = new BN254.G1Point[](2);
+        for (uint8 i = 0; i < quorumNumbers.length; i++) {
+            quorumApksBefore[i] = blsApkRegistry.getApk(uint8(quorumNumbers[i]));
+        }
 
-    //     BN254.G1Point memory pk = blsApkRegistry.getApk(defaultQuorumNumber);
-    //     require(pk.X == 0, "quorum apk not set to zero");
-    //     require(pk.Y == 0, "quorum apk not set to zero");
-    // }
+        cheats.startPrank(address(registryCoordinator));
+        blsApkRegistry.deregisterOperator(defaultOperator, quorumNumbers);
+        cheats.stopPrank();
+
+        BN254.G1Point memory quorumApkAfter;
+        for (uint8 i = 0; i < quorumNumbers.length; i++) {
+            quorumApkAfter = blsApkRegistry.getApk(uint8(quorumNumbers[i]));
+            BN254.G1Point memory quorumApk = blsApkRegistry.getApk(defaultQuorumNumber);
+            assertEq(
+                BN254.hashG1Point(quorumApksBefore[i].plus(defaultPubKey.negate())),
+                BN254.hashG1Point(quorumApkAfter),
+                "quorum apk not updated correctly"
+            );
+            assertEq(quorumApk.X, 0, "quorum apk not set to zero");
+            assertEq(quorumApk.Y, 0, "quorum apk not set to zero");
+        }
+    }
 }

--- a/test/utils/BLSMockAVSDeployer.sol
+++ b/test/utils/BLSMockAVSDeployer.sol
@@ -21,6 +21,11 @@ contract BLSMockAVSDeployer is MockAVSDeployer {
         _setAggregatePublicKeysAndSignature();
     }
 
+    function _setUpBLSMockAVSDeployer(uint8 numQuorumsToAdd) virtual public {
+        _deployMockEigenLayerAndAVS(numQuorumsToAdd);
+        _setAggregatePublicKeysAndSignature();
+    }
+
     function _setAggregatePublicKeysAndSignature() internal {
         // aggSignerPrivKey*g2
         aggSignerApkG2.X[1] = 19101821850089705274637533855249918363070101489527618151493230256975900223847;


### PR DESCRIPTION
BLSApkRegistryUnit.t.sol changes
- inheriting `BLSMockAVSDeployer` in the unit test file to cleanup deployments
- refactored tests to follow our unit testing convention (func names, asserts, etc)
- added missing revert tests
- added more storage checks for `registerBLSPublicKey` unit tests
- cleaned up quorumApk assertions using `_assertQuorumApkUpdates`
- improved fuzzing tests with multiple operators and multiple quorums, 
see `contract BLSApkRegistryUnitTests_quorumApkUpdates`


Changes
- added tree file
- events interface like the rest of the unit test files
- added [fmt] options to foundry.toml
- excluded FFI tests from `forge test` in foundry.toml