### PR TITLE
refactor: update minWithdrawalDelayBLocks variable

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 [submodule "lib/eigenlayer-contracts"]
 	path = lib/eigenlayer-contracts
 	url = https://github.com/Layr-labs/eigenlayer-contracts
-	branch = m2-mainnet
+	branch = m2-mainnet-fixes
 [submodule "lib/ds-test"]
 	path = lib/ds-test
 	url = https://github.com/dapphub/ds-test

--- a/docs/BLSSignatureChecker.md
+++ b/docs/BLSSignatureChecker.md
@@ -91,7 +91,7 @@ This method performs the following steps. Note that each step involves lookups o
     * `quorumNumbers` MUST be an ordered list of valid, initialized quorums
     * `params.nonSignerPubkeys` MUST ONLY contain unique pubkeys, in ascending order of their pubkey hash
 * For each quorum:
-    * If stale stakes are forbidden (see [`BLSSignatureChecker.setStaleStakesForbidden`](#blssignaturecheckersetstalestakesforbidden)), check the last `quorumUpdateBlockNumber` is within `DelegationManager.withdrawalDelayBlocks` of `referenceBlockNumber`. This references a value in the EigenLayer core contracts - see [EigenLayer core docs][core-docs-m2] for more info.
+    * If stale stakes are forbidden (see [`BLSSignatureChecker.setStaleStakesForbidden`](#blssignaturecheckersetstalestakesforbidden)), check the last `quorumUpdateBlockNumber` is within `DelegationManager.minWithdrawalDelayBlocks` of `referenceBlockNumber`. This references a value in the EigenLayer core contracts - see [EigenLayer core docs][core-docs-m2] for more info.
     * Validate that each `params.quorumApks` corresponds to the quorum's apk at the `referenceBlockNumber`
 * For each historical state lookup, the `referenceBlockNumber` and provided index MUST point to a valid historical entry: 
     * `referenceBlockNumber` MUST come after the entry's `updateBlockNumber`

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,8 +97,8 @@ These histories are used by offchain code to query state at particular blocks, a
 ##### Hooking Into EigenLayer Core
 
 The main thing that links an AVS to the EigenLayer core contracts is that when EigenLayer Operators register/deregister with an AVS, the AVS calls these functions in EigenLayer core:
-* [`AVSRegistry.registerOperatorToAVS`][core-registerToAVS]
-* [`AVSRegistry.deregisterOperatorFromAVS`][core-deregisterFromAVS]
+* [`AVSDirectory.registerOperatorToAVS`][core-registerToAVS]
+* [`AVSDirectory.deregisterOperatorFromAVS`][core-deregisterFromAVS]
 
 These methods ensure that the Operator registering with the AVS is also registered as an Operator in EigenLayer core. In this repo, these methods are called by the `ServiceManagerBase`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,8 +97,8 @@ These histories are used by offchain code to query state at particular blocks, a
 ##### Hooking Into EigenLayer Core
 
 The main thing that links an AVS to the EigenLayer core contracts is that when EigenLayer Operators register/deregister with an AVS, the AVS calls these functions in EigenLayer core:
-* [`DelegationManager.registerOperatorToAVS`][core-registerToAVS]
-* [`DelegationManager.deregisterOperatorFromAVS`][core-deregisterFromAVS]
+* [`AVSRegistry.registerOperatorToAVS`][core-registerToAVS]
+* [`AVSRegistry.deregisterOperatorFromAVS`][core-deregisterFromAVS]
 
 These methods ensure that the Operator registering with the AVS is also registered as an Operator in EigenLayer core. In this repo, these methods are called by the `ServiceManagerBase`.
 

--- a/src/BLSSignatureChecker.sol
+++ b/src/BLSSignatureChecker.sol
@@ -46,7 +46,7 @@ contract BLSSignatureChecker is IBLSSignatureChecker {
 
     /**
      * RegistryCoordinator owner can either enforce or not that operator stakes are staler
-     * than the delegation.withdrawalDelayBlocks() window.
+     * than the delegation.minWithdrawalDelayBlocks() window.
      * @param value to toggle staleStakesForbidden
      */
     function setStaleStakesForbidden(bool value) external onlyCoordinatorOwner {
@@ -179,8 +179,8 @@ contract BLSSignatureChecker is IBLSSignatureChecker {
          * - subtract the stake for each nonsigner to calculate the stake belonging to signers
          */
         {
-            uint256 withdrawalDelayBlocks = delegation.withdrawalDelayBlocks();
             bool _staleStakesForbidden = staleStakesForbidden;
+            uint256 withdrawalDelayBlocks = _staleStakesForbidden ? delegation.minWithdrawalDelayBlocks() : 0;
 
             for (uint256 i = 0; i < quorumNumbers.length; i++) {
                 // If we're disallowing stale stake updates, check that each quorum's last update block

--- a/src/ServiceManagerBase.sol
+++ b/src/ServiceManagerBase.sol
@@ -5,7 +5,7 @@ import {OwnableUpgradeable} from "@openzeppelin-upgrades/contracts/access/Ownabl
 
 import {BitmapUtils} from "./libraries/BitmapUtils.sol"; 
 import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
-import {IDelegationManager} from "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
+import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
 
 import {IServiceManager} from "./interfaces/IServiceManager.sol";
 import {IRegistryCoordinator} from "./interfaces/IRegistryCoordinator.sol";
@@ -20,8 +20,8 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
     using BitmapUtils for *;
 
     IRegistryCoordinator internal immutable _registryCoordinator;
-    IDelegationManager internal immutable _delegationManager;
     IStakeRegistry internal immutable _stakeRegistry;
+    IAVSDirectory internal immutable _avsDirectory;
 
     /// @notice when applied to a function, only allows the RegistryCoordinator to call it
     modifier onlyRegistryCoordinator() {
@@ -34,11 +34,11 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
 
     /// @notice Sets the (immutable) `_registryCoordinator` address
     constructor(
-        IDelegationManager __delegationManager,
+        IAVSDirectory __avsDirectory,
         IRegistryCoordinator __registryCoordinator,
         IStakeRegistry __stakeRegistry
     ) {
-        _delegationManager = __delegationManager;
+        _avsDirectory = __avsDirectory;
         _registryCoordinator = __registryCoordinator;
         _stakeRegistry = __stakeRegistry;
         _disableInitializers();
@@ -54,11 +54,11 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
      * @dev only callable by the owner
      */
     function setMetadataURI(string memory _metadataURI) public virtual onlyOwner {
-        _delegationManager.updateAVSMetadataURI(_metadataURI);
+        _avsDirectory.updateAVSMetadataURI(_metadataURI);
     }
 
     /**
-     * @notice Forwards a call to EigenLayer's DelegationManager contract to confirm operator registration with the AVS
+     * @notice Forwards a call to EigenLayer's AVSDirectory contract to confirm operator registration with the AVS
      * @param operator The address of the operator to register.
      * @param operatorSignature The signature, salt, and expiry of the operator's signature.
      */
@@ -66,15 +66,15 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
         address operator,
         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
     ) public virtual onlyRegistryCoordinator {
-        _delegationManager.registerOperatorToAVS(operator, operatorSignature);
+        _avsDirectory.registerOperatorToAVS(operator, operatorSignature);
     }
 
     /**
-     * @notice Forwards a call to EigenLayer's DelegationManager contract to confirm operator deregistration from the AVS
+     * @notice Forwards a call to EigenLayer's AVSDirectory contract to confirm operator deregistration from the AVS
      * @param operator The address of the operator to deregister.
      */
     function deregisterOperatorFromAVS(address operator) public virtual onlyRegistryCoordinator {
-        _delegationManager.deregisterOperatorFromAVS(operator);
+        _avsDirectory.deregisterOperatorFromAVS(operator);
     }
 
     /**
@@ -141,5 +141,10 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
             }
         }
         return restakedStrategies;        
+    }
+
+    /// @notice Returns the EigenLayer AVSDirectory contract.
+    function avsDirectory() external view override returns (address) {
+        return address(_avsDirectory);
     }
 }

--- a/src/ServiceManagerBase.sol
+++ b/src/ServiceManagerBase.sol
@@ -20,10 +20,6 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
     using BitmapUtils for *;
 
     IRegistryCoordinator internal immutable _registryCoordinator;
-<<<<<<< HEAD
-=======
-    IAVSDirectory internal immutable _avsDirectory;
->>>>>>> feat: add avs directory to service manager
     IStakeRegistry internal immutable _stakeRegistry;
     IAVSDirectory internal immutable _avsDirectory;
 

--- a/src/ServiceManagerBase.sol
+++ b/src/ServiceManagerBase.sol
@@ -20,6 +20,10 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
     using BitmapUtils for *;
 
     IRegistryCoordinator internal immutable _registryCoordinator;
+<<<<<<< HEAD
+=======
+    IAVSDirectory internal immutable _avsDirectory;
+>>>>>>> feat: add avs directory to service manager
     IStakeRegistry internal immutable _stakeRegistry;
     IAVSDirectory internal immutable _avsDirectory;
 

--- a/src/interfaces/IServiceManager.sol
+++ b/src/interfaces/IServiceManager.sol
@@ -47,4 +47,7 @@ interface IServiceManager {
      *      The off-chain service should do that validation separately
      */
     function getRestakeableStrategies() external view returns (address[] memory);
+
+    /// @notice Returns the EigenLayer AVSDirectory contract.
+    function avsDirectory() external view returns (address);
 }

--- a/test/integration/CoreRegistration.t.sol
+++ b/test/integration/CoreRegistration.t.sol
@@ -11,7 +11,6 @@ import { IAVSDirectory } from "eigenlayer-contracts/src/contracts/interfaces/IAV
 contract Test_CoreRegistration is MockAVSDeployer {
     // Contracts
     DelegationManager public delegationManager;
-    AVSDirectory public avsDirectory;
 
     // Operator info
     uint256 operatorPrivateKey = 420;

--- a/test/integration/CoreRegistration.t.sol
+++ b/test/integration/CoreRegistration.t.sol
@@ -23,6 +23,8 @@ contract Test_CoreRegistration is MockAVSDeployer {
 
         // Deploy New DelegationManager
         DelegationManager delegationManagerImplementation = new DelegationManager(strategyManagerMock, slasher, eigenPodManagerMock);
+        IStrategy[] memory initializeStrategiesToSetDelayBlocks = new IStrategy[](0);
+        uint256[] memory initializeWithdrawalDelayBlocks = new uint256[](0);
         delegationManager = DelegationManager(
             address(
                 new TransparentUpgradeableProxy(
@@ -33,7 +35,9 @@ contract Test_CoreRegistration is MockAVSDeployer {
                         address(this),
                         pauserRegistry,
                         0, // 0 is initialPausedStatus
-                        50400 // Initial withdrawal delay blocks
+                        50400, // Initial withdrawal delay blocks
+                        initializeStrategiesToSetDelayBlocks,
+                        initializeWithdrawalDelayBlocks
                     )
                 )
             )

--- a/test/integration/CoreRegistration.t.sol
+++ b/test/integration/CoreRegistration.t.sol
@@ -2,6 +2,8 @@
 pragma solidity =0.8.12;
 
 import "../utils/MockAVSDeployer.sol";
+import { AVSDirectory } from "eigenlayer-contracts/src/contracts/core/AVSDirectory.sol";
+import { IAVSDirectory } from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
 import { DelegationManager } from "eigenlayer-contracts/src/contracts/core/DelegationManager.sol";
 import { IDelegationManager } from "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
 import { IAVSDirectory } from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
@@ -43,6 +45,24 @@ contract Test_CoreRegistration is MockAVSDeployer {
                 )
             )
         );
+
+        // Deploy New AVS Directory
+        AVSDirectory avsDirectoryImplementation = new AVSDirectory(delegationManager);
+        avsDirectory = AVSDirectory(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(avsDirectoryImplementation),
+                    address(proxyAdmin),
+                    abi.encodeWithSelector(
+                        AVSDirectory.initialize.selector,
+                        address(this), // owner
+                        pauserRegistry,
+                        0 // 0 is initialPausedStatus
+                    )
+                )
+            )
+        );
+
 
         // Deploy New ServiceManager & RegistryCoordinator implementations
         serviceManagerImplementation = new ServiceManagerBase(
@@ -153,11 +173,14 @@ contract Test_CoreRegistration is MockAVSDeployer {
         serviceManager.setMetadataURI("Test MetadataURI");
     }
 
+    event AVSMetadataURIUpdated(address indexed avs, string metadataURI);
+
     function test_setMetadataURI() public {  
         address toPrankFrom = serviceManager.owner();      
         cheats.prank(toPrankFrom);
+        cheats.expectEmit(true, true, true, true);
+        emit AVSMetadataURIUpdated(address(serviceManager), "Test MetadataURI");
         serviceManager.setMetadataURI("Test MetadataURI");
-        // TODO: check effects here
     }
 
     // Utils

--- a/test/integration/IntegrationBase.t.sol
+++ b/test/integration/IntegrationBase.t.sol
@@ -166,15 +166,15 @@ abstract contract IntegrationBase is IntegrationConfig {
     /// DelegationManager:
     
     function assert_NotRegisteredToAVS(User operator, string memory err) internal {
-        IDelegationManager.OperatorAVSRegistrationStatus status = delegationManager.avsOperatorStatus(address(serviceManager), address(operator));
+        IAVSDirectory.OperatorAVSRegistrationStatus status = avsDirectory.avsOperatorStatus(address(serviceManager), address(operator));
 
-        assertTrue(status == IDelegationManager.OperatorAVSRegistrationStatus.UNREGISTERED, err);
+        assertTrue(status == IAVSDirectory.OperatorAVSRegistrationStatus.UNREGISTERED, err);
     }
 
     function assert_IsRegisteredToAVS(User operator, string memory err) internal {
-        IDelegationManager.OperatorAVSRegistrationStatus status = delegationManager.avsOperatorStatus(address(serviceManager), address(operator));
+        IAVSDirectory.OperatorAVSRegistrationStatus status = avsDirectory.avsOperatorStatus(address(serviceManager), address(operator));
 
-        assertTrue(status == IDelegationManager.OperatorAVSRegistrationStatus.REGISTERED, err);
+        assertTrue(status == IAVSDirectory.OperatorAVSRegistrationStatus.REGISTERED, err);
     }
 
     /*******************************************************************************

--- a/test/integration/IntegrationBase.t.sol
+++ b/test/integration/IntegrationBase.t.sol
@@ -163,7 +163,7 @@ abstract contract IntegrationBase is IntegrationConfig {
         }
     }
 
-    /// DelegationManager:
+    /// AVSDirectory:
     
     function assert_NotRegisteredToAVS(User operator, string memory err) internal {
         IAVSDirectory.OperatorAVSRegistrationStatus status = avsDirectory.avsOperatorStatus(address(serviceManager), address(operator));

--- a/test/integration/IntegrationChecks.t.sol
+++ b/test/integration/IntegrationChecks.t.sol
@@ -71,7 +71,7 @@ contract IntegrationChecks is IntegrationBase {
         assert_Snap_Added_OperatorListEntry(operator, quorums,
             "operator list should have one more entry");
 
-        // DelegationManager
+        // AVSDirectory
         assert_IsRegisteredToAVS(operator,
             "operator should be registered to AVS");
     }
@@ -128,7 +128,7 @@ contract IntegrationChecks is IntegrationBase {
         assert_Snap_Replaced_OperatorListEntries(incomingOperator, churnedOperators, churnedQuorums,
             "operator list should contain incoming operator and should not contain churned operators");
 
-        // DelegationManager
+        // AVSDirectory
         assert_IsRegisteredToAVS(incomingOperator,
             "operator should be registered to AVS");
 
@@ -235,7 +235,7 @@ contract IntegrationChecks is IntegrationBase {
         assert_Snap_Unchanged_OperatorListEntry(quorums,
             "operator list should be unchanged for each quorum");
 
-        // DelegationManager
+        // AVSDirectory
         assert_IsRegisteredToAVS(operator,
             "operator should be registered to AVS");
     }
@@ -315,7 +315,7 @@ contract IntegrationChecks is IntegrationBase {
         assert_Snap_Removed_OperatorListEntry(operator, quorums,
             "operator list should have one fewer entry");
 
-        // DelegationManager
+        // AVSDirectory
         assert_NotRegisteredToAVS(operator, 
             "operator should not be registered to the AVS");
     }
@@ -404,7 +404,7 @@ contract IntegrationChecks is IntegrationBase {
         assert_HasDeregisteredStatus(operator,
             "operatorInfo status should be DEREGISTERED");
 
-        // DelegationManager
+        // AVSDirectory
         assert_NotRegisteredToAVS(operator, 
             "operator should not be registered to the AVS");
     }

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -49,6 +49,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
 
     // Core contracts to deploy
     DelegationManager delegationManager;
+    AVSDirectory avsDirectory;
     StrategyManager strategyManager;
     EigenPodManager eigenPodManager;
     AVSDirectory avsDirectory;

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -152,7 +152,9 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
         DelayedWithdrawalRouter delayedWithdrawalRouterImplementation = new DelayedWithdrawalRouter(eigenPodManager);
 
         // Third, upgrade the proxy contracts to point to the implementations
-        uint256 withdrawalDelayBlocks = 7 days / 12 seconds;
+        uint256 minWithdrawalDelayBlocks = 7 days / 12 seconds;
+        IStrategy[] memory initializeStrategiesToSetDelayBlocks = new IStrategy[](0);
+        uint256[] memory initializeWithdrawalDelayBlocks = new uint256[](0);
         // DelegationManager
         proxyAdmin.upgradeAndCall(
             TransparentUpgradeableProxy(payable(address(delegationManager))),
@@ -162,7 +164,9 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
                 eigenLayerReputedMultisig, // initialOwner
                 pauserRegistry,
                 0 /* initialPausedStatus */,
-                withdrawalDelayBlocks
+                minWithdrawalDelayBlocks,
+                initializeStrategiesToSetDelayBlocks,
+                initializeWithdrawalDelayBlocks
             )
         );
         // StrategyManager
@@ -210,7 +214,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
                 eigenLayerReputedMultisig, // initialOwner
                 pauserRegistry,
                 0, // initialPausedStatus
-                withdrawalDelayBlocks
+                minWithdrawalDelayBlocks
             )
         );
 
@@ -339,9 +343,10 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
 
         // Whitelist strategy
         IStrategy[] memory strategies = new IStrategy[](1);
+        bool[] memory thirdPartyTransfersForbiddenValues = new bool[](1);
         strategies[0] = strategy;
         cheats.prank(strategyManager.strategyWhitelister());
-        strategyManager.addStrategiesToDepositWhitelist(strategies);
+        strategyManager.addStrategiesToDepositWhitelist(strategies, thirdPartyTransfersForbiddenValues);
 
         // Add to allStrats
         allStrats.push(strategy);

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -49,9 +49,9 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
 
     // Core contracts to deploy
     DelegationManager delegationManager;
+    AVSDirectory public avsDirectory;
     StrategyManager strategyManager;
     EigenPodManager eigenPodManager;
-    AVSDirectory avsDirectory;
     PauserRegistry pauserRegistry;
     Slasher slasher;
     IBeacon eigenPodBeacon;

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -49,7 +49,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
 
     // Core contracts to deploy
     DelegationManager delegationManager;
-    AVSDirectory avsDirectory;
+    AVSDirectory public avsDirectory;
     StrategyManager strategyManager;
     EigenPodManager eigenPodManager;
     AVSDirectory avsDirectory;

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -52,7 +52,6 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
     AVSDirectory public avsDirectory;
     StrategyManager strategyManager;
     EigenPodManager eigenPodManager;
-    AVSDirectory avsDirectory;
     PauserRegistry pauserRegistry;
     Slasher slasher;
     IBeacon eigenPodBeacon;

--- a/test/integration/User.t.sol
+++ b/test/integration/User.t.sol
@@ -12,6 +12,7 @@ import "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
 // Core
 import "eigenlayer-contracts/src/contracts/core/DelegationManager.sol";
 import "eigenlayer-contracts/src/contracts/core/StrategyManager.sol";
+import "eigenlayer-contracts/src/contracts/core/AVSDirectory.sol";
 
 // Middleware
 import "src/RegistryCoordinator.sol";
@@ -46,6 +47,7 @@ contract User is Test {
     // Core contracts
     DelegationManager delegationManager;
     StrategyManager strategyManager;
+    AVSDirectory avsDirectory;
 
     // Middleware contracts
     RegistryCoordinator registryCoordinator;
@@ -82,6 +84,7 @@ contract User is Test {
 
         delegationManager = DelegationManager(address(stakeRegistry.delegation()));
         strategyManager = StrategyManager(address(delegationManager.strategyManager()));
+        avsDirectory = AVSDirectory(address(serviceManager.avsDirectory()));
 
         timeMachine = deployer.timeMachine();
 
@@ -300,7 +303,7 @@ contract User is Test {
             expiry: type(uint256).max
         });
 
-        bytes32 digest = delegationManager.calculateOperatorAVSRegistrationDigestHash({
+        bytes32 digest = avsDirectory.calculateOperatorAVSRegistrationDigestHash({
             operator: address(this),
             avs: address(serviceManager),
             salt: signature.salt,

--- a/test/integration/User.t.sol
+++ b/test/integration/User.t.sol
@@ -30,6 +30,7 @@ import "test/integration/utils/BitmapStrings.t.sol";
 
 interface IUserDeployer {
     function registryCoordinator() external view returns (RegistryCoordinator);
+    function avsDirectory() external view returns (AVSDirectory);
     function timeMachine() external view returns (TimeMachine);
     function churnApproverPrivateKey() external view returns (uint);
     function churnApprover() external view returns (address);
@@ -76,6 +77,7 @@ contract User is Test {
         IUserDeployer deployer = IUserDeployer(msg.sender);
 
         registryCoordinator = deployer.registryCoordinator();
+        avsDirectory = deployer.avsDirectory();
         serviceManager = ServiceManagerBase(address(registryCoordinator.serviceManager()));
 
         blsApkRegistry = BLSApkRegistry(address(registryCoordinator.blsApkRegistry()));

--- a/test/mocks/AVSDirectoryMock.sol
+++ b/test/mocks/AVSDirectoryMock.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import {IAVSDirectory, ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
+
+contract AVSDirectoryMock is IAVSDirectory {
+    /**
+     * @notice Called by an avs to register an operator with the avs.
+     * @param operator The address of the operator to register.
+     * @param operatorSignature The signature, salt, and expiry of the operator's signature.
+     */
+    function registerOperatorToAVS(
+        address operator,
+        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
+    ) external {}
+
+    /**
+     * @notice Called by an avs to deregister an operator with the avs.
+     * @param operator The address of the operator to deregister.
+     */
+    function deregisterOperatorFromAVS(address operator) external {}
+
+    /**
+     * @notice Called by an AVS to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
+     * @param metadataURI The URI for metadata associated with an AVS
+     * @dev Note that the `metadataURI` is *never stored * and is only emitted in the `AVSMetadataURIUpdated` event
+     */
+    function updateAVSMetadataURI(string calldata metadataURI) external {}
+
+    /**
+     * @notice Returns whether or not the salt has already been used by the operator.
+     * @dev Salts is used in the `registerOperatorToAVS` function.
+     */
+    function operatorSaltIsSpent(address operator, bytes32 salt) external view returns (bool) {
+        return false;
+    }
+
+    /**
+     * @notice Calculates the digest hash to be signed by an operator to register with an AVS
+     * @param operator The account registering as an operator
+     * @param avs The AVS the operator is registering to
+     * @param salt A unique and single use value associated with the approver signature.
+     * @param expiry Time after which the approver's signature becomes invalid
+     */
+    function calculateOperatorAVSRegistrationDigestHash(
+        address operator,
+        address avs,
+        bytes32 salt,
+        uint256 expiry
+    ) external view returns (bytes32) {
+        return 0x0;
+    }
+
+    /// @notice The EIP-712 typehash for the Registration struct used by the contract
+    function OPERATOR_AVS_REGISTRATION_TYPEHASH() external view returns (bytes32) {
+        return 0x0;
+    }
+}

--- a/test/mocks/AVSDirectoryMock.sol
+++ b/test/mocks/AVSDirectoryMock.sol
@@ -31,9 +31,7 @@ contract AVSDirectoryMock is IAVSDirectory {
      * @notice Returns whether or not the salt has already been used by the operator.
      * @dev Salts is used in the `registerOperatorToAVS` function.
      */
-    function operatorSaltIsSpent(address operator, bytes32 salt) external view returns (bool) {
-        return false;
-    }
+    function operatorSaltIsSpent(address operator, bytes32 salt) external view returns (bool) {}
 
     /**
      * @notice Calculates the digest hash to be signed by an operator to register with an AVS
@@ -47,12 +45,8 @@ contract AVSDirectoryMock is IAVSDirectory {
         address avs,
         bytes32 salt,
         uint256 expiry
-    ) external view returns (bytes32) {
-        return 0x0;
-    }
+    ) external view returns (bytes32) {}
 
     /// @notice The EIP-712 typehash for the Registration struct used by the contract
-    function OPERATOR_AVS_REGISTRATION_TYPEHASH() external view returns (bytes32) {
-        return 0x0;
-    }
-}
+    function OPERATOR_AVS_REGISTRATION_TYPEHASH() external view returns (bytes32) {}
+} 

--- a/test/mocks/DelegationMock.sol
+++ b/test/mocks/DelegationMock.sol
@@ -77,8 +77,20 @@ contract DelegationMock is IDelegationManager {
         return 0;
     }
 
-    function withdrawalDelayBlocks() external pure returns (uint256) {
+    function minWithdrawalDelayBlocks() external view returns (uint256) {
         return 50400;
+    }
+
+    /**
+     * @notice Minimum delay enforced by this contract per Strategy for completing queued withdrawals. Measured in blocks, and adjustable by this contract's owner,
+     * up to a maximum of `MAX_WITHDRAWAL_DELAY_BLOCKS`. Minimum value is 0 (i.e. no delay enforced).
+     */
+    function strategyWithdrawalDelayBlocks(IStrategy /*strategy*/) external view returns (uint256) {
+        return 0;
+    }
+
+    function getWithdrawalDelay(IStrategy[] calldata /*strategies*/) public view returns (uint256) {
+        return 0;
     }
 
     function isDelegated(address staker) external view returns (bool) {

--- a/test/mocks/DelegationMock.sol
+++ b/test/mocks/DelegationMock.sol
@@ -132,17 +132,11 @@ contract DelegationMock is IDelegationManager {
 
     function DELEGATION_APPROVAL_TYPEHASH() external view returns (bytes32) {}
 
-    function OPERATOR_AVS_REGISTRATION_TYPEHASH() external view returns (bytes32) {}
-
     function domainSeparator() external view returns (bytes32) {}
 
     function cumulativeWithdrawalsQueued(address staker) external view returns (uint256) {}
 
     function calculateWithdrawalRoot(Withdrawal memory withdrawal) external pure returns (bytes32) {}
-
-    function registerOperatorToAVS(address operator, ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature) external {}
-
-    function deregisterOperatorFromAVS(address operator) external {}
 
     function operatorSaltIsSpent(address avs, bytes32 salt) external view returns (bool) {}
 

--- a/test/mocks/DelegationMock.sol
+++ b/test/mocks/DelegationMock.sol
@@ -188,10 +188,4 @@ contract DelegationMock is IDelegationManager {
     ) external {
         strategyManager.withdrawSharesAsTokens(recipient, strategy, shares, token);
     }
-
-    function minWithdrawalDelayBlocks() external view returns (uint256) {}
-
-    function strategyWithdrawalDelayBlocks(IStrategy strategy) external view returns (uint256) {}
-
-    function getWithdrawalDelay(IStrategy[] calldata strategies) external view returns (uint256) {}
 }

--- a/test/mocks/DelegationMock.sol
+++ b/test/mocks/DelegationMock.sol
@@ -132,17 +132,11 @@ contract DelegationMock is IDelegationManager {
 
     function DELEGATION_APPROVAL_TYPEHASH() external view returns (bytes32) {}
 
-    function OPERATOR_AVS_REGISTRATION_TYPEHASH() external view returns (bytes32) {}
-
     function domainSeparator() external view returns (bytes32) {}
 
     function cumulativeWithdrawalsQueued(address staker) external view returns (uint256) {}
 
     function calculateWithdrawalRoot(Withdrawal memory withdrawal) external pure returns (bytes32) {}
-
-    function registerOperatorToAVS(address operator, ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature) external {}
-
-    function deregisterOperatorFromAVS(address operator) external {}
 
     function operatorSaltIsSpent(address avs, bytes32 salt) external view returns (bool) {}
 
@@ -194,4 +188,10 @@ contract DelegationMock is IDelegationManager {
     ) external {
         strategyManager.withdrawSharesAsTokens(recipient, strategy, shares, token);
     }
+
+    function minWithdrawalDelayBlocks() external view returns (uint256) {}
+
+    function strategyWithdrawalDelayBlocks(IStrategy strategy) external view returns (uint256) {}
+
+    function getWithdrawalDelay(IStrategy[] calldata strategies) external view returns (uint256) {}
 }

--- a/test/tree/BLSSignatureCheckerUnit.tree
+++ b/test/tree/BLSSignatureCheckerUnit.tree
@@ -20,7 +20,7 @@
 │   ├── given that the non-signer pubkeys contain any duplicates (technically a sub-case of above)
 │   │   └── it should revert
 │   ├── given that the staleStakesForbidden flag is set and the quorumUpdateBlock number is strictly within
-│   │   `delegation.withdrawalDelayBlocks()` of the present block, for any of the quorumNumbers
+│   │   `delegation.minWithdrawalDelayBlocks()` of the present block, for any of the quorumNumbers
 │   │   └── it should revert
 │   ├── given that any of the provided nonSignerQuorumBitmapIndices is incorrect for the referenceBlockNumber
 │   │   └── ***it should revert (via bubbling up a revert from the RegistryCoordinator)

--- a/test/unit/BLSSignatureCheckerUnit.t.sol
+++ b/test/unit/BLSSignatureCheckerUnit.t.sol
@@ -312,7 +312,7 @@ contract BLSSignatureCheckerUnitTests is BLSMockAVSDeployer {
         }
 
         // move referenceBlockNumber forward to a block number the last block number where the stakes will be considered "not stale"
-        referenceBlockNumber = uint32(stalestUpdateBlock + delegationMock.withdrawalDelayBlocks());
+        referenceBlockNumber = uint32(stalestUpdateBlock + delegationMock.minWithdrawalDelayBlocks());
         // roll forward to make the reference block number valid
         cheats.roll(referenceBlockNumber);
         blsSignatureChecker.checkSignatures(

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -28,6 +28,7 @@ import {IServiceManager} from "../../src/interfaces/IServiceManager.sol";
 
 import {StrategyManagerMock} from "eigenlayer-contracts/src/test/mocks/StrategyManagerMock.sol";
 import {EigenPodManagerMock} from "eigenlayer-contracts/src/test/mocks/EigenPodManagerMock.sol";
+import {AVSDirectoryMock} from "../mocks/AVSDirectoryMock.sol";
 import {DelegationMock} from "../mocks/DelegationMock.sol";
 import {AVSDirectory} from "eigenlayer-contracts/src/contracts/core/AVSDirectory.sol";
 import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
@@ -135,7 +136,9 @@ contract MockAVSDeployer is Test {
         pausers[0] = pauser;
         pauserRegistry = new PauserRegistry(pausers, unpauser);
 
+
         delegationMock = new DelegationMock();
+        avsDirectoryMock = new AVSDirectoryMock();
         eigenPodManagerMock = new EigenPodManagerMock();
         strategyManagerMock = new StrategyManagerMock();
         slasherImplementation = new Slasher(strategyManagerMock, delegationMock);

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -69,7 +69,6 @@ contract MockAVSDeployer is Test {
     ServiceManagerBase public serviceManager;
 
     StrategyManagerMock public strategyManagerMock;
-    AVSDirectoryMock public avsDirectoryMock;
     DelegationMock public delegationMock;
     EigenPodManagerMock public eigenPodManagerMock;
     AVSDirectory public avsDirectory;

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -29,6 +29,11 @@ import {IServiceManager} from "../../src/interfaces/IServiceManager.sol";
 import {StrategyManagerMock} from "eigenlayer-contracts/src/test/mocks/StrategyManagerMock.sol";
 import {EigenPodManagerMock} from "eigenlayer-contracts/src/test/mocks/EigenPodManagerMock.sol";
 import {DelegationMock} from "../mocks/DelegationMock.sol";
+import {AVSDirectory} from "eigenlayer-contracts/src/contracts/core/AVSDirectory.sol";
+import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
+
+
+import {AVSDirectoryMock} from "../mocks/AVSDirectoryMock.sol";
 import {BLSApkRegistryHarness} from "../harnesses/BLSApkRegistryHarness.sol";
 import {EmptyContract} from "eigenlayer-contracts/src/test/mocks/EmptyContract.sol";
 
@@ -65,6 +70,9 @@ contract MockAVSDeployer is Test {
     StrategyManagerMock public strategyManagerMock;
     DelegationMock public delegationMock;
     EigenPodManagerMock public eigenPodManagerMock;
+    AVSDirectory public avsDirectory;
+    AVSDirectory public avsDirectoryImplementation;
+    AVSDirectoryMock public avsDirectoryMock;
 
     /// @notice StakeRegistry, Constant used as a divisor in calculating weights.
     uint256 public constant WEIGHTING_DIVISOR = 1e18;
@@ -137,6 +145,17 @@ contract MockAVSDeployer is Test {
                     address(slasherImplementation),
                     address(proxyAdmin),
                     abi.encodeWithSelector(Slasher.initialize.selector, msg.sender, pauserRegistry, 0/*initialPausedStatus*/)
+                )
+            )
+        );
+        avsDirectoryMock = new AVSDirectoryMock();
+        avsDirectoryImplementation = new AVSDirectory(delegationMock);
+        avsDirectory = AVSDirectory(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(avsDirectoryImplementation),
+                    address(proxyAdmin),
+                    abi.encodeWithSelector(AVSDirectory.initialize.selector, msg.sender, pauserRegistry, 0/*initialPausedStatus*/)
                 )
             )
         );
@@ -230,7 +249,7 @@ contract MockAVSDeployer is Test {
         );
 
         serviceManagerImplementation = new ServiceManagerBase(
-            delegationMock,
+            avsDirectoryMock,
             registryCoordinator,
             stakeRegistry
         );

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -28,6 +28,7 @@ import {IServiceManager} from "../../src/interfaces/IServiceManager.sol";
 
 import {StrategyManagerMock} from "eigenlayer-contracts/src/test/mocks/StrategyManagerMock.sol";
 import {EigenPodManagerMock} from "eigenlayer-contracts/src/test/mocks/EigenPodManagerMock.sol";
+import {AVSDirectoryMock} from "../mocks/AVSDirectoryMock.sol";
 import {DelegationMock} from "../mocks/DelegationMock.sol";
 import {AVSDirectory} from "eigenlayer-contracts/src/contracts/core/AVSDirectory.sol";
 import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
@@ -68,6 +69,7 @@ contract MockAVSDeployer is Test {
     ServiceManagerBase public serviceManager;
 
     StrategyManagerMock public strategyManagerMock;
+    AVSDirectoryMock public avsDirectoryMock;
     DelegationMock public delegationMock;
     EigenPodManagerMock public eigenPodManagerMock;
     AVSDirectory public avsDirectory;
@@ -135,7 +137,9 @@ contract MockAVSDeployer is Test {
         pausers[0] = pauser;
         pauserRegistry = new PauserRegistry(pausers, unpauser);
 
+
         delegationMock = new DelegationMock();
+        avsDirectoryMock = new AVSDirectoryMock();
         eigenPodManagerMock = new EigenPodManagerMock();
         strategyManagerMock = new StrategyManagerMock();
         slasherImplementation = new Slasher(strategyManagerMock, delegationMock);


### PR DESCRIPTION
Description:
- updated eigenlayer-contracts submodule to `m2-mainnet-fixes` branch at commit hash 
https://github.com/Layr-Labs/eigenlayer-contracts/tree/66ace9b45c79d36e67f3d1ceb25c44ffb28850de `66ace9b45c79d36e67f3d1ceb25c44ffb28850de`
- change `withdrawalDelayBlocks` to `minWithdrawalDelayBlocks` in sigChecker
- fixed tests and docs
- Updated ServiceManagerBase to call AVSDirectory instead