### PR TITLE
chore: fix flaky test

### DIFF
--- a/test/unit/IndexRegistryUnit.t.sol
+++ b/test/unit/IndexRegistryUnit.t.sol
@@ -694,7 +694,7 @@ contract IndexRegistryUnitTests_deregisterOperator is IndexRegistryUnitTests {
     *******************************************************************************/
     function testFuzz_Revert_WhenNonRegistryCoordinator(address nonRegistryCoordinator) public {
         cheats.assume(nonRegistryCoordinator != address(registryCoordinator));
-        cheats.assume(nonRegistryCoordinator != proxyAdminOwner);
+        cheats.assume(nonRegistryCoordinator != address(proxyAdmin));
         // de-register an operator
         bytes memory quorumNumbers = new bytes(defaultQuorumNumber);
 


### PR DESCRIPTION
filtering of fuzzed inputs was incorrect.
this was caught in a fuzz run by @RonTuretzky (h/t for flagging this)