### PR TITLE
Add AVS Directory Support to Service Manager

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -97,8 +97,8 @@ These histories are used by offchain code to query state at particular blocks, a
 ##### Hooking Into EigenLayer Core
 
 The main thing that links an AVS to the EigenLayer core contracts is that when EigenLayer Operators register/deregister with an AVS, the AVS calls these functions in EigenLayer core:
-* [`DelegationManager.registerOperatorToAVS`][core-registerToAVS]
-* [`DelegationManager.deregisterOperatorFromAVS`][core-deregisterFromAVS]
+* [`AVSRegistry.registerOperatorToAVS`][core-registerToAVS]
+* [`AVSRegistry.deregisterOperatorFromAVS`][core-deregisterFromAVS]
 
 These methods ensure that the Operator registering with the AVS is also registered as an Operator in EigenLayer core. In this repo, these methods are called by the `ServiceManagerBase`.
 

--- a/src/ServiceManagerBase.sol
+++ b/src/ServiceManagerBase.sol
@@ -5,7 +5,7 @@ import {OwnableUpgradeable} from "@openzeppelin-upgrades/contracts/access/Ownabl
 
 import {BitmapUtils} from "./libraries/BitmapUtils.sol"; 
 import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
-import {IDelegationManager} from "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
+import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
 
 import {IServiceManager} from "./interfaces/IServiceManager.sol";
 import {IRegistryCoordinator} from "./interfaces/IRegistryCoordinator.sol";
@@ -20,7 +20,7 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
     using BitmapUtils for *;
 
     IRegistryCoordinator internal immutable _registryCoordinator;
-    IDelegationManager internal immutable _delegationManager;
+    IAVSDirectory internal immutable _avsDirectory;
     IStakeRegistry internal immutable _stakeRegistry;
 
     /// @notice when applied to a function, only allows the RegistryCoordinator to call it
@@ -34,11 +34,11 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
 
     /// @notice Sets the (immutable) `_registryCoordinator` address
     constructor(
-        IDelegationManager __delegationManager,
+        IAVSDirectory __avsDirectory,
         IRegistryCoordinator __registryCoordinator,
         IStakeRegistry __stakeRegistry
     ) {
-        _delegationManager = __delegationManager;
+        _avsDirectory = __avsDirectory;
         _registryCoordinator = __registryCoordinator;
         _stakeRegistry = __stakeRegistry;
         _disableInitializers();
@@ -54,11 +54,11 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
      * @dev only callable by the owner
      */
     function setMetadataURI(string memory _metadataURI) public virtual onlyOwner {
-        _delegationManager.updateAVSMetadataURI(_metadataURI);
+        _avsDirectory.updateAVSMetadataURI(_metadataURI);
     }
 
     /**
-     * @notice Forwards a call to EigenLayer's DelegationManager contract to confirm operator registration with the AVS
+     * @notice Forwards a call to EigenLayer's AVSDirectory contract to confirm operator registration with the AVS
      * @param operator The address of the operator to register.
      * @param operatorSignature The signature, salt, and expiry of the operator's signature.
      */
@@ -66,15 +66,15 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
         address operator,
         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
     ) public virtual onlyRegistryCoordinator {
-        _delegationManager.registerOperatorToAVS(operator, operatorSignature);
+        _avsDirectory.registerOperatorToAVS(operator, operatorSignature);
     }
 
     /**
-     * @notice Forwards a call to EigenLayer's DelegationManager contract to confirm operator deregistration from the AVS
+     * @notice Forwards a call to EigenLayer's AVSDirectory contract to confirm operator deregistration from the AVS
      * @param operator The address of the operator to deregister.
      */
     function deregisterOperatorFromAVS(address operator) public virtual onlyRegistryCoordinator {
-        _delegationManager.deregisterOperatorFromAVS(operator);
+        _avsDirectory.deregisterOperatorFromAVS(operator);
     }
 
     /**

--- a/src/ServiceManagerBase.sol
+++ b/src/ServiceManagerBase.sol
@@ -5,7 +5,7 @@ import {OwnableUpgradeable} from "@openzeppelin-upgrades/contracts/access/Ownabl
 
 import {BitmapUtils} from "./libraries/BitmapUtils.sol"; 
 import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
-import {IDelegationManager} from "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
+import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
 
 import {IServiceManager} from "./interfaces/IServiceManager.sol";
 import {IRegistryCoordinator} from "./interfaces/IRegistryCoordinator.sol";
@@ -20,8 +20,8 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
     using BitmapUtils for *;
 
     IRegistryCoordinator internal immutable _registryCoordinator;
-    IDelegationManager internal immutable _delegationManager;
     IStakeRegistry internal immutable _stakeRegistry;
+    IAVSDirectory internal immutable _avsDirectory;
 
     /// @notice when applied to a function, only allows the RegistryCoordinator to call it
     modifier onlyRegistryCoordinator() {
@@ -34,11 +34,11 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
 
     /// @notice Sets the (immutable) `_registryCoordinator` address
     constructor(
-        IDelegationManager __delegationManager,
+        IAVSDirectory __avsDirectory,
         IRegistryCoordinator __registryCoordinator,
         IStakeRegistry __stakeRegistry
     ) {
-        _delegationManager = __delegationManager;
+        _avsDirectory = __avsDirectory;
         _registryCoordinator = __registryCoordinator;
         _stakeRegistry = __stakeRegistry;
         _disableInitializers();
@@ -54,11 +54,11 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
      * @dev only callable by the owner
      */
     function setMetadataURI(string memory _metadataURI) public virtual onlyOwner {
-        _delegationManager.updateAVSMetadataURI(_metadataURI);
+        _avsDirectory.updateAVSMetadataURI(_metadataURI);
     }
 
     /**
-     * @notice Forwards a call to EigenLayer's DelegationManager contract to confirm operator registration with the AVS
+     * @notice Forwards a call to EigenLayer's AVSDirectory contract to confirm operator registration with the AVS
      * @param operator The address of the operator to register.
      * @param operatorSignature The signature, salt, and expiry of the operator's signature.
      */
@@ -66,15 +66,15 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
         address operator,
         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
     ) public virtual onlyRegistryCoordinator {
-        _delegationManager.registerOperatorToAVS(operator, operatorSignature);
+        _avsDirectory.registerOperatorToAVS(operator, operatorSignature);
     }
 
     /**
-     * @notice Forwards a call to EigenLayer's DelegationManager contract to confirm operator deregistration from the AVS
+     * @notice Forwards a call to EigenLayer's AVSDirectory contract to confirm operator deregistration from the AVS
      * @param operator The address of the operator to deregister.
      */
     function deregisterOperatorFromAVS(address operator) public virtual onlyRegistryCoordinator {
-        _delegationManager.deregisterOperatorFromAVS(operator);
+        _avsDirectory.deregisterOperatorFromAVS(operator);
     }
 
     /**
@@ -141,5 +141,10 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
             }
         }
         return restakedStrategies;        
+    }
+
+    /// @notice Returns the EigenLayer AVSDirectory contract.
+    function avsDirectory() external view override returns (address) {
+        return address(_avsDirectory);
     }
 }

--- a/src/ServiceManagerBase.sol
+++ b/src/ServiceManagerBase.sol
@@ -20,6 +20,10 @@ contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
     using BitmapUtils for *;
 
     IRegistryCoordinator internal immutable _registryCoordinator;
+<<<<<<< HEAD
+=======
+    IAVSDirectory internal immutable _avsDirectory;
+>>>>>>> feat: add avs directory to service manager
     IStakeRegistry internal immutable _stakeRegistry;
     IAVSDirectory internal immutable _avsDirectory;
 

--- a/src/interfaces/IServiceManager.sol
+++ b/src/interfaces/IServiceManager.sol
@@ -47,4 +47,7 @@ interface IServiceManager {
      *      The off-chain service should do that validation separately
      */
     function getRestakeableStrategies() external view returns (address[] memory);
+
+    /// @notice Returns the EigenLayer AVSDirectory contract.
+    function avsDirectory() external view returns (address);
 }

--- a/test/integration/CoreRegistration.t.sol
+++ b/test/integration/CoreRegistration.t.sol
@@ -11,7 +11,6 @@ import { IAVSDirectory } from "eigenlayer-contracts/src/contracts/interfaces/IAV
 contract Test_CoreRegistration is MockAVSDeployer {
     // Contracts
     DelegationManager public delegationManager;
-    AVSDirectory public avsDirectory;
 
     // Operator info
     uint256 operatorPrivateKey = 420;

--- a/test/integration/CoreRegistration.t.sol
+++ b/test/integration/CoreRegistration.t.sol
@@ -130,7 +130,7 @@ contract Test_CoreRegistration is MockAVSDeployer {
 
         // Check operator is registered
         IAVSDirectory.OperatorAVSRegistrationStatus operatorStatus = avsDirectory.avsOperatorStatus(address(serviceManager), operator);
-        assertEq(uint8(operatorStatus), uint8(IDelegationManager.OperatorAVSRegistrationStatus.REGISTERED));
+        assertEq(uint8(operatorStatus), uint8(IAVSDirectory.OperatorAVSRegistrationStatus.REGISTERED));
     }
 
     function test_deregisterOperator_coreStateChanges() public {
@@ -144,7 +144,7 @@ contract Test_CoreRegistration is MockAVSDeployer {
 
         // Check operator is deregistered
         IAVSDirectory.OperatorAVSRegistrationStatus operatorStatus = avsDirectory.avsOperatorStatus(address(serviceManager), operator);
-        assertEq(uint8(operatorStatus), uint8(IDelegationManager.OperatorAVSRegistrationStatus.UNREGISTERED));
+        assertEq(uint8(operatorStatus), uint8(IAVSDirectory.OperatorAVSRegistrationStatus.UNREGISTERED));
     }
 
     function test_deregisterOperator_notGloballyDeregistered() public {
@@ -160,7 +160,7 @@ contract Test_CoreRegistration is MockAVSDeployer {
 
         // Check operator is still registered
         IAVSDirectory.OperatorAVSRegistrationStatus operatorStatus = avsDirectory.avsOperatorStatus(address(serviceManager), operator);
-        assertEq(uint8(operatorStatus), uint8(IDelegationManager.OperatorAVSRegistrationStatus.REGISTERED));
+        assertEq(uint8(operatorStatus), uint8(IAVSDirectory.OperatorAVSRegistrationStatus.REGISTERED));
     }
 
     function test_setMetadataURI_fail_notServiceManagerOwner() public {
@@ -206,7 +206,7 @@ contract Test_CoreRegistration is MockAVSDeployer {
         operatorSignature.salt = salt;
         operatorSignature.expiry = expiry;
         {
-            bytes32 digestHash = delegationManager.calculateOperatorAVSRegistrationDigestHash(operatorToSign, avs, salt, expiry);
+            bytes32 digestHash = avsDirectory.calculateOperatorAVSRegistrationDigestHash(operatorToSign, avs, salt, expiry);
             (uint8 v, bytes32 r, bytes32 s) = cheats.sign(_operatorPrivateKey, digestHash);
             operatorSignature.signature = abi.encodePacked(r, s, v);
         }

--- a/test/integration/IntegrationBase.t.sol
+++ b/test/integration/IntegrationBase.t.sol
@@ -166,15 +166,15 @@ abstract contract IntegrationBase is IntegrationConfig {
     /// DelegationManager:
     
     function assert_NotRegisteredToAVS(User operator, string memory err) internal {
-        IDelegationManager.OperatorAVSRegistrationStatus status = delegationManager.avsOperatorStatus(address(serviceManager), address(operator));
+        IAVSDirectory.OperatorAVSRegistrationStatus status = avsDirectory.avsOperatorStatus(address(serviceManager), address(operator));
 
-        assertTrue(status == IDelegationManager.OperatorAVSRegistrationStatus.UNREGISTERED, err);
+        assertTrue(status == IAVSDirectory.OperatorAVSRegistrationStatus.UNREGISTERED, err);
     }
 
     function assert_IsRegisteredToAVS(User operator, string memory err) internal {
-        IDelegationManager.OperatorAVSRegistrationStatus status = delegationManager.avsOperatorStatus(address(serviceManager), address(operator));
+        IAVSDirectory.OperatorAVSRegistrationStatus status = avsDirectory.avsOperatorStatus(address(serviceManager), address(operator));
 
-        assertTrue(status == IDelegationManager.OperatorAVSRegistrationStatus.REGISTERED, err);
+        assertTrue(status == IAVSDirectory.OperatorAVSRegistrationStatus.REGISTERED, err);
     }
 
     /*******************************************************************************

--- a/test/integration/IntegrationBase.t.sol
+++ b/test/integration/IntegrationBase.t.sol
@@ -163,7 +163,7 @@ abstract contract IntegrationBase is IntegrationConfig {
         }
     }
 
-    /// DelegationManager:
+    /// AVSDirectory:
     
     function assert_NotRegisteredToAVS(User operator, string memory err) internal {
         IAVSDirectory.OperatorAVSRegistrationStatus status = avsDirectory.avsOperatorStatus(address(serviceManager), address(operator));

--- a/test/integration/IntegrationBase.t.sol
+++ b/test/integration/IntegrationBase.t.sol
@@ -166,13 +166,13 @@ abstract contract IntegrationBase is IntegrationConfig {
     /// AVSDirectory:
     
     function assert_NotRegisteredToAVS(User operator, string memory err) internal {
-        IAVSDirectory.OperatorAVSRegistrationStatus status = avsDirectory.avsOperatorStatus(address(serviceManager), operator);
+        IAVSDirectory.OperatorAVSRegistrationStatus status = avsDirectory.avsOperatorStatus(address(serviceManager), address(operator));
 
         assertTrue(status == IAVSDirectory.OperatorAVSRegistrationStatus.UNREGISTERED, err);
     }
 
     function assert_IsRegisteredToAVS(User operator, string memory err) internal {
-        IAVSDirectory.OperatorAVSRegistrationStatus status = avsDirectory.avsOperatorStatus(address(serviceManager), operator);
+        IAVSDirectory.OperatorAVSRegistrationStatus status = avsDirectory.avsOperatorStatus(address(serviceManager), address(operator));
 
         assertTrue(status == IAVSDirectory.OperatorAVSRegistrationStatus.REGISTERED, err);
     }

--- a/test/integration/IntegrationBase.t.sol
+++ b/test/integration/IntegrationBase.t.sol
@@ -163,18 +163,18 @@ abstract contract IntegrationBase is IntegrationConfig {
         }
     }
 
-    /// DelegationManager:
+    /// AVSDirectory:
     
     function assert_NotRegisteredToAVS(User operator, string memory err) internal {
-        IDelegationManager.OperatorAVSRegistrationStatus status = delegationManager.avsOperatorStatus(address(serviceManager), address(operator));
+        IAVSDirectory.OperatorAVSRegistrationStatus status = avsDirectory.avsOperatorStatus(address(serviceManager), operator);
 
-        assertTrue(status == IDelegationManager.OperatorAVSRegistrationStatus.UNREGISTERED, err);
+        assertTrue(status == IAVSDirectory.OperatorAVSRegistrationStatus.UNREGISTERED, err);
     }
 
     function assert_IsRegisteredToAVS(User operator, string memory err) internal {
-        IDelegationManager.OperatorAVSRegistrationStatus status = delegationManager.avsOperatorStatus(address(serviceManager), address(operator));
+        IAVSDirectory.OperatorAVSRegistrationStatus status = avsDirectory.avsOperatorStatus(address(serviceManager), operator);
 
-        assertTrue(status == IDelegationManager.OperatorAVSRegistrationStatus.REGISTERED, err);
+        assertTrue(status == IAVSDirectory.OperatorAVSRegistrationStatus.REGISTERED, err);
     }
 
     /*******************************************************************************

--- a/test/integration/IntegrationChecks.t.sol
+++ b/test/integration/IntegrationChecks.t.sol
@@ -71,7 +71,7 @@ contract IntegrationChecks is IntegrationBase {
         assert_Snap_Added_OperatorListEntry(operator, quorums,
             "operator list should have one more entry");
 
-        // DelegationManager
+        // AVSDirectory
         assert_IsRegisteredToAVS(operator,
             "operator should be registered to AVS");
     }
@@ -128,7 +128,7 @@ contract IntegrationChecks is IntegrationBase {
         assert_Snap_Replaced_OperatorListEntries(incomingOperator, churnedOperators, churnedQuorums,
             "operator list should contain incoming operator and should not contain churned operators");
 
-        // DelegationManager
+        // AVSDirectory
         assert_IsRegisteredToAVS(incomingOperator,
             "operator should be registered to AVS");
 
@@ -235,7 +235,7 @@ contract IntegrationChecks is IntegrationBase {
         assert_Snap_Unchanged_OperatorListEntry(quorums,
             "operator list should be unchanged for each quorum");
 
-        // DelegationManager
+        // AVSDirectory
         assert_IsRegisteredToAVS(operator,
             "operator should be registered to AVS");
     }
@@ -315,7 +315,7 @@ contract IntegrationChecks is IntegrationBase {
         assert_Snap_Removed_OperatorListEntry(operator, quorums,
             "operator list should have one fewer entry");
 
-        // DelegationManager
+        // AVSDirectory
         assert_NotRegisteredToAVS(operator, 
             "operator should not be registered to the AVS");
     }
@@ -404,7 +404,7 @@ contract IntegrationChecks is IntegrationBase {
         assert_HasDeregisteredStatus(operator,
             "operatorInfo status should be DEREGISTERED");
 
-        // DelegationManager
+        // AVSDirectory
         assert_NotRegisteredToAVS(operator, 
             "operator should not be registered to the AVS");
     }

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -15,6 +15,7 @@ import "@openzeppelin/contracts/utils/Strings.sol";
 import "eigenlayer-contracts/src/contracts/core/DelegationManager.sol";
 import "eigenlayer-contracts/src/contracts/core/StrategyManager.sol";
 import "eigenlayer-contracts/src/contracts/core/Slasher.sol";
+import "eigenlayer-contracts/src/contracts/core/AVSDirectory.sol";
 import "eigenlayer-contracts/src/contracts/strategies/StrategyBase.sol";
 import "eigenlayer-contracts/src/contracts/pods/EigenPodManager.sol";
 import "eigenlayer-contracts/src/contracts/pods/EigenPod.sol";
@@ -48,6 +49,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
 
     // Core contracts to deploy
     DelegationManager delegationManager;
+    AVSDirectory avsDirectory;
     StrategyManager strategyManager;
     EigenPodManager eigenPodManager;
     PauserRegistry pauserRegistry;
@@ -124,6 +126,9 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
             address(new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), ""))
         );
         delayedWithdrawalRouter = DelayedWithdrawalRouter(
+            address(new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), ""))
+        );
+        avsDirectory = AVSDirectory(
             address(new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), ""))
         );
 
@@ -215,6 +220,17 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
                 pauserRegistry,
                 0, // initialPausedStatus
                 minWithdrawalDelayBlocks
+            )
+        );
+        // AVS Directory
+        proxyAdmin.upgradeAndCall(
+            TransparentUpgradeableProxy(payable(address(avsDirectory))),
+            address(new AVSDirectory(delegationManager)),
+            abi.encodeWithSelector(
+                AVSDirectory.initialize.selector,
+                eigenLayerReputedMultisig, // initialOwner
+                pauserRegistry,
+                0 // initialPausedStatus
             )
         );
 

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -49,6 +49,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
 
     // Core contracts to deploy
     DelegationManager delegationManager;
+    AVSDirectory avsDirectory;
     StrategyManager strategyManager;
     EigenPodManager eigenPodManager;
     AVSDirectory avsDirectory;

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -49,7 +49,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
 
     // Core contracts to deploy
     DelegationManager delegationManager;
-    AVSDirectory avsDirectory;
+    AVSDirectory public avsDirectory;
     StrategyManager strategyManager;
     EigenPodManager eigenPodManager;
     PauserRegistry pauserRegistry;
@@ -299,7 +299,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
         StakeRegistry stakeRegistryImplementation = new StakeRegistry(IRegistryCoordinator(registryCoordinator), IDelegationManager(delegationManager));
         BLSApkRegistry blsApkRegistryImplementation = new BLSApkRegistry(IRegistryCoordinator(registryCoordinator));
         IndexRegistry indexRegistryImplementation = new IndexRegistry(IRegistryCoordinator(registryCoordinator));
-        ServiceManagerBase serviceManagerImplementation = new ServiceManagerBase(IDelegationManager(delegationManager), IRegistryCoordinator(registryCoordinator), stakeRegistry);
+        ServiceManagerBase serviceManagerImplementation = new ServiceManagerBase(IAVSDirectory(avsDirectory), IRegistryCoordinator(registryCoordinator), stakeRegistry);
 
         proxyAdmin.upgrade(
             TransparentUpgradeableProxy(payable(address(stakeRegistry))),

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -49,7 +49,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
 
     // Core contracts to deploy
     DelegationManager delegationManager;
-    AVSDirectory avsDirectory;
+    AVSDirectory public avsDirectory;
     StrategyManager strategyManager;
     EigenPodManager eigenPodManager;
     AVSDirectory avsDirectory;

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -52,7 +52,6 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
     AVSDirectory public avsDirectory;
     StrategyManager strategyManager;
     EigenPodManager eigenPodManager;
-    AVSDirectory avsDirectory;
     PauserRegistry pauserRegistry;
     Slasher slasher;
     IBeacon eigenPodBeacon;

--- a/test/integration/User.t.sol
+++ b/test/integration/User.t.sol
@@ -12,6 +12,7 @@ import "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
 // Core
 import "eigenlayer-contracts/src/contracts/core/DelegationManager.sol";
 import "eigenlayer-contracts/src/contracts/core/StrategyManager.sol";
+import "eigenlayer-contracts/src/contracts/core/AVSDirectory.sol";
 
 // Middleware
 import "src/RegistryCoordinator.sol";
@@ -46,6 +47,7 @@ contract User is Test {
     // Core contracts
     DelegationManager delegationManager;
     StrategyManager strategyManager;
+    AVSDirectory avsDirectory;
 
     // Middleware contracts
     RegistryCoordinator registryCoordinator;
@@ -82,6 +84,7 @@ contract User is Test {
 
         delegationManager = DelegationManager(address(stakeRegistry.delegation()));
         strategyManager = StrategyManager(address(delegationManager.strategyManager()));
+        avsDirectory = AVSDirectory(address(serviceManager.avsDirectory()));
 
         timeMachine = deployer.timeMachine();
 
@@ -300,7 +303,7 @@ contract User is Test {
             expiry: type(uint256).max
         });
 
-        bytes32 digest = delegationManager.calculateOperatorAVSRegistrationDigestHash({
+        bytes32 digest = avsDirectory.calculateOperatorAVSRegistrationDigestHash({
             operator: address(this),
             avs: address(serviceManager),
             salt: signature.salt,

--- a/test/integration/User.t.sol
+++ b/test/integration/User.t.sol
@@ -30,6 +30,7 @@ import "test/integration/utils/BitmapStrings.t.sol";
 
 interface IUserDeployer {
     function registryCoordinator() external view returns (RegistryCoordinator);
+    function avsDirectory() external view returns (AVSDirectory);
     function timeMachine() external view returns (TimeMachine);
     function churnApproverPrivateKey() external view returns (uint);
     function churnApprover() external view returns (address);
@@ -76,6 +77,7 @@ contract User is Test {
         IUserDeployer deployer = IUserDeployer(msg.sender);
 
         registryCoordinator = deployer.registryCoordinator();
+        avsDirectory = deployer.avsDirectory();
         serviceManager = ServiceManagerBase(address(registryCoordinator.serviceManager()));
 
         blsApkRegistry = BLSApkRegistry(address(registryCoordinator.blsApkRegistry()));

--- a/test/integration/User.t.sol
+++ b/test/integration/User.t.sol
@@ -12,6 +12,7 @@ import "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
 // Core
 import "eigenlayer-contracts/src/contracts/core/DelegationManager.sol";
 import "eigenlayer-contracts/src/contracts/core/StrategyManager.sol";
+import "eigenlayer-contracts/src/contracts/core/AVSDirectory.sol";
 
 // Middleware
 import "src/RegistryCoordinator.sol";
@@ -29,6 +30,7 @@ import "test/integration/utils/BitmapStrings.t.sol";
 
 interface IUserDeployer {
     function registryCoordinator() external view returns (RegistryCoordinator);
+    function avsDirectory() external view returns (AVSDirectory);
     function timeMachine() external view returns (TimeMachine);
     function churnApproverPrivateKey() external view returns (uint);
     function churnApprover() external view returns (address);
@@ -46,6 +48,7 @@ contract User is Test {
     // Core contracts
     DelegationManager delegationManager;
     StrategyManager strategyManager;
+    AVSDirectory avsDirectory;
 
     // Middleware contracts
     RegistryCoordinator registryCoordinator;
@@ -74,6 +77,7 @@ contract User is Test {
         IUserDeployer deployer = IUserDeployer(msg.sender);
 
         registryCoordinator = deployer.registryCoordinator();
+        avsDirectory = deployer.avsDirectory();
         serviceManager = ServiceManagerBase(address(registryCoordinator.serviceManager()));
 
         blsApkRegistry = BLSApkRegistry(address(registryCoordinator.blsApkRegistry()));
@@ -300,7 +304,7 @@ contract User is Test {
             expiry: type(uint256).max
         });
 
-        bytes32 digest = delegationManager.calculateOperatorAVSRegistrationDigestHash({
+        bytes32 digest = avsDirectory.calculateOperatorAVSRegistrationDigestHash({
             operator: address(this),
             avs: address(serviceManager),
             salt: signature.salt,

--- a/test/mocks/AVSDirectoryMock.sol
+++ b/test/mocks/AVSDirectoryMock.sol
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity =0.8.12;
 
-<<<<<<< HEAD
 import {IAVSDirectory, ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
-=======
-import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
-import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
->>>>>>> cac457271cc43feb8aefe886ef359a4f6621cb9c
 
 contract AVSDirectoryMock is IAVSDirectory {
     /**

--- a/test/mocks/AVSDirectoryMock.sol
+++ b/test/mocks/AVSDirectoryMock.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
+import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
+
+contract AVSDirectoryMock is IAVSDirectory {
+    /**
+     * @notice Called by an avs to register an operator with the avs.
+     * @param operator The address of the operator to register.
+     * @param operatorSignature The signature, salt, and expiry of the operator's signature.
+     */
+    function registerOperatorToAVS(
+        address operator,
+        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
+    ) external {}
+
+    /**
+     * @notice Called by an avs to deregister an operator with the avs.
+     * @param operator The address of the operator to deregister.
+     */
+    function deregisterOperatorFromAVS(address operator) external {}
+
+    /**
+     * @notice Called by an AVS to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
+     * @param metadataURI The URI for metadata associated with an AVS
+     * @dev Note that the `metadataURI` is *never stored * and is only emitted in the `AVSMetadataURIUpdated` event
+     */
+    function updateAVSMetadataURI(string calldata metadataURI) external {}
+
+    /**
+     * @notice Returns whether or not the salt has already been used by the operator.
+     * @dev Salts is used in the `registerOperatorToAVS` function.
+     */
+    function operatorSaltIsSpent(address operator, bytes32 salt) external view returns (bool) {}
+
+    /**
+     * @notice Calculates the digest hash to be signed by an operator to register with an AVS
+     * @param operator The account registering as an operator
+     * @param avs The AVS the operator is registering to
+     * @param salt A unique and single use value associated with the approver signature.
+     * @param expiry Time after which the approver's signature becomes invalid
+     */
+    function calculateOperatorAVSRegistrationDigestHash(
+        address operator,
+        address avs,
+        bytes32 salt,
+        uint256 expiry
+    ) external view returns (bytes32) {}
+
+    /// @notice The EIP-712 typehash for the Registration struct used by the contract
+    function OPERATOR_AVS_REGISTRATION_TYPEHASH() external view returns (bytes32) {}
+} 

--- a/test/mocks/AVSDirectoryMock.sol
+++ b/test/mocks/AVSDirectoryMock.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import {IAVSDirectory, ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
+
+contract AVSDirectoryMock is IAVSDirectory {
+    /**
+     * @notice Called by an avs to register an operator with the avs.
+     * @param operator The address of the operator to register.
+     * @param operatorSignature The signature, salt, and expiry of the operator's signature.
+     */
+    function registerOperatorToAVS(
+        address operator,
+        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
+    ) external {}
+
+    /**
+     * @notice Called by an avs to deregister an operator with the avs.
+     * @param operator The address of the operator to deregister.
+     */
+    function deregisterOperatorFromAVS(address operator) external {}
+
+    /**
+     * @notice Called by an AVS to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
+     * @param metadataURI The URI for metadata associated with an AVS
+     * @dev Note that the `metadataURI` is *never stored * and is only emitted in the `AVSMetadataURIUpdated` event
+     */
+    function updateAVSMetadataURI(string calldata metadataURI) external {}
+
+    /**
+     * @notice Returns whether or not the salt has already been used by the operator.
+     * @dev Salts is used in the `registerOperatorToAVS` function.
+     */
+    function operatorSaltIsSpent(address operator, bytes32 salt) external view returns (bool) {
+        return false;
+    }
+
+    /**
+     * @notice Calculates the digest hash to be signed by an operator to register with an AVS
+     * @param operator The account registering as an operator
+     * @param avs The AVS the operator is registering to
+     * @param salt A unique and single use value associated with the approver signature.
+     * @param expiry Time after which the approver's signature becomes invalid
+     */
+    function calculateOperatorAVSRegistrationDigestHash(
+        address operator,
+        address avs,
+        bytes32 salt,
+        uint256 expiry
+    ) external view returns (bytes32) {
+        return 0x0;
+    }
+
+    /// @notice The EIP-712 typehash for the Registration struct used by the contract
+    function OPERATOR_AVS_REGISTRATION_TYPEHASH() external view returns (bytes32) {
+        return 0x0;
+    }
+}

--- a/test/mocks/AVSDirectoryMock.sol
+++ b/test/mocks/AVSDirectoryMock.sol
@@ -31,9 +31,7 @@ contract AVSDirectoryMock is IAVSDirectory {
      * @notice Returns whether or not the salt has already been used by the operator.
      * @dev Salts is used in the `registerOperatorToAVS` function.
      */
-    function operatorSaltIsSpent(address operator, bytes32 salt) external view returns (bool) {
-        return false;
-    }
+    function operatorSaltIsSpent(address operator, bytes32 salt) external view returns (bool) {}
 
     /**
      * @notice Calculates the digest hash to be signed by an operator to register with an AVS
@@ -47,12 +45,8 @@ contract AVSDirectoryMock is IAVSDirectory {
         address avs,
         bytes32 salt,
         uint256 expiry
-    ) external view returns (bytes32) {
-        return 0x0;
-    }
+    ) external view returns (bytes32) {}
 
     /// @notice The EIP-712 typehash for the Registration struct used by the contract
-    function OPERATOR_AVS_REGISTRATION_TYPEHASH() external view returns (bytes32) {
-        return 0x0;
-    }
-}
+    function OPERATOR_AVS_REGISTRATION_TYPEHASH() external view returns (bytes32) {}
+} 

--- a/test/mocks/DelegationMock.sol
+++ b/test/mocks/DelegationMock.sol
@@ -132,17 +132,11 @@ contract DelegationMock is IDelegationManager {
 
     function DELEGATION_APPROVAL_TYPEHASH() external view returns (bytes32) {}
 
-    function OPERATOR_AVS_REGISTRATION_TYPEHASH() external view returns (bytes32) {}
-
     function domainSeparator() external view returns (bytes32) {}
 
     function cumulativeWithdrawalsQueued(address staker) external view returns (uint256) {}
 
     function calculateWithdrawalRoot(Withdrawal memory withdrawal) external pure returns (bytes32) {}
-
-    function registerOperatorToAVS(address operator, ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature) external {}
-
-    function deregisterOperatorFromAVS(address operator) external {}
 
     function operatorSaltIsSpent(address avs, bytes32 salt) external view returns (bool) {}
 

--- a/test/mocks/DelegationMock.sol
+++ b/test/mocks/DelegationMock.sol
@@ -188,10 +188,4 @@ contract DelegationMock is IDelegationManager {
     ) external {
         strategyManager.withdrawSharesAsTokens(recipient, strategy, shares, token);
     }
-
-    function minWithdrawalDelayBlocks() external view returns (uint256) {}
-
-    function strategyWithdrawalDelayBlocks(IStrategy strategy) external view returns (uint256) {}
-
-    function getWithdrawalDelay(IStrategy[] calldata strategies) external view returns (uint256) {}
 }

--- a/test/mocks/DelegationMock.sol
+++ b/test/mocks/DelegationMock.sol
@@ -132,17 +132,11 @@ contract DelegationMock is IDelegationManager {
 
     function DELEGATION_APPROVAL_TYPEHASH() external view returns (bytes32) {}
 
-    function OPERATOR_AVS_REGISTRATION_TYPEHASH() external view returns (bytes32) {}
-
     function domainSeparator() external view returns (bytes32) {}
 
     function cumulativeWithdrawalsQueued(address staker) external view returns (uint256) {}
 
     function calculateWithdrawalRoot(Withdrawal memory withdrawal) external pure returns (bytes32) {}
-
-    function registerOperatorToAVS(address operator, ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature) external {}
-
-    function deregisterOperatorFromAVS(address operator) external {}
 
     function operatorSaltIsSpent(address avs, bytes32 salt) external view returns (bool) {}
 
@@ -194,4 +188,10 @@ contract DelegationMock is IDelegationManager {
     ) external {
         strategyManager.withdrawSharesAsTokens(recipient, strategy, shares, token);
     }
+
+    function minWithdrawalDelayBlocks() external view returns (uint256) {}
+
+    function strategyWithdrawalDelayBlocks(IStrategy strategy) external view returns (uint256) {}
+
+    function getWithdrawalDelay(IStrategy[] calldata strategies) external view returns (uint256) {}
 }

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -69,7 +69,6 @@ contract MockAVSDeployer is Test {
     ServiceManagerBase public serviceManager;
 
     StrategyManagerMock public strategyManagerMock;
-    AVSDirectoryMock public avsDirectoryMock;
     DelegationMock public delegationMock;
     EigenPodManagerMock public eigenPodManagerMock;
     AVSDirectory public avsDirectory;

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -29,6 +29,11 @@ import {IServiceManager} from "../../src/interfaces/IServiceManager.sol";
 import {StrategyManagerMock} from "eigenlayer-contracts/src/test/mocks/StrategyManagerMock.sol";
 import {EigenPodManagerMock} from "eigenlayer-contracts/src/test/mocks/EigenPodManagerMock.sol";
 import {DelegationMock} from "../mocks/DelegationMock.sol";
+import {AVSDirectory} from "eigenlayer-contracts/src/contracts/core/AVSDirectory.sol";
+import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
+
+
+import {AVSDirectoryMock} from "../mocks/AVSDirectoryMock.sol";
 import {BLSApkRegistryHarness} from "../harnesses/BLSApkRegistryHarness.sol";
 import {EmptyContract} from "eigenlayer-contracts/src/test/mocks/EmptyContract.sol";
 
@@ -65,6 +70,9 @@ contract MockAVSDeployer is Test {
     StrategyManagerMock public strategyManagerMock;
     DelegationMock public delegationMock;
     EigenPodManagerMock public eigenPodManagerMock;
+    AVSDirectory public avsDirectory;
+    AVSDirectory public avsDirectoryImplementation;
+    AVSDirectoryMock public avsDirectoryMock;
 
     /// @notice StakeRegistry, Constant used as a divisor in calculating weights.
     uint256 public constant WEIGHTING_DIVISOR = 1e18;
@@ -137,6 +145,17 @@ contract MockAVSDeployer is Test {
                     address(slasherImplementation),
                     address(proxyAdmin),
                     abi.encodeWithSelector(Slasher.initialize.selector, msg.sender, pauserRegistry, 0/*initialPausedStatus*/)
+                )
+            )
+        );
+        avsDirectoryMock = new AVSDirectoryMock();
+        avsDirectoryImplementation = new AVSDirectory(delegationMock);
+        avsDirectory = AVSDirectory(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(avsDirectoryImplementation),
+                    address(proxyAdmin),
+                    abi.encodeWithSelector(AVSDirectory.initialize.selector, msg.sender, pauserRegistry, 0/*initialPausedStatus*/)
                 )
             )
         );
@@ -230,7 +249,7 @@ contract MockAVSDeployer is Test {
         );
 
         serviceManagerImplementation = new ServiceManagerBase(
-            delegationMock,
+            avsDirectoryMock,
             registryCoordinator,
             stakeRegistry
         );

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -28,6 +28,7 @@ import {IServiceManager} from "../../src/interfaces/IServiceManager.sol";
 
 import {StrategyManagerMock} from "eigenlayer-contracts/src/test/mocks/StrategyManagerMock.sol";
 import {EigenPodManagerMock} from "eigenlayer-contracts/src/test/mocks/EigenPodManagerMock.sol";
+import {AVSDirectoryMock} from "../mocks/AVSDirectoryMock.sol";
 import {DelegationMock} from "../mocks/DelegationMock.sol";
 import {AVSDirectory} from "eigenlayer-contracts/src/contracts/core/AVSDirectory.sol";
 import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
@@ -68,6 +69,7 @@ contract MockAVSDeployer is Test {
     ServiceManagerBase public serviceManager;
 
     StrategyManagerMock public strategyManagerMock;
+    AVSDirectoryMock public avsDirectoryMock;
     DelegationMock public delegationMock;
     EigenPodManagerMock public eigenPodManagerMock;
     AVSDirectory public avsDirectory;
@@ -135,7 +137,9 @@ contract MockAVSDeployer is Test {
         pausers[0] = pauser;
         pauserRegistry = new PauserRegistry(pausers, unpauser);
 
+
         delegationMock = new DelegationMock();
+        avsDirectoryMock = new AVSDirectoryMock();
         eigenPodManagerMock = new EigenPodManagerMock();
         strategyManagerMock = new StrategyManagerMock();
         slasherImplementation = new Slasher(strategyManagerMock, delegationMock);

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -28,6 +28,7 @@ import {IServiceManager} from "../../src/interfaces/IServiceManager.sol";
 
 import {StrategyManagerMock} from "eigenlayer-contracts/src/test/mocks/StrategyManagerMock.sol";
 import {EigenPodManagerMock} from "eigenlayer-contracts/src/test/mocks/EigenPodManagerMock.sol";
+import {AVSDirectoryMock} from "../mocks/AVSDirectoryMock.sol";
 import {DelegationMock} from "../mocks/DelegationMock.sol";
 import {BLSApkRegistryHarness} from "../harnesses/BLSApkRegistryHarness.sol";
 import {EmptyContract} from "eigenlayer-contracts/src/test/mocks/EmptyContract.sol";
@@ -63,6 +64,7 @@ contract MockAVSDeployer is Test {
     ServiceManagerBase public serviceManager;
 
     StrategyManagerMock public strategyManagerMock;
+    AVSDirectoryMock public avsDirectoryMock;
     DelegationMock public delegationMock;
     EigenPodManagerMock public eigenPodManagerMock;
 
@@ -127,7 +129,9 @@ contract MockAVSDeployer is Test {
         pausers[0] = pauser;
         pauserRegistry = new PauserRegistry(pausers, unpauser);
 
+
         delegationMock = new DelegationMock();
+        avsDirectoryMock = new AVSDirectoryMock();
         eigenPodManagerMock = new EigenPodManagerMock();
         strategyManagerMock = new StrategyManagerMock();
         slasherImplementation = new Slasher(strategyManagerMock, delegationMock);
@@ -230,7 +234,7 @@ contract MockAVSDeployer is Test {
         );
 
         serviceManagerImplementation = new ServiceManagerBase(
-            delegationMock,
+            avsDirectoryMock,
             registryCoordinator,
             stakeRegistry
         );


### PR DESCRIPTION
- Per PR in core, registration/deregistration of AVSs has moved to the AVSDirectory: https://github.com/Layr-Labs/eigenlayer-contracts/pull/403 