### PR TITLE
feat: batch operator id conversions

### DIFF
--- a/src/OperatorStateRetriever.sol
+++ b/src/OperatorStateRetriever.sol
@@ -179,6 +179,12 @@ contract OperatorStateRetriever {
         return quorumBitmaps;
     }
 
+    /**
+     * @notice This function returns the operatorIds for each of the operators in the operators array
+     * @param registryCoordinator is the AVS registry coordinator to fetch the operator information from
+     * @param operators is the array of operator address to get corresponding operatorIds for
+     * @dev if an operator is not registered, the operatorId will be 0
+     */
     function getBatchOperatorId(
         IRegistryCoordinator registryCoordinator,
         address[] memory operators
@@ -189,6 +195,12 @@ contract OperatorStateRetriever {
         }
     }
 
+    /**
+     * @notice This function returns the operator addresses for each of the operators in the operatorIds array
+     * @param registryCoordinator is the AVS registry coordinator to fetch the operator information from
+     * @param operators is the array of operatorIds to get corresponding operator addresses for
+     * @dev if an operator is not registered, the operator address will be 0
+     */
     function getBatchOperatorFromId(
         IRegistryCoordinator registryCoordinator,
         bytes32[] memory operatorIds

--- a/src/OperatorStateRetriever.sol
+++ b/src/OperatorStateRetriever.sol
@@ -178,4 +178,25 @@ contract OperatorStateRetriever {
         }
         return quorumBitmaps;
     }
+
+    function getBatchOperatorId(
+        IRegistryCoordinator registryCoordinator,
+        address[] memory operators
+    ) external view returns (bytes32[] memory operatorIds) {
+        operatorIds = new bytes32[](operators.length);
+        for (uint256 i = 0; i < operators.length; ++i) {
+            operatorIds[i] = registryCoordinator.getOperatorId(operators[i]);
+        }
+    }
+
+    function getBatchOperatorFromId(
+        IRegistryCoordinator registryCoordinator,
+        bytes32[] memory operatorIds
+    ) external view returns (address[] memory operators) {
+        operators = new address[](operatorIds.length);
+        for (uint256 i = 0; i < operatorIds.length; ++i) {
+            operators[i] = registryCoordinator.getOperatorFromId(operatorIds[i]);
+        }
+    }
+    
 }


### PR DESCRIPTION
Adds two view functions to OperatorStateRetriever:
- getBatchOperatorId: batch conversion of operator address to operator id
- getBatchOperatorFromId: batch conversion of operator id to operator address