### PR TITLE
feat: experimental fncs to potentially save gas when updating weights for operator set

### DIFF
--- a/src/interfaces/IStakeRegistry.sol
+++ b/src/interfaces/IStakeRegistry.sol
@@ -245,4 +245,17 @@ interface IStakeRegistry is IRegistry {
         bytes32 operatorId, 
         bytes calldata quorumNumbers
     ) external returns (uint192);
+
+    // struct returned by the `updateOperatorsStake` function
+    struct OperatorsToRemove {
+        uint256 bitmap;
+        // simply tracks the number of '1's stored in the bitmap
+        uint256 numberBitmapEntries;
+    }
+
+    function updateOperatorsStake(
+        address[] calldata operators, 
+        bytes32[] calldata operatorIds, 
+        uint8 quorumNumber
+    ) external returns (OperatorsToRemove memory);
 }

--- a/src/libraries/BitmapUtils.sol
+++ b/src/libraries/BitmapUtils.sol
@@ -115,17 +115,27 @@ library BitmapUtils {
      * @return bytesArray The resulting bitmap array of bytes.
      * @dev Each byte in the input is processed as indicating a single bit to flip in the bitmap
      */
-    function bitmapToBytesArray(uint256 bitmap) internal pure returns (bytes memory bytesArray) {
+    function bitmapToBytesArray(uint256 bitmap) internal pure returns (bytes memory /*bytesArray*/) {
         // initialize an empty uint256 to be used as a bitmask inside the loop
         uint256 bitMask;
-        // loop through each index in the bitmap to construct the array
-        for (uint256 i = 0; i < 256; ++i) {
+        // allocate only the needed amount of memory
+        bytes memory bytesArray = new bytes(countNumOnes(bitmap));
+        // track the array index to assign to
+        uint256 arrayIndex = 0;
+        /**
+         * loop through each index in the bitmap to construct the array,
+         * but short-circuit the loop if we reach the number of ones and thus are done
+         * assigning to memory
+         */
+        for (uint256 i = 0; (arrayIndex < bytesArray.length) && (i < 256); ++i) {
             // construct a single-bit mask for the i-th bit
             bitMask = uint256(1 << i);
             // check if the i-th bit is flipped in the bitmap
             if (bitmap & bitMask != 0) {
                 // if the i-th bit is flipped, then add a byte encoding the value 'i' to the `bytesArray`
-                bytesArray = bytes.concat(bytesArray, bytes1(uint8(i)));
+                bytesArray[arrayIndex] = bytes1(uint8(i));
+                // increment the bytesArray slot since we've assigned one more byte of memory
+                unchecked{ ++arrayIndex; }
             }
         }
         return bytesArray;

--- a/test/mocks/StakeRegistryMock.sol
+++ b/test/mocks/StakeRegistryMock.sol
@@ -208,6 +208,12 @@ contract StakeRegistryMock is IStakeRegistry {
         return updateOperatorStakeReturnBitmap;
     }
 
+    function updateOperatorsStake(
+        address[] calldata operators, 
+        bytes32[] calldata operatorIds, 
+        uint8 quorumNumber
+    ) external returns (OperatorsToRemove memory){}
+
     function getMockOperatorId(address operator) external pure returns(bytes32) {
         return bytes32(uint256(keccak256(abi.encodePacked(operator, "operatorId"))));
     }

--- a/test/unit/BitmapUtils.t.sol
+++ b/test/unit/BitmapUtils.t.sol
@@ -228,6 +228,37 @@ contract BitmapUtilsUnitTests_bytesArrayToBitmap is BitmapUtilsUnitTests {
         assertEq(bitmap, 8160);
         emit log_named_uint("gasSpent", gasSpent);
     }
+
+    function testFuzz_bitmapToBytesArrayToBitmap(uint256 originalBitmap) public {
+        uint256 gasLeftBefore = gasleft();
+        bytes memory bytesArray = bitmapUtilsWrapper.bitmapToBytesArray(originalBitmap);
+        uint256 gasLeftAfter = gasleft();
+        uint256 gasSpent = gasLeftBefore - gasLeftAfter;
+        emit log_named_uint("gas spent by bitmapToBytesArray operation", gasSpent);
+        uint256 bitmapOutput = bitmapUtilsWrapper.orderedBytesArrayToBitmap(bytesArray);
+        assertEq(originalBitmap, bitmapOutput, "bitmap output does not match original bitmap!");
+    }
+
+    function test_bitmapToBytesArrayToBitmap_maxBitmap() public {
+        uint256 originalBitmap = type(uint256).max;
+        testFuzz_bitmapToBytesArrayToBitmap(originalBitmap);
+    }
+
+    function test_bitmapToBytesArrayToBitmap_emptyBitmap() public {
+        uint256 originalBitmap = 0;
+        testFuzz_bitmapToBytesArrayToBitmap(originalBitmap);
+    }
+
+    function test_bitmapToBytesArrayToBitmap_firstTenEntriesBitmap() public {
+        uint256 originalBitmap = 2047;
+        testFuzz_bitmapToBytesArrayToBitmap(originalBitmap);
+    }
+
+    function test_bitmapToBytesArrayToBitmap_distributedTenEntriesBitmap() public {
+        // 2^0+2^10+2^20+2^30+2^40+2^50+2^60+2^70+2^80+2^90
+        uint256 originalBitmap = 1239150146850664126585242625;
+        testFuzz_bitmapToBytesArrayToBitmap(originalBitmap);
+    }
 }
 
 contract BitmapUtilsUnitTests_isArrayStrictlyAscendingOrdered is BitmapUtilsUnitTests {


### PR DESCRIPTION
So far this PR adds one new function (each) to the StakeRegistry + RegistryCoordinator.

These are focused on doing stake weight updates for a set of operators + the entire set of operators in a single quorum, specifically.

This also adds the ability to input more than the total set of operators, to mitigate race conditions where deregistering or newly-registering operators could cause reverts in doing stake weight updates.
^However, I think this in particular may be broken right now, as I believe the stake weights of non-registered addresses can be made non-zero via this method. 

I have not confirmed the potential gas savings, and this pushes the RegistryCoordinator over the contract size limit, so the only way this would actually get merged is if we delete the other (approximately equivalent) `updateOperatorsForQuorum` function.