### PR TITLE
docs: clarify usage of msgHash

### DIFF
--- a/docs/BLSSignatureChecker.md
+++ b/docs/BLSSignatureChecker.md
@@ -62,6 +62,7 @@ struct QuorumStakeTotals {
 The goal of this method is to allow an AVS to validate a BLS signature formed from the aggregate pubkey ("apk") of Operators registered in one or more quorums at some `referenceBlockNumber`.
 
 Some notes on method parameters:
+* `msgHash` is the hash being signed by the apk. Note that the caller is responsible for ensuring `msgHash` is a hash! If someone can provide arbitrary input, it may be possible to tamper with signature verification.
 * `referenceBlockNumber` is the reason each registry contract keeps historical states: so that lookups can be performed on each registry's info at a particular block. This is important because Operators may sign some data on behalf of an AVS, then deregister from one or more of the AVS's quorums. Historical states allow signature validation to be performed against a "fixed point" in AVS/quorum history.
 * `quorumNumbers` is used to perform signature validation across one *or more* quorums. Also, Operators may be registered for more than one quorum - and for each quorum an Operator is registered for, that Operator's pubkey is included in that quorum's apk within the `BLSApkRegistry`. This means that, when calculating an apk across multiple `quorumNumbers`, Operators registered for more than one of these quorums will have their pubkey included more than once in the total apk.
 * `params` contains both a signature from all signing Operators, as well as several fields that identify registered, non-signing Operators. While non-signing Operators haven't contributed to the signature, but need to be accounted for because, as Operators registered for one or more signing quorums, their public keys are included in that quorum's apk. Essentially, in order to validate the signature, nonsigners' public keys need to be subtracted out from the total apk to derive the apk that actually signed the message.
@@ -87,7 +88,7 @@ This method performs the following steps. Note that each step involves lookups o
 * Input validation:
     * Quorum-related fields MUST have equal lengths: `quorumNumbers`, `params.quorumApks`, `params.quorumApkIndices`, `params.totalStakeIndices`, `params.nonSignerStakeIndices`
     * Nonsigner-related fields MUST have equal lengths: `params.nonSignerPubkeys`, `params.nonSignerQuorumBitmapIndices`
-    * `referenceBlockNumber` MUST NOT be greater than `block.number`
+    * `referenceBlockNumber` MUST be less than `block.number`
     * `quorumNumbers` MUST be an ordered list of valid, initialized quorums
     * `params.nonSignerPubkeys` MUST ONLY contain unique pubkeys, in ascending order of their pubkey hash
 * For each quorum:

--- a/src/BLSSignatureChecker.sol
+++ b/src/BLSSignatureChecker.sol
@@ -75,6 +75,9 @@ contract BLSSignatureChecker is IBLSSignatureChecker {
      * is correct, i.e., ensure that the stake returned from the specified block number is recent enough and that the stake is either the most recent update
      * for the total stake (of the operator) or latest before the referenceBlockNumber.
      * @param msgHash is the hash being signed
+     * @dev NOTE: Be careful to ensure `msgHash` is collision-resistant! This method does not hash 
+     * `msgHash` in any way, so if an attacker is able to pass in an arbitrary value, they may be able
+     * to tamper with signature verification.
      * @param quorumNumbers is the bytes array of quorum numbers that are being signed for
      * @param referenceBlockNumber is the block number at which the stake information is being verified
      * @param params is the struct containing information on nonsigners, stakes, quorum apks, and the aggregate signature


### PR DESCRIPTION
- also updates checkSignature docs with `referenceBlockNumber` change