### PR TITLE
feat: massive improvement in gas usage of `BitmapUtils.bitmapToBytesA…

### DIFF
--- a/src/libraries/BitmapUtils.sol
+++ b/src/libraries/BitmapUtils.sol
@@ -115,17 +115,27 @@ library BitmapUtils {
      * @return bytesArray The resulting bitmap array of bytes.
      * @dev Each byte in the input is processed as indicating a single bit to flip in the bitmap
      */
-    function bitmapToBytesArray(uint256 bitmap) internal pure returns (bytes memory bytesArray) {
+    function bitmapToBytesArray(uint256 bitmap) internal pure returns (bytes memory /*bytesArray*/) {
         // initialize an empty uint256 to be used as a bitmask inside the loop
         uint256 bitMask;
-        // loop through each index in the bitmap to construct the array
-        for (uint256 i = 0; i < 256; ++i) {
+        // allocate only the needed amount of memory
+        bytes memory bytesArray = new bytes(countNumOnes(bitmap));
+        // track the array index to assign to
+        uint256 arrayIndex = 0;
+        /**
+         * loop through each index in the bitmap to construct the array,
+         * but short-circuit the loop if we reach the number of ones and thus are done
+         * assigning to memory
+         */
+        for (uint256 i = 0; (arrayIndex < bytesArray.length) && (i < 256); ++i) {
             // construct a single-bit mask for the i-th bit
             bitMask = uint256(1 << i);
             // check if the i-th bit is flipped in the bitmap
             if (bitmap & bitMask != 0) {
                 // if the i-th bit is flipped, then add a byte encoding the value 'i' to the `bytesArray`
-                bytesArray = bytes.concat(bytesArray, bytes1(uint8(i)));
+                bytesArray[arrayIndex] = bytes1(uint8(i));
+                // increment the bytesArray slot since we've assigned one more byte of memory
+                unchecked{ ++arrayIndex; }
             }
         }
         return bytesArray;

--- a/test/unit/BitmapUtils.t.sol
+++ b/test/unit/BitmapUtils.t.sol
@@ -228,6 +228,37 @@ contract BitmapUtilsUnitTests_bytesArrayToBitmap is BitmapUtilsUnitTests {
         assertEq(bitmap, 8160);
         emit log_named_uint("gasSpent", gasSpent);
     }
+
+    function testFuzz_bitmapToBytesArrayToBitmap(uint256 originalBitmap) public {
+        uint256 gasLeftBefore = gasleft();
+        bytes memory bytesArray = bitmapUtilsWrapper.bitmapToBytesArray(originalBitmap);
+        uint256 gasLeftAfter = gasleft();
+        uint256 gasSpent = gasLeftBefore - gasLeftAfter;
+        emit log_named_uint("gas spent by bitmapToBytesArray operation", gasSpent);
+        uint256 bitmapOutput = bitmapUtilsWrapper.orderedBytesArrayToBitmap(bytesArray);
+        assertEq(originalBitmap, bitmapOutput, "bitmap output does not match original bitmap!");
+    }
+
+    function test_bitmapToBytesArrayToBitmap_maxBitmap() public {
+        uint256 originalBitmap = type(uint256).max;
+        testFuzz_bitmapToBytesArrayToBitmap(originalBitmap);
+    }
+
+    function test_bitmapToBytesArrayToBitmap_emptyBitmap() public {
+        uint256 originalBitmap = 0;
+        testFuzz_bitmapToBytesArrayToBitmap(originalBitmap);
+    }
+
+    function test_bitmapToBytesArrayToBitmap_firstTenEntriesBitmap() public {
+        uint256 originalBitmap = 2047;
+        testFuzz_bitmapToBytesArrayToBitmap(originalBitmap);
+    }
+
+    function test_bitmapToBytesArrayToBitmap_distributedTenEntriesBitmap() public {
+        // 2^0+2^10+2^20+2^30+2^40+2^50+2^60+2^70+2^80+2^90
+        uint256 originalBitmap = 1239150146850664126585242625;
+        testFuzz_bitmapToBytesArrayToBitmap(originalBitmap);
+    }
 }
 
 contract BitmapUtilsUnitTests_isArrayStrictlyAscendingOrdered is BitmapUtilsUnitTests {


### PR DESCRIPTION
…rray`

This function was naively using the built-in `bytes.concat` method, but it copies the array to memory, incurring memory expansion costs!

Fuzzed tests (e.g. testFuzz_BytesArrayToBitmapToBytesArray) -- which do the encoding twice -- show a ~20k gas improvement with this commit

see for reference:
https://github.com/Layr-Labs/eigenlayer-middleware/actions/runs/7574740337/job/20629810269#step:5:151-152