### PR TITLE
chore: update from calldata to memory

### DIFF
--- a/src/BLSSignatureChecker.sol
+++ b/src/BLSSignatureChecker.sol
@@ -86,7 +86,7 @@ contract BLSSignatureChecker is IBLSSignatureChecker {
      */
     function checkSignatures(
         bytes32 msgHash, 
-        bytes calldata quorumNumbers,
+        bytes memory quorumNumbers,
         uint32 referenceBlockNumber, 
         NonSignerStakesAndSignature memory params
     ) 


### PR DESCRIPTION
I needed to call checkSignatures within a contract that gets passed data to decode into the params for the checkSignatures call as bytes and evaluate if the signatures were valid. However, with the quorumNumbers param being calldata, it's impossible to pass it as calldata after using abi.decode.

ie `abi.decode(data, (bytes32, bytes, uint32, NonSignerStakesAndSignatures))`