### PR TITLE
fix: include missing fields in TYPEHASH defintion

### DIFF
--- a/src/RegistryCoordinatorStorage.sol
+++ b/src/RegistryCoordinatorStorage.sol
@@ -15,7 +15,7 @@ abstract contract RegistryCoordinatorStorage is IRegistryCoordinator {
 
     /// @notice The EIP-712 typehash for the `DelegationApproval` struct used by the contract
     bytes32 public constant OPERATOR_CHURN_APPROVAL_TYPEHASH =
-        keccak256("OperatorChurnApproval(address registeringOperator,bytes32 registeringOperatorId,OperatorKickParam[] operatorKickParams,bytes32 salt,uint256 expiry)OperatorKickParam(address operator,bytes32[] operatorIdsToSwap)");
+        keccak256("OperatorChurnApproval(address registeringOperator,bytes32 registeringOperatorId,OperatorKickParam[] operatorKickParams,bytes32 salt,uint256 expiry)OperatorKickParam(uint8 quorumNumber,address operator)");
     /// @notice The EIP-712 typehash used for registering BLS public keys
     bytes32 public constant PUBKEY_REGISTRATION_TYPEHASH = keccak256("BN254PubkeyRegistration(address operator)");
     /// @notice The maximum value of a quorum bitmap

--- a/src/RegistryCoordinatorStorage.sol
+++ b/src/RegistryCoordinatorStorage.sol
@@ -15,7 +15,7 @@ abstract contract RegistryCoordinatorStorage is IRegistryCoordinator {
 
     /// @notice The EIP-712 typehash for the `DelegationApproval` struct used by the contract
     bytes32 public constant OPERATOR_CHURN_APPROVAL_TYPEHASH =
-        keccak256("OperatorChurnApproval(address registeringOperator,bytes32 registeringOperatorId,OperatorKickParam[] operatorKickParams)OperatorKickParam(address operator,bytes32[] operatorIdsToSwap)");
+        keccak256("OperatorChurnApproval(address registeringOperator,bytes32 registeringOperatorId,OperatorKickParam[] operatorKickParams,bytes32 salt,uint256 expiry)OperatorKickParam(address operator,bytes32[] operatorIdsToSwap)");
     /// @notice The EIP-712 typehash used for registering BLS public keys
     bytes32 public constant PUBKEY_REGISTRATION_TYPEHASH = keccak256("BN254PubkeyRegistration(address operator)");
     /// @notice The maximum value of a quorum bitmap


### PR DESCRIPTION
the `salt` and `expiry` fields were missing from the `OPERATOR_CHURN_APPROVAL_TYPEHASH` def