### PR TITLE
feat: reregistration delay and BLS key rotation

### DIFF
--- a/src/BLSApkRegistry.sol
+++ b/src/BLSApkRegistry.sol
@@ -131,6 +131,15 @@ contract BLSApkRegistry is BLSApkRegistryStorage {
             params.pubkeyG2
         ), "BLSApkRegistry.registerBLSPublicKey: either the G1 signature is wrong, or G1 and G2 private key do not match");
 
+        //if keys already registered checkpoint the previous pubkey and pubkeyHash of the operator
+        if(operatorToPubkeyHash[operator] != bytes32(0)) {
+            operatorPubkeyHistory[operator].push(PubkeyCheckpoint({
+                previousPubkeyG1: operatorToPubkey[operator],
+                previousPubkeyHash: operatorToPubkeyHash[operator],
+                blockNumber: uint32(block.number)
+            }));
+        }
+
         operatorToPubkey[operator] = params.pubkeyG1;
         operatorToPubkeyHash[operator] = pubkeyHash;
         pubkeyHashToOperator[pubkeyHash] = operator;

--- a/src/BLSApkRegistry.sol
+++ b/src/BLSApkRegistry.sol
@@ -107,10 +107,6 @@ contract BLSApkRegistry is BLSApkRegistryStorage {
             pubkeyHash != ZERO_PK_HASH, "BLSApkRegistry.registerBLSPublicKey: cannot register zero pubkey"
         );
         require(
-            operatorToPubkeyHash[operator] == bytes32(0),
-            "BLSApkRegistry.registerBLSPublicKey: operator already registered pubkey"
-        );
-        require(
             pubkeyHashToOperator[pubkeyHash] == address(0),
             "BLSApkRegistry.registerBLSPublicKey: public key already registered"
         );

--- a/src/BLSApkRegistry.sol
+++ b/src/BLSApkRegistry.sol
@@ -103,6 +103,9 @@ contract BLSApkRegistry is BLSApkRegistryStorage {
         BN254.G1Point calldata pubkeyRegistrationMessageHash
     ) external onlyRegistryCoordinator returns (bytes32 operatorId) {
         bytes32 pubkeyHash = BN254.hashG1Point(params.pubkeyG1);
+        if(operatorToPubkeyHash[operator] == pubkeyHash) {
+            return pubkeyHash;
+        }
         require(
             pubkeyHash != ZERO_PK_HASH, "BLSApkRegistry.registerBLSPublicKey: cannot register zero pubkey"
         );

--- a/src/BLSApkRegistryStorage.sol
+++ b/src/BLSApkRegistryStorage.sol
@@ -29,6 +29,9 @@ abstract contract BLSApkRegistryStorage is Initializable, IBLSApkRegistry {
     /// @notice maps quorumNumber => current aggregate pubkey of quorum
     mapping(uint8 => BN254.G1Point) public currentApk;
 
+    /// @notice maps operator address to pubkey history
+    mapping(address => PubkeyCheckpoint[]) public operatorPubkeyHistory;
+
     constructor(IRegistryCoordinator _registryCoordinator) {
         registryCoordinator = address(_registryCoordinator);
         // disable initializers so that the implementation contract cannot be initialized
@@ -36,5 +39,5 @@ abstract contract BLSApkRegistryStorage is Initializable, IBLSApkRegistry {
     }
 
     // storage gap for upgradeability
-    uint256[45] private __GAP;
+    uint256[44] private __GAP;
 }

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -507,6 +507,12 @@ contract RegistryCoordinator is
         if (operatorId == 0) {
             operatorId = blsApkRegistry.registerBLSPublicKey(operator, params, pubkeyRegistrationMessageHash(operator));
         }
+        if (_operatorInfo[operator].status == OperatorStatus.DEREGISTERED && 
+            params.pubkeyRegistrationSignature.X != 0 &&
+            params.pubkeyRegistrationSignature.Y != 0
+        ) {
+            operatorId = blsApkRegistry.registerBLSPublicKey(operator, params, pubkeyRegistrationMessageHash(operator));
+        }
         return operatorId;
     }
 

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -511,7 +511,8 @@ contract RegistryCoordinator is
         }
         if (_operatorInfo[operator].status == OperatorStatus.DEREGISTERED && 
             params.pubkeyRegistrationSignature.X != 0 &&
-            params.pubkeyRegistrationSignature.Y != 0
+            params.pubkeyRegistrationSignature.Y != 0 &&
+            BN254.hashG1Point(params.pubkeyG1) != operatorId
         ) {
             operatorId = blsApkRegistry.registerBLSPublicKey(operator, params, pubkeyRegistrationMessageHash(operator));
         }

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -511,8 +511,7 @@ contract RegistryCoordinator is
         }
         if (_operatorInfo[operator].status == OperatorStatus.DEREGISTERED && 
             params.pubkeyRegistrationSignature.X != 0 &&
-            params.pubkeyRegistrationSignature.Y != 0 &&
-            BN254.hashG1Point(params.pubkeyG1) != operatorId
+            params.pubkeyRegistrationSignature.Y != 0 
         ) {
             operatorId = blsApkRegistry.registerBLSPublicKey(operator, params, pubkeyRegistrationMessageHash(operator));
         }

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -471,6 +471,8 @@ contract RegistryCoordinator is
         // If the operator wasn't registered for any quorums, update their status
         // and register them with this AVS in EigenLayer core (DelegationManager)
         if (_operatorInfo[operator].status != OperatorStatus.REGISTERED) {
+            require(lastDeregistrationTimestamp[operator] + REREGISTRATION_DELAY < block.timestamp, "RegistryCoordinator._registerOperator: operator cannot reregister yet");
+
             _operatorInfo[operator] = OperatorInfo({
                 operatorId: operatorId,
                 status: OperatorStatus.REGISTERED
@@ -596,6 +598,7 @@ contract RegistryCoordinator is
         // them from the AVS via the EigenLayer core contracts
         if (newBitmap.isEmpty()) {
             operatorInfo.status = OperatorStatus.DEREGISTERED;
+            lastDeregistrationTimestamp[operator] = block.timestamp;
             serviceManager.deregisterOperatorFromAVS(operator);
             emit OperatorDeregistered(operator, operatorId);
         }

--- a/src/RegistryCoordinatorStorage.sol
+++ b/src/RegistryCoordinatorStorage.sol
@@ -30,6 +30,8 @@ abstract contract RegistryCoordinatorStorage is IRegistryCoordinator {
     uint8 internal constant PAUSED_UPDATE_OPERATOR = 2;
     /// @notice The maximum number of quorums this contract supports
     uint8 internal constant MAX_QUORUM_COUNT = 192;
+    /// @notice The amount of time that must pass before an operator can register after deregistering
+    uint256 internal constant REREGISTRATION_DELAY = 7 days;
 
     /// @notice the ServiceManager for this AVS, which forwards calls onto EigenLayer's core contracts
     IServiceManager public immutable serviceManager;
@@ -64,6 +66,9 @@ abstract contract RegistryCoordinatorStorage is IRegistryCoordinator {
     /// @notice the address of the entity allowed to eject operators from the AVS
     address public ejector;
 
+    /// @notice maps operator address => timestamp of last deregistration
+    mapping(address => uint256) public lastDeregistrationTimestamp;
+
     constructor(
         IServiceManager _serviceManager,
         IStakeRegistry _stakeRegistry,
@@ -78,5 +83,5 @@ abstract contract RegistryCoordinatorStorage is IRegistryCoordinator {
 
     // storage gap for upgradeability
     // slither-disable-next-line shadowing-state
-    uint256[41] private __GAP;
+    uint256[40] private __GAP;
 }

--- a/src/interfaces/IBLSApkRegistry.sol
+++ b/src/interfaces/IBLSApkRegistry.sol
@@ -33,6 +33,18 @@ interface IBLSApkRegistry is IRegistry {
         BN254.G2Point pubkeyG2;
     }
 
+    /**
+     * @notice Struct used to checkpoint the previous pubkeys and their hashes for a given operator
+     * @param previousPubkeyG1 is the G1 public key of the operator
+     * @param previoudPubkeyHash is the hash of the public key of the operator
+     * @param blockNumber is the block number at which the pubkey was updated
+     */
+    struct PubkeyCheckpoint {
+        BN254.G1Point previousPubkeyG1;
+        bytes32 previousPubkeyHash;
+        uint32 blockNumber;
+    }
+
     // EVENTS
     /// @notice Emitted when `operator` registers with the public keys `pubkeyG1` and `pubkeyG2`.
     event NewPubkeyRegistration(address indexed operator, BN254.G1Point pubkeyG1, BN254.G2Point pubkeyG2);

--- a/test/integration/CoreRegistration.t.sol
+++ b/test/integration/CoreRegistration.t.sol
@@ -128,6 +128,7 @@ contract Test_CoreRegistration is MockAVSDeployer {
 
         // Register operator
         cheats.prank(operator);
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, operatorSignature);
 
         // Check operator is registered
@@ -198,6 +199,7 @@ contract Test_CoreRegistration is MockAVSDeployer {
 
         // Register operator
         cheats.prank(operator);
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, operatorSignature);
     }
 

--- a/test/integration/User.t.sol
+++ b/test/integration/User.t.sol
@@ -64,6 +64,7 @@ contract User is Test {
 
     string public NAME;
     bytes32 public operatorId;
+    uint256 public reregistrationDelay;
 
     // BLS keypair:
     uint privKey;
@@ -94,6 +95,7 @@ contract User is Test {
         churnApprover = deployer.churnApprover();
 
         NAME = name;
+        reregistrationDelay = 7 days + 1;
 
         // Generate BN254 keypair and registration signature
         privKey = _privKey;
@@ -117,6 +119,8 @@ contract User is Test {
     function registerOperator(bytes calldata quorums) public createSnapshot virtual returns (bytes32) {
         _log("registerOperator", quorums);
 
+        uint256 deregistrationTimestamp = registryCoordinator.lastDeregistrationTimestamp(address(this));
+        vm.warp(deregistrationTimestamp + reregistrationDelay);
         registryCoordinator.registerOperator({
             quorumNumbers: quorums,
             socket: NAME,
@@ -208,6 +212,10 @@ contract User is Test {
                 expiry: expiry
             });
 
+        {
+            uint256 deregistrationTimestamp = registryCoordinator.lastDeregistrationTimestamp(address(this));
+            vm.warp(deregistrationTimestamp + reregistrationDelay);
+        }
         registryCoordinator.registerOperatorWithChurn({
             quorumNumbers: allQuorums,
             socket: NAME,

--- a/test/unit/BLSApkRegistryUnit.t.sol
+++ b/test/unit/BLSApkRegistryUnit.t.sol
@@ -309,22 +309,6 @@ contract BLSApkRegistryUnitTests_registerBLSPublicKey is BLSApkRegistryUnitTests
         blsApkRegistry.registerBLSPublicKey(operator, pubkeyRegistrationParams, messageHash);
     }
 
-    function testFuzz_registerOperator_Revert_WhenOperatorAlreadyRegistered(address operator)
-        public
-    {
-        pubkeyRegistrationParams.pubkeyRegistrationSignature = _signMessage(operator);
-        BN254.G1Point memory messageHash =
-            registryCoordinator.pubkeyRegistrationMessageHash(operator);
-
-        cheats.startPrank(address(registryCoordinator));
-        blsApkRegistry.registerBLSPublicKey(operator, pubkeyRegistrationParams, messageHash);
-
-        cheats.expectRevert(
-            "BLSApkRegistry.registerBLSPublicKey: operator already registered pubkey"
-        );
-        blsApkRegistry.registerBLSPublicKey(operator, pubkeyRegistrationParams, messageHash);
-    }
-
     function testFuzz_registerOperator_Revert_WhenPubkeyAlreadyRegistered(
         address operator,
         address operator2

--- a/test/unit/BLSApkRegistryUnit.t.sol
+++ b/test/unit/BLSApkRegistryUnit.t.sol
@@ -399,6 +399,85 @@ contract BLSApkRegistryUnitTests_registerBLSPublicKey is BLSApkRegistryUnitTests
             "operator address not stored correctly"
         );
     }
+
+    function testFuzz_registerBLSPublicKey_RegisteringSameKey(address operator)
+        public
+        filterFuzzedAddressInputs(operator)
+    {
+        pubkeyRegistrationParams.pubkeyRegistrationSignature = _signMessage(operator);
+        BN254.G1Point memory messageHash =
+            registryCoordinator.pubkeyRegistrationMessageHash(operator);
+
+        cheats.startPrank(address(registryCoordinator));
+        blsApkRegistry.registerBLSPublicKey(operator, pubkeyRegistrationParams, messageHash);
+
+        bytes32 operatorId = blsApkRegistry.registerBLSPublicKey(operator, pubkeyRegistrationParams, messageHash);
+
+        assertEq(
+            blsApkRegistry.getOperatorId(operator),
+            operatorId,
+            "operatorId is not the same"
+        );
+    }
+
+    function testFuzz_registerBLSPublicKey_RegisteringNewKey(address operator)
+        public
+        filterFuzzedAddressInputs(operator)
+    {
+        pubkeyRegistrationParams.pubkeyRegistrationSignature = _signMessage(operator);
+        BN254.G1Point memory messageHash =
+            registryCoordinator.pubkeyRegistrationMessageHash(operator);
+        cheats.prank(address(registryCoordinator));
+        cheats.expectEmit(true, true, true, true, address(blsApkRegistry));
+        emit NewPubkeyRegistration(
+            operator, pubkeyRegistrationParams.pubkeyG1, pubkeyRegistrationParams.pubkeyG2
+        );
+        blsApkRegistry.registerBLSPublicKey(operator, pubkeyRegistrationParams, messageHash);
+
+        (BN254.G1Point memory registeredPubkey, bytes32 registeredpkHash) =
+            blsApkRegistry.getRegisteredPubkey(operator);
+        assertEq(registeredPubkey.X, defaultPubkey.X, "registeredPubkey not set correctly");
+        assertEq(registeredPubkey.Y, defaultPubkey.Y, "registeredPubkey not set correctly");
+        assertEq(registeredpkHash, defaultPubkeyHash, "registeredpkHash not set correctly");
+        assertEq(
+            blsApkRegistry.pubkeyHashToOperator(BN254.hashG1Point(defaultPubkey)),
+            operator,
+            "operator address not stored correctly"
+        );
+
+        privKey = 420;
+        pubkeyRegistrationParams.pubkeyG1 = BN254.generatorG1().scalar_mul(privKey);
+        defaultPubkey = pubkeyRegistrationParams.pubkeyG1;
+        defaultPubkeyHash = BN254.hashG1Point(defaultPubkey);
+        pubkeyRegistrationParams.pubkeyG2.X[1] =
+            uint256(0x22010BC55552F4993B17F82BCDADC5A90839B3D67E382564485A0AA07F7E1923);
+        pubkeyRegistrationParams.pubkeyG2.X[0] =
+            uint256(0x2944BFD71F3073401E9D5F9AEA081BE98B98DA48EC8EE80ECFC7E97C7254CEA9);
+        pubkeyRegistrationParams.pubkeyG2.Y[1] =
+            uint256(0x1BDC8A9DEF8E46F40008649021A65F97501E2E5988B485368053BBD4487239C6);
+        pubkeyRegistrationParams.pubkeyG2.Y[0] =
+            uint256(0x0B7D0B9ECAD9C2884453B975CC656802DE966F21793B5A0F3D2A98A37FD24540);
+
+        pubkeyRegistrationParams.pubkeyRegistrationSignature = _signMessage(operator);
+        messageHash = registryCoordinator.pubkeyRegistrationMessageHash(operator);
+        cheats.prank(address(registryCoordinator));
+        cheats.expectEmit(true, true, true, true, address(blsApkRegistry));
+        emit NewPubkeyRegistration(
+            operator, pubkeyRegistrationParams.pubkeyG1, pubkeyRegistrationParams.pubkeyG2
+        );
+        blsApkRegistry.registerBLSPublicKey(operator, pubkeyRegistrationParams, messageHash);
+
+        (registeredPubkey, registeredpkHash) =
+            blsApkRegistry.getRegisteredPubkey(operator);
+        assertEq(registeredPubkey.X, defaultPubkey.X, "registeredPubkey not set correctly");
+        assertEq(registeredPubkey.Y, defaultPubkey.Y, "registeredPubkey not set correctly");
+        assertEq(registeredpkHash, defaultPubkeyHash, "registeredpkHash not set correctly");
+        assertEq(
+            blsApkRegistry.pubkeyHashToOperator(BN254.hashG1Point(defaultPubkey)),
+            operator,
+            "operator address not stored correctly"
+        );
+    }
 }
 
 /// @notice test for BLSApkRegistry.registerOperator()

--- a/test/unit/RegistryCoordinatorUnit.t.sol
+++ b/test/unit/RegistryCoordinatorUnit.t.sol
@@ -314,6 +314,7 @@ contract RegistryCoordinatorUnitTests_RegisterOperator is RegistryCoordinatorUni
 
         uint256 gasBefore = gasleft();
         cheats.prank(defaultOperator);
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
         uint256 gasAfter = gasleft();
         emit log_named_uint("gasUsed, register for single quorum", gasBefore - gasAfter);
@@ -372,6 +373,7 @@ contract RegistryCoordinatorUnitTests_RegisterOperator is RegistryCoordinatorUni
         
         uint256 gasBefore = gasleft();
         cheats.prank(defaultOperator);
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
         uint256 gasAfter = gasleft();
         emit log_named_uint("gasUsed", gasBefore - gasAfter);
@@ -408,6 +410,7 @@ contract RegistryCoordinatorUnitTests_RegisterOperator is RegistryCoordinatorUni
         _setOperatorWeight(defaultOperator, uint8(quorumNumbers[0]), defaultStake);
         cheats.prank(defaultOperator);
         cheats.roll(registrationBlockNumber);
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
 
         bytes memory newQuorumNumbers = new bytes(1);
@@ -424,6 +427,7 @@ contract RegistryCoordinatorUnitTests_RegisterOperator is RegistryCoordinatorUni
         emit QuorumIndexUpdate(defaultOperatorId, uint8(newQuorumNumbers[0]), 0);
         cheats.roll(nextRegistrationBlockNumber);
         cheats.prank(defaultOperator);
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         registryCoordinator.registerOperator(newQuorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
 
         uint256 quorumBitmap = BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers) | BitmapUtils.orderedBytesArrayToBitmap(newQuorumNumbers);
@@ -497,11 +501,13 @@ contract RegistryCoordinatorUnitTests_RegisterOperator is RegistryCoordinatorUni
         _setOperatorWeight(defaultOperator, uint8(quorumNumbers[0]), defaultStake);
         cheats.prank(defaultOperator);
         cheats.roll(registrationBlockNumber);
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
 
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
 
         cheats.prank(defaultOperator);
         cheats.roll(nextRegistrationBlockNumber);
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         cheats.expectRevert("RegistryCoordinator._registerOperator: operator already registered for some quorums being registered for");
 
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
@@ -531,9 +537,11 @@ contract RegistryCoordinatorUnitTests_RegisterOperator is RegistryCoordinatorUni
         bytes memory quorumNumbers = new bytes(1);
         quorumNumbers[0] = bytes1(defaultQuorumNumber);
 
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         _setOperatorWeight(defaultOperator, uint8(quorumNumbers[0]), defaultStake);
         registryCoordinator._registerOperatorExternal(defaultOperator, defaultOperatorId, quorumNumbers, defaultSocket, emptySig);
 
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         cheats.expectRevert("RegistryCoordinator._registerOperator: operator already registered for some quorums being registered for");
         registryCoordinator._registerOperatorExternal(defaultOperator, defaultOperatorId, quorumNumbers, defaultSocket, emptySig);
     }
@@ -554,6 +562,7 @@ contract RegistryCoordinatorUnitTests_RegisterOperator is RegistryCoordinatorUni
         cheats.expectEmit(true, true, true, true, address(indexRegistry));
         emit QuorumIndexUpdate(defaultOperatorId, defaultQuorumNumber, 0);
 
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         registryCoordinator._registerOperatorExternal(defaultOperator, defaultOperatorId, quorumNumbers, defaultSocket, emptySig);
 
         uint256 quorumBitmap = BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers);
@@ -633,7 +642,7 @@ contract RegistryCoordinatorUnitTests_DeregisterOperator_EjectOperator is Regist
         _setOperatorWeight(defaultOperator, uint8(quorumNumbers[0]), defaultStake);
 
         cheats.startPrank(defaultOperator);
-        
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         cheats.roll(registrationBlockNumber);
         
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
@@ -687,7 +696,7 @@ contract RegistryCoordinatorUnitTests_DeregisterOperator_EjectOperator is Regist
         }
 
         cheats.startPrank(defaultOperator);
-        
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         cheats.roll(registrationBlockNumber);
         
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
@@ -747,7 +756,7 @@ contract RegistryCoordinatorUnitTests_DeregisterOperator_EjectOperator is Regist
         }
 
         cheats.startPrank(defaultOperator);
-        
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         cheats.roll(registrationBlockNumber);
         
         registryCoordinator.registerOperator(registrationquorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
@@ -906,6 +915,7 @@ contract RegistryCoordinatorUnitTests_DeregisterOperator_EjectOperator is Regist
             registryCoordinator.getQuorumBitmapUpdateByIndex(defaultOperatorId, 0);
 
         // re-register the operator
+        cheats.warp(block.timestamp + defaultReregistrationDelay + 1);
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
         // check success of registration
         uint256 quorumBitmap = BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers);
@@ -950,6 +960,7 @@ contract RegistryCoordinatorUnitTests_DeregisterOperator_EjectOperator is Regist
         _setOperatorWeight(defaultOperator, uint8(quorumNumbers[0]), defaultStake);
 
         cheats.roll(registrationBlockNumber);
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         cheats.startPrank(defaultOperator);
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
 
@@ -977,6 +988,7 @@ contract RegistryCoordinatorUnitTests_DeregisterOperator_EjectOperator is Regist
         _setOperatorWeight(defaultOperator, uint8(quorumNumbers[0]), defaultStake);
 
         cheats.roll(registrationBlockNumber);
+        cheats.warp(block.timestamp + defaultReregistrationDelay); 
         cheats.startPrank(defaultOperator);
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
 
@@ -1012,6 +1024,7 @@ contract RegistryCoordinatorUnitTests_DeregisterOperator_EjectOperator is Regist
         }
 
         cheats.roll(registrationBlockNumber);
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         cheats.startPrank(defaultOperator);
         registryCoordinator.registerOperator(registrationquorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
 
@@ -1080,6 +1093,7 @@ contract RegistryCoordinatorUnitTests_DeregisterOperator_EjectOperator is Regist
         _setOperatorWeight(defaultOperator, uint8(quorumNumbers[0]), defaultStake);
 
         cheats.prank(defaultOperator);
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
 
         cheats.expectEmit(true, true, true, true, address(blsApkRegistry));
@@ -1116,6 +1130,7 @@ contract RegistryCoordinatorUnitTests_DeregisterOperator_EjectOperator is Regist
         }
 
         cheats.prank(defaultOperator);
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
 
         // eject from only first quorum
@@ -1155,6 +1170,7 @@ contract RegistryCoordinatorUnitTests_DeregisterOperator_EjectOperator is Regist
         _setOperatorWeight(defaultOperator, uint8(quorumNumbers[0]), defaultStake);
 
         cheats.prank(defaultOperator);
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
         
         cheats.expectRevert("RegistryCoordinator.onlyEjector: caller is not the ejector");
@@ -1178,6 +1194,7 @@ contract RegistryCoordinatorUnitTests_DeregisterOperator_EjectOperator is Regist
         quorumNumbers[0] = bytes1(defaultQuorumNumber);
         _setOperatorWeight(defaultOperator, uint8(quorumNumbers[0]), defaultStake);
         cheats.roll(registrationBlockNumber);
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         cheats.startPrank(defaultOperator);        
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
 
@@ -1534,6 +1551,7 @@ contract RegistryCoordinatorUnitTests_UpdateOperators is RegistryCoordinatorUnit
         _setOperatorWeight(defaultOperator, uint8(quorumNumbers[0]), defaultStake);
         cheats.startPrank(defaultOperator);
         cheats.roll(registrationBlockNumber);
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
 
         address[] memory operatorsToUpdate = new address[](1);
@@ -1559,6 +1577,7 @@ contract RegistryCoordinatorUnitTests_UpdateOperators is RegistryCoordinatorUnit
         }
         cheats.startPrank(defaultOperator);
         cheats.roll(registrationBlockNumber);
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
 
         address[] memory operatorsToUpdate = new address[](1);
@@ -1646,6 +1665,7 @@ contract RegistryCoordinatorUnitTests_UpdateOperators is RegistryCoordinatorUnit
         _setOperatorWeight(defaultOperator, uint8(quorumNumbers[0]), defaultStake);
         cheats.startPrank(defaultOperator);
         cheats.roll(registrationBlockNumber);
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
 
         address[][] memory operatorsToUpdate = new address[][](1);
@@ -1721,6 +1741,7 @@ contract RegistryCoordinatorUnitTests_UpdateOperators is RegistryCoordinatorUnit
         _setOperatorWeight(defaultOperator, uint8(quorumNumbers[0]), defaultStake);
         cheats.startPrank(defaultOperator);
         cheats.roll(registrationBlockNumber);
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
 
         address[][] memory operatorsToUpdate = new address[][](1);

--- a/test/unit/RegistryCoordinatorUnit.t.sol
+++ b/test/unit/RegistryCoordinatorUnit.t.sol
@@ -948,6 +948,23 @@ contract RegistryCoordinatorUnitTests_DeregisterOperator_EjectOperator is Regist
         );
     }
 
+    function test_reregisterOperator_revert_reregistrationDelay() public {
+        test_deregisterOperator_singleQuorumAndSingleOperator();
+
+        ISignatureUtils.SignatureWithSaltAndExpiry memory emptySig;
+        uint32 reregistrationBlockNumber = 201;
+
+        bytes memory quorumNumbers = new bytes(1);
+        quorumNumbers[0] = bytes1(defaultQuorumNumber);
+
+        cheats.startPrank(defaultOperator);
+        cheats.roll(reregistrationBlockNumber);
+        cheats.warp(block.timestamp + defaultReregistrationDelay - 1);
+
+        cheats.expectRevert("RegistryCoordinator._registerOperator: operator cannot reregister yet");
+        registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySig);
+    }
+
     // tests for the internal `_deregisterOperator` function:
     function test_deregisterOperatorExternal_revert_noQuorums() public {
         ISignatureUtils.SignatureWithSaltAndExpiry memory emptySig;

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -99,6 +99,7 @@ contract MockAVSDeployer is Test {
     uint16 defaultKickBIPsOfOperatorStake = 15000;
     uint16 defaultKickBIPsOfTotalStake = 150;
     uint8 numQuorums = 192;
+    uint256 defaultReregistrationDelay = 7 days + 1;
 
     IRegistryCoordinator.OperatorSetParam[] operatorSetParams;
 
@@ -344,6 +345,7 @@ contract MockAVSDeployer is Test {
         }
 
         ISignatureUtils.SignatureWithSaltAndExpiry memory emptySignatureAndExpiry;
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         cheats.prank(operator);
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySignatureAndExpiry);
     }
@@ -363,6 +365,7 @@ contract MockAVSDeployer is Test {
         }
 
         ISignatureUtils.SignatureWithSaltAndExpiry memory emptySignatureAndExpiry;
+        cheats.warp(block.timestamp + defaultReregistrationDelay);
         cheats.prank(operator);
         registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySignatureAndExpiry);
     }


### PR DESCRIPTION
Allows operators to rotate BLS keys by fully deregistering and reregistering with a new signature