### PR TITLE
feat: `paymentInitiator` role in `ServiceManagerBase`

### DIFF
--- a/src/ServiceManagerBase.sol
+++ b/src/ServiceManagerBase.sol
@@ -4,25 +4,22 @@ pragma solidity ^0.8.12;
 import {OwnableUpgradeable} from "@openzeppelin-upgrades/contracts/access/OwnableUpgradeable.sol";
 import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
 import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
-import {IPaymentCoordinator} from "eigenlayer-contracts/src/contracts/interfaces/IPaymentCoordinator.sol";
+import {IPaymentCoordinator} from
+    "eigenlayer-contracts/src/contracts/interfaces/IPaymentCoordinator.sol";
 
+import {ServiceManagerBaseStorage} from "./ServiceManagerBaseStorage.sol";
 import {IServiceManager} from "./interfaces/IServiceManager.sol";
 import {IRegistryCoordinator} from "./interfaces/IRegistryCoordinator.sol";
 import {IStakeRegistry} from "./interfaces/IStakeRegistry.sol";
-import {BitmapUtils} from "./libraries/BitmapUtils.sol"; 
+import {BitmapUtils} from "./libraries/BitmapUtils.sol";
 
 /**
  * @title Minimal implementation of a ServiceManager-type contract.
  * This contract can be inherited from or simply used as a point-of-reference.
  * @author Layr Labs, Inc.
  */
-abstract contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
+abstract contract ServiceManagerBase is ServiceManagerBaseStorage, OwnableUpgradeable {
     using BitmapUtils for *;
-
-    IAVSDirectory internal immutable _avsDirectory;
-    IPaymentCoordinator internal immutable _paymentCoordinator;
-    IRegistryCoordinator internal immutable _registryCoordinator;
-    IStakeRegistry internal immutable _stakeRegistry;
 
     /// @notice when applied to a function, only allows the RegistryCoordinator to call it
     modifier onlyRegistryCoordinator() {
@@ -33,22 +30,37 @@ abstract contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
         _;
     }
 
+    modifier onlyPaymentInitiator() {
+        require(
+            msg.sender == paymentInitiator,
+            "ServiceManagerBase.onlyPaymentInitiator: caller is not the payment initiator"
+        );
+        _;
+    }
+
     /// @notice Sets the (immutable) `_registryCoordinator` address
     constructor(
         IAVSDirectory __avsDirectory,
         IPaymentCoordinator ___paymentCoordinator,
         IRegistryCoordinator __registryCoordinator,
         IStakeRegistry __stakeRegistry
-    ) {
-        _avsDirectory = __avsDirectory;
-        _paymentCoordinator = ___paymentCoordinator;
-        _registryCoordinator = __registryCoordinator;
-        _stakeRegistry = __stakeRegistry;
+    )
+        ServiceManagerBaseStorage(
+            __avsDirectory,
+            ___paymentCoordinator,
+            __registryCoordinator,
+            __stakeRegistry
+        )
+    {
         _disableInitializers();
     }
 
-    function __ServiceManagerBase_init(address initialOwner) internal virtual onlyInitializing {
+    function __ServiceManagerBase_init(
+        address initialOwner,
+        address _paymentInitiator
+    ) internal virtual onlyInitializing {
         _transferOwnership(initialOwner);
+        _setPaymentInitiator(_paymentInitiator);
     }
 
     /**
@@ -73,15 +85,20 @@ abstract contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
      * @dev This function will revert if the `rangePayment` is malformed,
      * e.g. if the `strategies` and `weights` arrays are of non-equal lengths
      */
-    function payForRange(
-        IPaymentCoordinator.RangePayment[] calldata rangePayments
-    ) public virtual onlyOwner {
+    function payForRange(IPaymentCoordinator.RangePayment[] calldata rangePayments)
+        public
+        virtual
+        onlyPaymentInitiator
+    {
         for (uint256 i = 0; i < rangePayments.length; ++i) {
             // transfer token to ServiceManager and approve PaymentCoordinator to transfer again
             // in payForRange() call
             rangePayments[i].token.transferFrom(msg.sender, address(this), rangePayments[i].amount);
-            uint256 allowance = rangePayments[i].token.allowance(address(this), address(_paymentCoordinator));
-            rangePayments[i].token.approve(address(_paymentCoordinator), rangePayments[i].amount + allowance);
+            uint256 allowance =
+                rangePayments[i].token.allowance(address(this), address(_paymentCoordinator));
+            rangePayments[i].token.approve(
+                address(_paymentCoordinator), rangePayments[i].amount + allowance
+            );
         }
 
         _paymentCoordinator.payForRange(rangePayments);
@@ -108,9 +125,23 @@ abstract contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
     }
 
     /**
+     * @notice Sets the payment initiator address
+     * @param newPaymentInitiator The new payment initiator address
+     * @dev only callable by the owner
+     */
+    function setPaymentInitiator(address newPaymentInitiator) external onlyOwner {
+        _setPaymentInitiator(newPaymentInitiator);
+    }
+
+    function _setPaymentInitiator(address newPaymentInitiator) internal {
+        emit PaymentInitiatorUpdated(paymentInitiator, newPaymentInitiator);
+        paymentInitiator = newPaymentInitiator;
+    }
+
+    /**
      * @notice Returns the list of strategies that the AVS supports for restaking
      * @dev This function is intended to be called off-chain
-     * @dev No guarantee is made on uniqueness of each element in the returned array. 
+     * @dev No guarantee is made on uniqueness of each element in the returned array.
      *      The off-chain service should do that validation separately
      */
     function getRestakeableStrategies() external view returns (address[] memory) {
@@ -119,18 +150,19 @@ abstract contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
         if (quorumCount == 0) {
             return new address[](0);
         }
-        
+
         uint256 strategyCount;
-        for(uint256 i = 0; i < quorumCount; i++) {
+        for (uint256 i = 0; i < quorumCount; i++) {
             strategyCount += _stakeRegistry.strategyParamsLength(uint8(i));
         }
 
         address[] memory restakedStrategies = new address[](strategyCount);
         uint256 index = 0;
-        for(uint256 i = 0; i < _registryCoordinator.quorumCount(); i++) {
+        for (uint256 i = 0; i < _registryCoordinator.quorumCount(); i++) {
             uint256 strategyParamsLength = _stakeRegistry.strategyParamsLength(uint8(i));
             for (uint256 j = 0; j < strategyParamsLength; j++) {
-                restakedStrategies[index] = address(_stakeRegistry.strategyParamsByIndex(uint8(i), j).strategy);
+                restakedStrategies[index] =
+                    address(_stakeRegistry.strategyParamsByIndex(uint8(i), j).strategy);
                 index++;
             }
         }
@@ -141,10 +173,14 @@ abstract contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
      * @notice Returns the list of strategies that the operator has potentially restaked on the AVS
      * @param operator The address of the operator to get restaked strategies for
      * @dev This function is intended to be called off-chain
-     * @dev No guarantee is made on whether the operator has shares for a strategy in a quorum or uniqueness 
+     * @dev No guarantee is made on whether the operator has shares for a strategy in a quorum or uniqueness
      *      of each element in the returned array. The off-chain service should do that validation separately
      */
-    function getOperatorRestakedStrategies(address operator) external view returns (address[] memory) {
+    function getOperatorRestakedStrategies(address operator)
+        external
+        view
+        returns (address[] memory)
+    {
         bytes32 operatorId = _registryCoordinator.getOperatorId(operator);
         uint192 operatorBitmap = _registryCoordinator.getCurrentQuorumBitmap(operatorId);
 
@@ -155,29 +191,30 @@ abstract contract ServiceManagerBase is IServiceManager, OwnableUpgradeable {
         // Get number of strategies for each quorum in operator bitmap
         bytes memory operatorRestakedQuorums = BitmapUtils.bitmapToBytesArray(operatorBitmap);
         uint256 strategyCount;
-        for(uint256 i = 0; i < operatorRestakedQuorums.length; i++) {
+        for (uint256 i = 0; i < operatorRestakedQuorums.length; i++) {
             strategyCount += _stakeRegistry.strategyParamsLength(uint8(operatorRestakedQuorums[i]));
         }
 
         // Get strategies for each quorum in operator bitmap
         address[] memory restakedStrategies = new address[](strategyCount);
         uint256 index = 0;
-        for(uint256 i = 0; i < operatorRestakedQuorums.length; i++) {
+        for (uint256 i = 0; i < operatorRestakedQuorums.length; i++) {
             uint8 quorum = uint8(operatorRestakedQuorums[i]);
             uint256 strategyParamsLength = _stakeRegistry.strategyParamsLength(quorum);
             for (uint256 j = 0; j < strategyParamsLength; j++) {
-                restakedStrategies[index] = address(_stakeRegistry.strategyParamsByIndex(quorum, j).strategy);
+                restakedStrategies[index] =
+                    address(_stakeRegistry.strategyParamsByIndex(quorum, j).strategy);
                 index++;
             }
         }
-        return restakedStrategies;        
+        return restakedStrategies;
     }
 
     /// @notice Returns the EigenLayer AVSDirectory contract.
     function avsDirectory() external view override returns (address) {
         return address(_avsDirectory);
     }
-    
+
     // storage gap for upgradeability
     // slither-disable-next-line shadowing-state
     uint256[50] private __GAP;

--- a/src/ServiceManagerBase.sol
+++ b/src/ServiceManagerBase.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.12;
 
 import {OwnableUpgradeable} from "@openzeppelin-upgrades/contracts/access/OwnableUpgradeable.sol";
+import {Initializable} from "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";
 import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
 import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
 import {IPaymentCoordinator} from
@@ -18,7 +19,11 @@ import {BitmapUtils} from "./libraries/BitmapUtils.sol";
  * This contract can be inherited from or simply used as a point-of-reference.
  * @author Layr Labs, Inc.
  */
-abstract contract ServiceManagerBase is ServiceManagerBaseStorage, OwnableUpgradeable {
+abstract contract ServiceManagerBase is
+    ServiceManagerBaseStorage,
+    Initializable,
+    OwnableUpgradeable
+{
     using BitmapUtils for *;
 
     /// @notice when applied to a function, only allows the RegistryCoordinator to call it

--- a/src/ServiceManagerBase.sol
+++ b/src/ServiceManagerBase.sol
@@ -19,11 +19,7 @@ import {BitmapUtils} from "./libraries/BitmapUtils.sol";
  * This contract can be inherited from or simply used as a point-of-reference.
  * @author Layr Labs, Inc.
  */
-abstract contract ServiceManagerBase is
-    ServiceManagerBaseStorage,
-    Initializable,
-    OwnableUpgradeable
-{
+abstract contract ServiceManagerBase is OwnableUpgradeable, ServiceManagerBaseStorage {
     using BitmapUtils for *;
 
     /// @notice when applied to a function, only allows the RegistryCoordinator to call it
@@ -219,8 +215,4 @@ abstract contract ServiceManagerBase is
     function avsDirectory() external view override returns (address) {
         return address(_avsDirectory);
     }
-
-    // storage gap for upgradeability
-    // slither-disable-next-line shadowing-state
-    uint256[50] private __GAP;
 }

--- a/src/ServiceManagerBaseStorage.sol
+++ b/src/ServiceManagerBaseStorage.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.12;
 
-import {Initializable} from "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";
-
 import {IServiceManager} from "./interfaces/IServiceManager.sol";
 import {IRegistryCoordinator} from "./interfaces/IRegistryCoordinator.sol";
 import {IStakeRegistry} from "./interfaces/IStakeRegistry.sol";
@@ -12,17 +10,16 @@ import {IPaymentCoordinator} from
     "eigenlayer-contracts/src/contracts/interfaces/IPaymentCoordinator.sol";
 
 /**
- * @title Storage variables for the `IndexRegistry` contract.
+ * @title Storage variables for the `ServiceManagerBase` contract.
  * @author Layr Labs, Inc.
  * @notice This storage contract is separate from the logic to simplify the upgrade process.
  */
-abstract contract ServiceManagerBaseStorage is Initializable, IServiceManager {
+abstract contract ServiceManagerBaseStorage is IServiceManager {
     /**
      *
      *                            CONSTANTS AND IMMUTABLES
      *
      */
-    /// @notice The RegistryCoordinator contract for this middleware
     IAVSDirectory internal immutable _avsDirectory;
     IPaymentCoordinator internal immutable _paymentCoordinator;
     IRegistryCoordinator internal immutable _registryCoordinator;
@@ -33,9 +30,11 @@ abstract contract ServiceManagerBaseStorage is Initializable, IServiceManager {
      *                            STATE VARIABLES
      *
      */
+
+    /// @notice The address of the entity that can initiate payments
     address public paymentInitiator;
 
-    /// @notice Sets the (immutable) `_registryCoordinator` address
+    /// @notice Sets the (immutable) `_avsDirectory`, `_paymentCoordinator`, `_registryCoordinator`, and `_stakeRegistry` addresses
     constructor(
         IAVSDirectory __avsDirectory,
         IPaymentCoordinator __paymentCoordinator,
@@ -46,9 +45,8 @@ abstract contract ServiceManagerBaseStorage is Initializable, IServiceManager {
         _paymentCoordinator = __paymentCoordinator;
         _registryCoordinator = __registryCoordinator;
         _stakeRegistry = __stakeRegistry;
-        _disableInitializers();
     }
 
     // storage gap for upgradeability
-    uint256[47] private __GAP;
+    uint256[50] private __GAP;
 }

--- a/src/ServiceManagerBaseStorage.sol
+++ b/src/ServiceManagerBaseStorage.sol
@@ -48,5 +48,5 @@ abstract contract ServiceManagerBaseStorage is IServiceManager {
     }
 
     // storage gap for upgradeability
-    uint256[50] private __GAP;
+    uint256[49] private __GAP;
 }

--- a/src/ServiceManagerBaseStorage.sol
+++ b/src/ServiceManagerBaseStorage.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.12;
+
+import {Initializable} from "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";
+
+import {IServiceManager} from "./interfaces/IServiceManager.sol";
+import {IRegistryCoordinator} from "./interfaces/IRegistryCoordinator.sol";
+import {IStakeRegistry} from "./interfaces/IStakeRegistry.sol";
+
+import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
+import {IPaymentCoordinator} from
+    "eigenlayer-contracts/src/contracts/interfaces/IPaymentCoordinator.sol";
+
+/**
+ * @title Storage variables for the `IndexRegistry` contract.
+ * @author Layr Labs, Inc.
+ * @notice This storage contract is separate from the logic to simplify the upgrade process.
+ */
+abstract contract ServiceManagerBaseStorage is Initializable, IServiceManager {
+    /**
+     *
+     *                            CONSTANTS AND IMMUTABLES
+     *
+     */
+    /// @notice The RegistryCoordinator contract for this middleware
+    IAVSDirectory internal immutable _avsDirectory;
+    IPaymentCoordinator internal immutable _paymentCoordinator;
+    IRegistryCoordinator internal immutable _registryCoordinator;
+    IStakeRegistry internal immutable _stakeRegistry;
+
+    /**
+     *
+     *                            STATE VARIABLES
+     *
+     */
+    address public paymentInitiator;
+
+    /// @notice Sets the (immutable) `_registryCoordinator` address
+    constructor(
+        IAVSDirectory __avsDirectory,
+        IPaymentCoordinator __paymentCoordinator,
+        IRegistryCoordinator __registryCoordinator,
+        IStakeRegistry __stakeRegistry
+    ) {
+        _avsDirectory = __avsDirectory;
+        _paymentCoordinator = __paymentCoordinator;
+        _registryCoordinator = __registryCoordinator;
+        _stakeRegistry = __stakeRegistry;
+        _disableInitializers();
+    }
+
+    // storage gap for upgradeability
+    uint256[47] private __GAP;
+}

--- a/src/interfaces/IServiceManager.sol
+++ b/src/interfaces/IServiceManager.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
-import {IPaymentCoordinator} from "eigenlayer-contracts/src/contracts/interfaces/IPaymentCoordinator.sol";
+import {IPaymentCoordinator} from
+    "eigenlayer-contracts/src/contracts/interfaces/IPaymentCoordinator.sol";
 import {IServiceManagerUI} from "./IServiceManagerUI.sol";
 
 /**
@@ -23,4 +24,7 @@ interface IServiceManager is IServiceManagerUI {
      * e.g. if the `strategies` and `weights` arrays are of non-equal lengths
      */
     function payForRange(IPaymentCoordinator.RangePayment[] calldata rangePayments) external;
+
+    // EVENTS
+    event PaymentInitiatorUpdated(address prevPaymentInitiator, address newPaymentInitiator);
 }

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -43,7 +43,6 @@ import "eigenlayer-contracts/src/test/mocks/EmptyContract.sol";
 import "test/integration/User.t.sol";
 
 abstract contract IntegrationDeployer is Test, IUserDeployer {
-
     using Strings for *;
 
     Vm cheats = Vm(VM_ADDRESS);
@@ -85,7 +84,8 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
     address eigenLayerReputedMultisig = address(this); // admin address
     address constant pauser = address(555);
     address constant unpauser = address(556);
-    address public registryCoordinatorOwner = address(uint160(uint256(keccak256("registryCoordinatorOwner"))));
+    address public registryCoordinatorOwner =
+        address(uint160(uint256(keccak256("registryCoordinatorOwner"))));
     uint256 public churnApproverPrivateKey = uint256(keccak256("churnApproverPrivateKey"));
     address public churnApprover = cheats.addr(churnApproverPrivateKey);
     address ejector = address(uint160(uint256(keccak256("ejector"))));
@@ -93,15 +93,15 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
 
     // Constants/Defaults
     uint64 constant MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR = 32e9;
-    uint constant MIN_BALANCE = 1e6;
-    uint constant MAX_BALANCE = 5e6;
-    uint constant MAX_STRATEGY_COUNT = 32; // From StakeRegistry.MAX_WEIGHING_FUNCTION_LENGTH
+    uint256 constant MIN_BALANCE = 1e6;
+    uint256 constant MAX_BALANCE = 5e6;
+    uint256 constant MAX_STRATEGY_COUNT = 32; // From StakeRegistry.MAX_WEIGHING_FUNCTION_LENGTH
     uint96 constant DEFAULT_STRATEGY_MULTIPLIER = 1e18;
     // PaymentCoordinator
     uint32 MAX_PAYMENT_DURATION = 70 days;
     uint32 MAX_RETROACTIVE_LENGTH = 84 days;
     uint32 MAX_FUTURE_LENGTH = 28 days;
-    uint32 GENESIS_PAYMENT_TIMESTAMP = 1712092632;
+    uint32 GENESIS_PAYMENT_TIMESTAMP = 1_712_092_632;
     /// @notice Delay in timestamp before a posted root can be claimed against
     uint32 activationDelay = 7 days;
     /// @notice intervals(epochs) are 2 weeks
@@ -128,22 +128,34 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
          * not yet deployed, we give these proxies an empty contract as the initial implementation, to act as if they have no code.
          */
         delegationManager = DelegationManager(
-            address(new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), ""))
+            address(
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
+            )
         );
         strategyManager = StrategyManager(
-            address(new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), ""))
+            address(
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
+            )
         );
         slasher = Slasher(
-            address(new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), ""))
+            address(
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
+            )
         );
         eigenPodManager = EigenPodManager(
-            address(new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), ""))
+            address(
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
+            )
         );
         delayedWithdrawalRouter = DelayedWithdrawalRouter(
-            address(new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), ""))
+            address(
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
+            )
         );
         avsDirectory = AVSDirectory(
-            address(new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), ""))
+            address(
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
+            )
         );
         // paymentCoordinator = PaymentCoordinator(
         //     address(new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), ""))
@@ -161,17 +173,16 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
         eigenPodBeacon = new UpgradeableBeacon(address(pod));
 
         // Second, deploy the *implementation* contracts, using the *proxy contracts* as inputs
-        DelegationManager delegationImplementation = new DelegationManager(strategyManager, slasher, eigenPodManager);
-        StrategyManager strategyManagerImplementation = new StrategyManager(delegationManager, eigenPodManager, slasher);
+        DelegationManager delegationImplementation =
+            new DelegationManager(strategyManager, slasher, eigenPodManager);
+        StrategyManager strategyManagerImplementation =
+            new StrategyManager(delegationManager, eigenPodManager, slasher);
         Slasher slasherImplementation = new Slasher(strategyManager, delegationManager);
         EigenPodManager eigenPodManagerImplementation = new EigenPodManager(
-            ethPOSDeposit,
-            eigenPodBeacon,
-            strategyManager,
-            slasher,
-            delegationManager
+            ethPOSDeposit, eigenPodBeacon, strategyManager, slasher, delegationManager
         );
-        DelayedWithdrawalRouter delayedWithdrawalRouterImplementation = new DelayedWithdrawalRouter(eigenPodManager);
+        DelayedWithdrawalRouter delayedWithdrawalRouterImplementation =
+            new DelayedWithdrawalRouter(eigenPodManager);
         AVSDirectory avsDirectoryImplemntation = new AVSDirectory(delegationManager);
         // PaymentCoordinator paymentCoordinatorImplementation = new PaymentCoordinator(
         //     delegationManager,
@@ -194,7 +205,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
                 DelegationManager.initialize.selector,
                 eigenLayerReputedMultisig, // initialOwner
                 pauserRegistry,
-                0 /* initialPausedStatus */,
+                0, /* initialPausedStatus */
                 minWithdrawalDelayBlocks,
                 initializeStrategiesToSetDelayBlocks,
                 initializeWithdrawalDelayBlocks
@@ -276,8 +287,8 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
 
         // Deploy and whitelist strategies
         baseStrategyImplementation = new StrategyBase(strategyManager);
-        for (uint i = 0; i < MAX_STRATEGY_COUNT; i++) {
-            string memory number = uint(i).toString();
+        for (uint256 i = 0; i < MAX_STRATEGY_COUNT; i++) {
+            string memory number = uint256(i).toString();
             string memory stratName = string.concat("StrategyToken", number);
             string memory stratSymbol = string.concat("STT", number);
             _newStrategyAndToken(stratName, stratSymbol, 10e50, address(this));
@@ -287,58 +298,44 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
         timeMachine = new TimeMachine();
 
         cheats.startPrank(registryCoordinatorOwner);
-        registryCoordinator = RegistryCoordinator(address(
-            new TransparentUpgradeableProxy(
-                address(emptyContract),
-                address(proxyAdmin),
-                ""
+        registryCoordinator = RegistryCoordinator(
+            address(
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
             )
-        ));
+        );
 
         stakeRegistry = StakeRegistry(
             address(
-                new TransparentUpgradeableProxy(
-                    address(emptyContract),
-                    address(proxyAdmin),
-                    ""
-                )
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
             )
         );
 
         indexRegistry = IndexRegistry(
             address(
-                new TransparentUpgradeableProxy(
-                    address(emptyContract),
-                    address(proxyAdmin),
-                    ""
-                )
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
             )
         );
 
         blsApkRegistry = BLSApkRegistry(
             address(
-                new TransparentUpgradeableProxy(
-                    address(emptyContract),
-                    address(proxyAdmin),
-                    ""
-                )
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
             )
         );
 
         serviceManager = ServiceManagerMock(
             address(
-                new TransparentUpgradeableProxy(
-                    address(emptyContract),
-                    address(proxyAdmin),
-                    ""
-                )
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
             )
         );
         cheats.stopPrank();
 
-        StakeRegistry stakeRegistryImplementation = new StakeRegistry(IRegistryCoordinator(registryCoordinator), IDelegationManager(delegationManager));
-        BLSApkRegistry blsApkRegistryImplementation = new BLSApkRegistry(IRegistryCoordinator(registryCoordinator));
-        IndexRegistry indexRegistryImplementation = new IndexRegistry(IRegistryCoordinator(registryCoordinator));
+        StakeRegistry stakeRegistryImplementation = new StakeRegistry(
+            IRegistryCoordinator(registryCoordinator), IDelegationManager(delegationManager)
+        );
+        BLSApkRegistry blsApkRegistryImplementation =
+            new BLSApkRegistry(IRegistryCoordinator(registryCoordinator));
+        IndexRegistry indexRegistryImplementation =
+            new IndexRegistry(IRegistryCoordinator(registryCoordinator));
         ServiceManagerMock serviceManagerImplementation = new ServiceManagerMock(
             IAVSDirectory(avsDirectory),
             paymentCoordinator,
@@ -350,7 +347,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
             TransparentUpgradeableProxy(payable(address(stakeRegistry))),
             address(stakeRegistryImplementation)
         );
-        
+
         proxyAdmin.upgrade(
             TransparentUpgradeableProxy(payable(address(blsApkRegistry))),
             address(blsApkRegistryImplementation)
@@ -366,9 +363,13 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
             address(serviceManagerImplementation)
         );
 
-        serviceManager.initialize({initialOwner: registryCoordinatorOwner});
+        serviceManager.initialize({
+            initialOwner: registryCoordinatorOwner,
+            paymentInitiator: address(proxyAdmin)
+        });
 
-        RegistryCoordinator registryCoordinatorImplementation = new RegistryCoordinator(serviceManager, stakeRegistry, blsApkRegistry, indexRegistry);
+        RegistryCoordinator registryCoordinatorImplementation =
+            new RegistryCoordinator(serviceManager, stakeRegistry, blsApkRegistry, indexRegistry);
         proxyAdmin.upgradeAndCall(
             TransparentUpgradeableProxy(payable(address(registryCoordinator))),
             address(registryCoordinatorImplementation),
@@ -378,7 +379,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
                 churnApprover,
                 ejector,
                 pauserRegistry,
-                0/*initialPausedStatus*/,
+                0, /*initialPausedStatus*/
                 new IRegistryCoordinator.OperatorSetParam[](0),
                 new uint96[](0),
                 new IStakeRegistry.StrategyParams[][](0)
@@ -390,14 +391,22 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
 
     /// @dev Deploy a strategy and its underlying token, push to global lists of tokens/strategies, and whitelist
     /// strategy in strategyManager
-    function _newStrategyAndToken(string memory tokenName, string memory tokenSymbol, uint initialSupply, address owner) internal {
-        IERC20 underlyingToken = new ERC20PresetFixedSupply(tokenName, tokenSymbol, initialSupply, owner); 
+    function _newStrategyAndToken(
+        string memory tokenName,
+        string memory tokenSymbol,
+        uint256 initialSupply,
+        address owner
+    ) internal {
+        IERC20 underlyingToken =
+            new ERC20PresetFixedSupply(tokenName, tokenSymbol, initialSupply, owner);
         StrategyBase strategy = StrategyBase(
             address(
                 new TransparentUpgradeableProxy(
                     address(baseStrategyImplementation),
                     address(proxyAdmin),
-                    abi.encodeWithSelector(StrategyBase.initialize.selector, underlyingToken, pauserRegistry)
+                    abi.encodeWithSelector(
+                        StrategyBase.initialize.selector, underlyingToken, pauserRegistry
+                    )
                 )
             )
         );
@@ -407,7 +416,9 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
         bool[] memory thirdPartyTransfersForbiddenValues = new bool[](1);
         strategies[0] = strategy;
         cheats.prank(strategyManager.strategyWhitelister());
-        strategyManager.addStrategiesToDepositWhitelist(strategies, thirdPartyTransfersForbiddenValues);
+        strategyManager.addStrategiesToDepositWhitelist(
+            strategies, thirdPartyTransfersForbiddenValues
+        );
 
         // Add to allStrats
         allStrats.push(strategy);

--- a/test/mocks/ServiceManagerMock.sol
+++ b/test/mocks/ServiceManagerMock.sol
@@ -9,9 +9,14 @@ contract ServiceManagerMock is ServiceManagerBase {
         IPaymentCoordinator _paymentCoordinator,
         IRegistryCoordinator _registryCoordinator,
         IStakeRegistry _stakeRegistry
-    ) ServiceManagerBase(_avsDirectory, _paymentCoordinator, _registryCoordinator, _stakeRegistry) {}
+    )
+        ServiceManagerBase(_avsDirectory, _paymentCoordinator, _registryCoordinator, _stakeRegistry)
+    {}
 
-    function initialize(address initialOwner) public virtual initializer {
-        __ServiceManagerBase_init(initialOwner);
+    function initialize(
+        address initialOwner,
+        address paymentInitiator
+    ) public virtual initializer {
+        __ServiceManagerBase_init(initialOwner, paymentInitiator);
     }
 }

--- a/test/unit/ServiceManagerBase.t.sol
+++ b/test/unit/ServiceManagerBase.t.sol
@@ -2,30 +2,29 @@
 pragma solidity ^0.8.12;
 
 import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
-import {PaymentCoordinator, IPaymentCoordinator, IERC20} from "eigenlayer-contracts/src/contracts/core/PaymentCoordinator.sol";
+import {
+    PaymentCoordinator,
+    IPaymentCoordinator,
+    IERC20
+} from "eigenlayer-contracts/src/contracts/core/PaymentCoordinator.sol";
 import {StrategyBase} from "eigenlayer-contracts/src/contracts/strategies/StrategyBase.sol";
 import {IServiceManagerBaseEvents} from "../events/IServiceManagerBaseEvents.sol";
 
 import "../utils/MockAVSDeployer.sol";
 
-contract ServiceManagerBase_UnitTests is
-    MockAVSDeployer,
-    IServiceManagerBaseEvents
-{
+contract ServiceManagerBase_UnitTests is MockAVSDeployer, IServiceManagerBaseEvents {
     // PaymentCoordinator config
-    address paymentUpdater =
-        address(uint160(uint256(keccak256("paymentUpdater"))));
+    address paymentUpdater = address(uint160(uint256(keccak256("paymentUpdater"))));
     uint32 CALCULATION_INTERVAL_SECONDS = 7 days;
     uint32 MAX_PAYMENT_DURATION = 70 days;
     uint32 MAX_RETROACTIVE_LENGTH = 84 days;
     uint32 MAX_FUTURE_LENGTH = 28 days;
-    uint32 GENESIS_PAYMENT_TIMESTAMP = 1712188800;
+    uint32 GENESIS_PAYMENT_TIMESTAMP = 1_712_188_800;
     uint256 MAX_PAYMENT_AMOUNT = 1e38 - 1;
     /// @notice Delay in timestamp before a posted root can be claimed against
     uint32 activationDelay = 7 days;
     /// @notice the commission for all operators across all avss
     uint16 globalCommissionBips = 1000;
-    
 
     // Testing Config and Mocks
     address serviceManagerOwner;
@@ -67,7 +66,7 @@ contract ServiceManagerBase_UnitTests is
                         PaymentCoordinator.initialize.selector,
                         msg.sender,
                         pauserRegistry,
-                        0 /*initialPausedStatus*/,
+                        0, /*initialPausedStatus*/
                         paymentUpdater,
                         activationDelay,
                         globalCommissionBips
@@ -82,18 +81,19 @@ contract ServiceManagerBase_UnitTests is
             registryCoordinatorImplementation,
             stakeRegistryImplementation
         );
+
         serviceManager = ServiceManagerMock(
             address(
                 new TransparentUpgradeableProxy(
                     address(serviceManagerImplementation),
                     address(proxyAdmin),
                     abi.encodeWithSelector(
-                        ServiceManagerMock.initialize.selector,
-                        msg.sender
+                        ServiceManagerMock.initialize.selector, msg.sender, msg.sender
                     )
                 )
             )
         );
+
         serviceManagerOwner = serviceManager.owner();
 
         _setUpDefaultStrategiesAndMultipliers();
@@ -105,18 +105,11 @@ contract ServiceManagerBase_UnitTests is
     }
 
     /// @notice deploy token to owner and approve ServiceManager. Used for deploying payment tokens
-    function _deployMockPaymentTokens(
-        address owner,
-        uint256 numTokens
-    ) internal virtual {
+    function _deployMockPaymentTokens(address owner, uint256 numTokens) internal virtual {
         cheats.startPrank(owner);
         for (uint256 i = 0; i < numTokens; ++i) {
-            IERC20 token = new ERC20PresetFixedSupply(
-                "dog wif hat",
-                "MOCK1",
-                mockTokenInitialSupply,
-                owner
-            );
+            IERC20 token =
+                new ERC20PresetFixedSupply("dog wif hat", "MOCK1", mockTokenInitialSupply, owner);
             paymentTokens.push(token);
             token.approve(address(serviceManager), mockTokenInitialSupply);
         }
@@ -137,22 +130,12 @@ contract ServiceManagerBase_UnitTests is
     function _setUpDefaultStrategiesAndMultipliers() internal virtual {
         // Deploy Mock Strategies
         IERC20 token1 = new ERC20PresetFixedSupply(
-            "dog wif hat",
-            "MOCK1",
-            mockTokenInitialSupply,
-            address(this)
+            "dog wif hat", "MOCK1", mockTokenInitialSupply, address(this)
         );
-        IERC20 token2 = new ERC20PresetFixedSupply(
-            "jeo boden",
-            "MOCK2",
-            mockTokenInitialSupply,
-            address(this)
-        );
+        IERC20 token2 =
+            new ERC20PresetFixedSupply("jeo boden", "MOCK2", mockTokenInitialSupply, address(this));
         IERC20 token3 = new ERC20PresetFixedSupply(
-            "pepe wif avs",
-            "MOCK3",
-            mockTokenInitialSupply,
-            address(this)
+            "pepe wif avs", "MOCK3", mockTokenInitialSupply, address(this)
         );
         strategyImplementation = new StrategyBase(strategyManagerMock);
         strategyMock1 = StrategyBase(
@@ -160,11 +143,7 @@ contract ServiceManagerBase_UnitTests is
                 new TransparentUpgradeableProxy(
                     address(strategyImplementation),
                     address(proxyAdmin),
-                    abi.encodeWithSelector(
-                        StrategyBase.initialize.selector,
-                        token1,
-                        pauserRegistry
-                    )
+                    abi.encodeWithSelector(StrategyBase.initialize.selector, token1, pauserRegistry)
                 )
             )
         );
@@ -173,11 +152,7 @@ contract ServiceManagerBase_UnitTests is
                 new TransparentUpgradeableProxy(
                     address(strategyImplementation),
                     address(proxyAdmin),
-                    abi.encodeWithSelector(
-                        StrategyBase.initialize.selector,
-                        token2,
-                        pauserRegistry
-                    )
+                    abi.encodeWithSelector(StrategyBase.initialize.selector, token2, pauserRegistry)
                 )
             )
         );
@@ -186,11 +161,7 @@ contract ServiceManagerBase_UnitTests is
                 new TransparentUpgradeableProxy(
                     address(strategyImplementation),
                     address(proxyAdmin),
-                    abi.encodeWithSelector(
-                        StrategyBase.initialize.selector,
-                        token3,
-                        pauserRegistry
-                    )
+                    abi.encodeWithSelector(StrategyBase.initialize.selector, token3, pauserRegistry)
                 )
             )
         );
@@ -205,29 +176,18 @@ contract ServiceManagerBase_UnitTests is
         strategyManagerMock.setStrategyWhitelist(strategies[2], true);
 
         defaultStrategyAndMultipliers.push(
-            IPaymentCoordinator.StrategyAndMultiplier(
-                IStrategy(address(strategies[0])),
-                1e18
-            )
+            IPaymentCoordinator.StrategyAndMultiplier(IStrategy(address(strategies[0])), 1e18)
         );
         defaultStrategyAndMultipliers.push(
-            IPaymentCoordinator.StrategyAndMultiplier(
-                IStrategy(address(strategies[1])),
-                2e18
-            )
+            IPaymentCoordinator.StrategyAndMultiplier(IStrategy(address(strategies[1])), 2e18)
         );
         defaultStrategyAndMultipliers.push(
-            IPaymentCoordinator.StrategyAndMultiplier(
-                IStrategy(address(strategies[2])),
-                3e18
-            )
+            IPaymentCoordinator.StrategyAndMultiplier(IStrategy(address(strategies[2])), 3e18)
         );
     }
 
     /// @dev Sort to ensure that the array is in ascending order for strategies
-    function _sortArrayAsc(
-        IStrategy[] memory arr
-    ) internal pure returns (IStrategy[] memory) {
+    function _sortArrayAsc(IStrategy[] memory arr) internal pure returns (IStrategy[] memory) {
         uint256 l = arr.length;
         for (uint256 i = 0; i < l; i++) {
             for (uint256 j = i + 1; j < l; j++) {
@@ -241,34 +201,31 @@ contract ServiceManagerBase_UnitTests is
         return arr;
     }
 
-    function _maxTimestamp(
-        uint32 timestamp1,
-        uint32 timestamp2
-    ) internal pure returns (uint32) {
+    function _maxTimestamp(uint32 timestamp1, uint32 timestamp2) internal pure returns (uint32) {
         return timestamp1 > timestamp2 ? timestamp1 : timestamp2;
     }
 
-    function testFuzz_submitPayments_Revert_WhenNotOwner(
-        address caller
-    ) public filterFuzzedAddressInputs(caller) {
+    function testFuzz_submitPayments_Revert_WhenNotOwner(address caller)
+        public
+        filterFuzzedAddressInputs(caller)
+    {
         cheats.assume(caller != serviceManagerOwner);
         IPaymentCoordinator.RangePayment[] memory rangePayments;
 
         cheats.prank(caller);
-        cheats.expectRevert("Ownable: caller is not the owner");
+        cheats.expectRevert(
+            "ServiceManagerBase.onlyPaymentInitiator: caller is not the payment initiator"
+        );
         serviceManager.payForRange(rangePayments);
     }
 
     function test_submitPayments_Revert_WhenERC20NotApproved() public {
         IERC20 token = new ERC20PresetFixedSupply(
-            "dog wif hat",
-            "MOCK1",
-            mockTokenInitialSupply,
-            serviceManagerOwner
+            "dog wif hat", "MOCK1", mockTokenInitialSupply, serviceManagerOwner
         );
 
-        IPaymentCoordinator.RangePayment[]
-            memory rangePayments = new IPaymentCoordinator.RangePayment[](1);
+        IPaymentCoordinator.RangePayment[] memory rangePayments =
+            new IPaymentCoordinator.RangePayment[](1);
         rangePayments[0] = IPaymentCoordinator.RangePayment({
             strategiesAndMultipliers: defaultStrategyAndMultipliers,
             token: token,
@@ -289,10 +246,7 @@ contract ServiceManagerBase_UnitTests is
     ) public {
         // 1. Bound fuzz inputs to valid ranges and amounts
         IERC20 paymentToken = new ERC20PresetFixedSupply(
-            "dog wif hat",
-            "MOCK1",
-            mockTokenInitialSupply,
-            serviceManagerOwner
+            "dog wif hat", "MOCK1", mockTokenInitialSupply, serviceManagerOwner
         );
         amount = bound(amount, 1, MAX_PAYMENT_AMOUNT);
         duration = bound(duration, 0, MAX_PAYMENT_DURATION);
@@ -301,21 +255,16 @@ contract ServiceManagerBase_UnitTests is
             startTimestamp,
             uint256(
                 _maxTimestamp(
-                    GENESIS_PAYMENT_TIMESTAMP,
-                    uint32(block.timestamp) - MAX_RETROACTIVE_LENGTH
+                    GENESIS_PAYMENT_TIMESTAMP, uint32(block.timestamp) - MAX_RETROACTIVE_LENGTH
                 )
-            ) +
-                CALCULATION_INTERVAL_SECONDS -
-                1,
+            ) + CALCULATION_INTERVAL_SECONDS - 1,
             block.timestamp + uint256(MAX_FUTURE_LENGTH)
         );
-        startTimestamp =
-            startTimestamp -
-            (startTimestamp % CALCULATION_INTERVAL_SECONDS);
+        startTimestamp = startTimestamp - (startTimestamp % CALCULATION_INTERVAL_SECONDS);
 
         // 2. Create range payment input param
-        IPaymentCoordinator.RangePayment[]
-            memory rangePayments = new IPaymentCoordinator.RangePayment[](1);
+        IPaymentCoordinator.RangePayment[] memory rangePayments =
+            new IPaymentCoordinator.RangePayment[](1);
         rangePayments[0] = IPaymentCoordinator.RangePayment({
             strategiesAndMultipliers: defaultStrategyAndMultipliers,
             token: paymentToken,
@@ -329,40 +278,25 @@ contract ServiceManagerBase_UnitTests is
         paymentToken.approve(address(serviceManager), amount);
 
         // 4. call payForRange() with expected event emitted
-        uint256 serviceManagerOwnerBalanceBefore = paymentToken.balanceOf(
-            address(serviceManagerOwner)
-        );
-        uint256 paymentCoordinatorBalanceBefore = paymentToken.balanceOf(
-            address(paymentCoordinator)
-        );
+        uint256 serviceManagerOwnerBalanceBefore =
+            paymentToken.balanceOf(address(serviceManagerOwner));
+        uint256 paymentCoordinatorBalanceBefore =
+            paymentToken.balanceOf(address(paymentCoordinator));
 
         paymentToken.approve(address(paymentCoordinator), amount);
-        uint256 currPaymentNonce = paymentCoordinator.paymentNonce(
-            address(serviceManager)
-        );
-        bytes32 rangePaymentHash = keccak256(
-            abi.encode(
-                address(serviceManager),
-                currPaymentNonce,
-                rangePayments[0]
-            )
-        );
+        uint256 currPaymentNonce = paymentCoordinator.paymentNonce(address(serviceManager));
+        bytes32 rangePaymentHash =
+            keccak256(abi.encode(address(serviceManager), currPaymentNonce, rangePayments[0]));
 
         cheats.expectEmit(true, true, true, true, address(paymentCoordinator));
         emit RangePaymentCreated(
-            address(serviceManager),
-            currPaymentNonce,
-            rangePaymentHash,
-            rangePayments[0]
+            address(serviceManager), currPaymentNonce, rangePaymentHash, rangePayments[0]
         );
         serviceManager.payForRange(rangePayments);
         cheats.stopPrank();
 
         assertTrue(
-            paymentCoordinator.isRangePaymentHash(
-                address(serviceManager),
-                rangePaymentHash
-            ),
+            paymentCoordinator.isRangePaymentHash(address(serviceManager), rangePaymentHash),
             "Range payment hash not submitted"
         );
         assertEq(
@@ -391,25 +325,16 @@ contract ServiceManagerBase_UnitTests is
         cheats.assume(2 <= numPayments && numPayments <= 10);
         cheats.prank(paymentCoordinator.owner());
 
-        IPaymentCoordinator.RangePayment[]
-            memory rangePayments = new IPaymentCoordinator.RangePayment[](
-                numPayments
-            );
+        IPaymentCoordinator.RangePayment[] memory rangePayments =
+            new IPaymentCoordinator.RangePayment[](numPayments);
         bytes32[] memory rangePaymentHashes = new bytes32[](numPayments);
-        uint256 startPaymentNonce = paymentCoordinator.paymentNonce(
-            address(serviceManager)
-        );
+        uint256 startPaymentNonce = paymentCoordinator.paymentNonce(address(serviceManager));
         _deployMockPaymentTokens(serviceManagerOwner, numPayments);
 
-        uint256[] memory avsBalancesBefore = _getBalanceForTokens(
-            paymentTokens,
-            serviceManagerOwner
-        );
-        uint256[]
-            memory paymentCoordinatorBalancesBefore = _getBalanceForTokens(
-                paymentTokens,
-                address(paymentCoordinator)
-            );
+        uint256[] memory avsBalancesBefore =
+            _getBalanceForTokens(paymentTokens, serviceManagerOwner);
+        uint256[] memory paymentCoordinatorBalancesBefore =
+            _getBalanceForTokens(paymentTokens, address(paymentCoordinator));
         uint256[] memory amounts = new uint256[](numPayments);
 
         // Create multiple range payments and their expected event
@@ -423,44 +348,28 @@ contract ServiceManagerBase_UnitTests is
                 startTimestamp + i,
                 uint256(
                     _maxTimestamp(
-                        GENESIS_PAYMENT_TIMESTAMP,
-                        uint32(block.timestamp) - MAX_RETROACTIVE_LENGTH
+                        GENESIS_PAYMENT_TIMESTAMP, uint32(block.timestamp) - MAX_RETROACTIVE_LENGTH
                     )
-                ) +
-                    CALCULATION_INTERVAL_SECONDS -
-                    1,
+                ) + CALCULATION_INTERVAL_SECONDS - 1,
                 block.timestamp + uint256(MAX_FUTURE_LENGTH)
             );
-            startTimestamp =
-                startTimestamp -
-                (startTimestamp % CALCULATION_INTERVAL_SECONDS);
+            startTimestamp = startTimestamp - (startTimestamp % CALCULATION_INTERVAL_SECONDS);
 
             // 2. Create range payment input param
-            IPaymentCoordinator.RangePayment
-                memory rangePayment = IPaymentCoordinator.RangePayment({
-                    strategiesAndMultipliers: defaultStrategyAndMultipliers,
-                    token: paymentTokens[i],
-                    amount: amounts[i],
-                    startTimestamp: uint32(startTimestamp),
-                    duration: uint32(duration)
-                });
+            IPaymentCoordinator.RangePayment memory rangePayment = IPaymentCoordinator.RangePayment({
+                strategiesAndMultipliers: defaultStrategyAndMultipliers,
+                token: paymentTokens[i],
+                amount: amounts[i],
+                startTimestamp: uint32(startTimestamp),
+                duration: uint32(duration)
+            });
             rangePayments[i] = rangePayment;
 
             // 3. expected event emitted for this rangePayment
             rangePaymentHashes[i] = keccak256(
-                abi.encode(
-                    address(serviceManager),
-                    startPaymentNonce + i,
-                    rangePayments[i]
-                )
+                abi.encode(address(serviceManager), startPaymentNonce + i, rangePayments[i])
             );
-            cheats.expectEmit(
-                true,
-                true,
-                true,
-                true,
-                address(paymentCoordinator)
-            );
+            cheats.expectEmit(true, true, true, true, address(paymentCoordinator));
             emit RangePaymentCreated(
                 address(serviceManager),
                 startPaymentNonce + i,
@@ -483,8 +392,7 @@ contract ServiceManagerBase_UnitTests is
         for (uint256 i = 0; i < numPayments; ++i) {
             assertTrue(
                 paymentCoordinator.isRangePaymentHash(
-                    address(serviceManager),
-                    rangePaymentHashes[i]
+                    address(serviceManager), rangePaymentHashes[i]
                 ),
                 "Range payment hash not submitted"
             );
@@ -510,24 +418,18 @@ contract ServiceManagerBase_UnitTests is
         cheats.assume(2 <= numPayments && numPayments <= 10);
         cheats.prank(paymentCoordinator.owner());
 
-        IPaymentCoordinator.RangePayment[]
-            memory rangePayments = new IPaymentCoordinator.RangePayment[](
-                numPayments
-            );
+        IPaymentCoordinator.RangePayment[] memory rangePayments =
+            new IPaymentCoordinator.RangePayment[](numPayments);
         bytes32[] memory rangePaymentHashes = new bytes32[](numPayments);
-        uint256 startPaymentNonce = paymentCoordinator.paymentNonce(
-            address(serviceManager)
-        );
+        uint256 startPaymentNonce = paymentCoordinator.paymentNonce(address(serviceManager));
         IERC20 paymentToken = new ERC20PresetFixedSupply(
-            "dog wif hat",
-            "MOCK1",
-            mockTokenInitialSupply,
-            serviceManagerOwner
+            "dog wif hat", "MOCK1", mockTokenInitialSupply, serviceManagerOwner
         );
         cheats.prank(serviceManagerOwner);
         paymentToken.approve(address(serviceManager), mockTokenInitialSupply);
         uint256 avsBalanceBefore = paymentToken.balanceOf(serviceManagerOwner);
-        uint256 paymentCoordinatorBalanceBefore = paymentToken.balanceOf(address(paymentCoordinator));
+        uint256 paymentCoordinatorBalanceBefore =
+            paymentToken.balanceOf(address(paymentCoordinator));
         uint256 totalAmount = 0;
 
         uint256[] memory amounts = new uint256[](numPayments);
@@ -544,44 +446,28 @@ contract ServiceManagerBase_UnitTests is
                 startTimestamp + i,
                 uint256(
                     _maxTimestamp(
-                        GENESIS_PAYMENT_TIMESTAMP,
-                        uint32(block.timestamp) - MAX_RETROACTIVE_LENGTH
+                        GENESIS_PAYMENT_TIMESTAMP, uint32(block.timestamp) - MAX_RETROACTIVE_LENGTH
                     )
-                ) +
-                    CALCULATION_INTERVAL_SECONDS -
-                    1,
+                ) + CALCULATION_INTERVAL_SECONDS - 1,
                 block.timestamp + uint256(MAX_FUTURE_LENGTH)
             );
-            startTimestamp =
-                startTimestamp -
-                (startTimestamp % CALCULATION_INTERVAL_SECONDS);
+            startTimestamp = startTimestamp - (startTimestamp % CALCULATION_INTERVAL_SECONDS);
 
             // 2. Create range payment input param
-            IPaymentCoordinator.RangePayment
-                memory rangePayment = IPaymentCoordinator.RangePayment({
-                    strategiesAndMultipliers: defaultStrategyAndMultipliers,
-                    token: paymentToken,
-                    amount: amounts[i],
-                    startTimestamp: uint32(startTimestamp),
-                    duration: uint32(duration)
-                });
+            IPaymentCoordinator.RangePayment memory rangePayment = IPaymentCoordinator.RangePayment({
+                strategiesAndMultipliers: defaultStrategyAndMultipliers,
+                token: paymentToken,
+                amount: amounts[i],
+                startTimestamp: uint32(startTimestamp),
+                duration: uint32(duration)
+            });
             rangePayments[i] = rangePayment;
 
             // 3. expected event emitted for this rangePayment
             rangePaymentHashes[i] = keccak256(
-                abi.encode(
-                    address(serviceManager),
-                    startPaymentNonce + i,
-                    rangePayments[i]
-                )
+                abi.encode(address(serviceManager), startPaymentNonce + i, rangePayments[i])
             );
-            cheats.expectEmit(
-                true,
-                true,
-                true,
-                true,
-                address(paymentCoordinator)
-            );
+            cheats.expectEmit(true, true, true, true, address(paymentCoordinator));
             emit RangePaymentCreated(
                 address(serviceManager),
                 startPaymentNonce + i,
@@ -614,11 +500,25 @@ contract ServiceManagerBase_UnitTests is
         for (uint256 i = 0; i < numPayments; ++i) {
             assertTrue(
                 paymentCoordinator.isRangePaymentHash(
-                    address(serviceManager),
-                    rangePaymentHashes[i]
+                    address(serviceManager), rangePaymentHashes[i]
                 ),
                 "Range payment hash not submitted"
             );
         }
+    }
+
+    function test_setPaymentInitiator() public {
+        address newPaymentInitiator = address(uint160(uint256(keccak256("newPaymentInitiator"))));
+        cheats.prank(serviceManagerOwner);
+        serviceManager.setPaymentInitiator(newPaymentInitiator);
+        assertEq(newPaymentInitiator, serviceManager.paymentInitiator());
+    }
+
+    function test_setPaymentInitiator_revert_notOwner() public {
+        address caller = address(uint160(uint256(keccak256("caller"))));
+        address newPaymentInitiator = address(uint160(uint256(keccak256("newPaymentInitiator"))));
+        cheats.expectRevert("Ownable: caller is not the owner");
+        cheats.prank(caller);
+        serviceManager.setPaymentInitiator(newPaymentInitiator);
     }
 }

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -25,14 +25,14 @@ import {IIndexRegistry} from "../../src/interfaces/IIndexRegistry.sol";
 import {IRegistryCoordinator} from "../../src/interfaces/IRegistryCoordinator.sol";
 import {IServiceManager} from "../../src/interfaces/IServiceManager.sol";
 
-
 import {StrategyManagerMock} from "eigenlayer-contracts/src/test/mocks/StrategyManagerMock.sol";
 import {EigenPodManagerMock} from "eigenlayer-contracts/src/test/mocks/EigenPodManagerMock.sol";
 import {AVSDirectoryMock} from "../mocks/AVSDirectoryMock.sol";
 import {DelegationMock} from "../mocks/DelegationMock.sol";
 import {AVSDirectory} from "eigenlayer-contracts/src/contracts/core/AVSDirectory.sol";
 import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
-import {IPaymentCoordinator} from "eigenlayer-contracts/src/contracts/interfaces/IPaymentCoordinator.sol";
+import {IPaymentCoordinator} from
+    "eigenlayer-contracts/src/contracts/interfaces/IPaymentCoordinator.sol";
 import {PaymentCoordinator} from "eigenlayer-contracts/src/contracts/core/PaymentCoordinator.sol";
 import {PaymentCoordinatorMock} from "../mocks/PaymentCoordinatorMock.sol";
 
@@ -83,7 +83,8 @@ contract MockAVSDeployer is Test {
     uint256 public constant WEIGHTING_DIVISOR = 1e18;
 
     address public proxyAdminOwner = address(uint160(uint256(keccak256("proxyAdminOwner"))));
-    address public registryCoordinatorOwner = address(uint160(uint256(keccak256("registryCoordinatorOwner"))));
+    address public registryCoordinatorOwner =
+        address(uint160(uint256(keccak256("registryCoordinatorOwner"))));
     address public pauser = address(uint160(uint256(keccak256("pauser"))));
     address public unpauser = address(uint160(uint256(keccak256("unpauser"))));
 
@@ -95,13 +96,16 @@ contract MockAVSDeployer is Test {
 
     address defaultOperator = address(uint160(uint256(keccak256("defaultOperator"))));
     bytes32 defaultOperatorId;
-    BN254.G1Point internal defaultPubKey =  BN254.G1Point(18260007818883133054078754218619977578772505796600400998181738095793040006897,3432351341799135763167709827653955074218841517684851694584291831827675065899);
+    BN254.G1Point internal defaultPubKey = BN254.G1Point(
+        18_260_007_818_883_133_054_078_754_218_619_977_578_772_505_796_600_400_998_181_738_095_793_040_006_897,
+        3_432_351_341_799_135_763_167_709_827_653_955_074_218_841_517_684_851_694_584_291_831_827_675_065_899
+    );
     string defaultSocket = "69.69.69.69:420";
     uint96 defaultStake = 1 ether;
     uint8 defaultQuorumNumber = 0;
 
     uint32 defaultMaxOperatorCount = 10;
-    uint16 defaultKickBIPsOfOperatorStake = 15000;
+    uint16 defaultKickBIPsOfOperatorStake = 15_000;
     uint16 defaultKickBIPsOfTotalStake = 150;
     uint8 numQuorums = 192;
 
@@ -140,7 +144,6 @@ contract MockAVSDeployer is Test {
         pausers[0] = pauser;
         pauserRegistry = new PauserRegistry(pausers, unpauser);
 
-
         delegationMock = new DelegationMock();
         avsDirectoryMock = new AVSDirectoryMock();
         eigenPodManagerMock = new EigenPodManagerMock();
@@ -151,7 +154,12 @@ contract MockAVSDeployer is Test {
                 new TransparentUpgradeableProxy(
                     address(slasherImplementation),
                     address(proxyAdmin),
-                    abi.encodeWithSelector(Slasher.initialize.selector, msg.sender, pauserRegistry, 0/*initialPausedStatus*/)
+                    abi.encodeWithSelector(
+                        Slasher.initialize.selector,
+                        msg.sender,
+                        pauserRegistry,
+                        0 /*initialPausedStatus*/
+                    )
                 )
             )
         );
@@ -162,65 +170,48 @@ contract MockAVSDeployer is Test {
                 new TransparentUpgradeableProxy(
                     address(avsDirectoryImplementation),
                     address(proxyAdmin),
-                    abi.encodeWithSelector(AVSDirectory.initialize.selector, msg.sender, pauserRegistry, 0/*initialPausedStatus*/)
+                    abi.encodeWithSelector(
+                        AVSDirectory.initialize.selector,
+                        msg.sender,
+                        pauserRegistry,
+                        0 /*initialPausedStatus*/
+                    )
                 )
             )
         );
         paymentCoordinatorMock = new PaymentCoordinatorMock();
 
-        strategyManagerMock.setAddresses(
-            delegationMock,
-            eigenPodManagerMock,
-            slasher
-        );
+        strategyManagerMock.setAddresses(delegationMock, eigenPodManagerMock, slasher);
         cheats.stopPrank();
 
         cheats.startPrank(registryCoordinatorOwner);
-        registryCoordinator = RegistryCoordinatorHarness(address(
-            new TransparentUpgradeableProxy(
-                address(emptyContract),
-                address(proxyAdmin),
-                ""
+        registryCoordinator = RegistryCoordinatorHarness(
+            address(
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
             )
-        ));
+        );
 
         stakeRegistry = StakeRegistryHarness(
             address(
-                new TransparentUpgradeableProxy(
-                    address(emptyContract),
-                    address(proxyAdmin),
-                    ""
-                )
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
             )
         );
 
         indexRegistry = IndexRegistry(
             address(
-                new TransparentUpgradeableProxy(
-                    address(emptyContract),
-                    address(proxyAdmin),
-                    ""
-                )
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
             )
         );
 
         blsApkRegistry = BLSApkRegistryHarness(
             address(
-                new TransparentUpgradeableProxy(
-                    address(emptyContract),
-                    address(proxyAdmin),
-                    ""
-                )
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
             )
         );
 
         serviceManager = ServiceManagerMock(
             address(
-                new TransparentUpgradeableProxy(
-                    address(emptyContract),
-                    address(proxyAdmin),
-                    ""
-                )
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
             )
         );
 
@@ -228,28 +219,22 @@ contract MockAVSDeployer is Test {
 
         cheats.startPrank(proxyAdminOwner);
 
-        stakeRegistryImplementation = new StakeRegistryHarness(
-            IRegistryCoordinator(registryCoordinator),
-            delegationMock
-        );
+        stakeRegistryImplementation =
+            new StakeRegistryHarness(IRegistryCoordinator(registryCoordinator), delegationMock);
 
         proxyAdmin.upgrade(
             TransparentUpgradeableProxy(payable(address(stakeRegistry))),
             address(stakeRegistryImplementation)
         );
 
-        blsApkRegistryImplementation = new BLSApkRegistryHarness(
-            registryCoordinator
-        );
+        blsApkRegistryImplementation = new BLSApkRegistryHarness(registryCoordinator);
 
         proxyAdmin.upgrade(
             TransparentUpgradeableProxy(payable(address(blsApkRegistry))),
             address(blsApkRegistryImplementation)
         );
 
-        indexRegistryImplementation = new IndexRegistry(
-            registryCoordinator
-        );
+        indexRegistryImplementation = new IndexRegistry(registryCoordinator);
 
         proxyAdmin.upgrade(
             TransparentUpgradeableProxy(payable(address(indexRegistry))),
@@ -268,7 +253,10 @@ contract MockAVSDeployer is Test {
             address(serviceManagerImplementation)
         );
 
-        serviceManager.initialize({initialOwner: registryCoordinatorOwner});
+        serviceManager.initialize({
+            initialOwner: registryCoordinatorOwner,
+            paymentInitiator: address(proxyAdminOwner)
+        });
 
         // set the public key for an operator, using harnessed function to bypass checks
         blsApkRegistry.setBLSPublicKey(defaultOperator, defaultPubKey);
@@ -276,7 +264,7 @@ contract MockAVSDeployer is Test {
         // setup the dummy minimum stake for quorum
         uint96[] memory minimumStakeForQuorum = new uint96[](numQuorumsToAdd);
         for (uint256 i = 0; i < minimumStakeForQuorum.length; i++) {
-            minimumStakeForQuorum[i] = uint96(i+1);
+            minimumStakeForQuorum[i] = uint96(i + 1);
         }
 
         // setup the dummy quorum strategies
@@ -285,26 +273,24 @@ contract MockAVSDeployer is Test {
         for (uint256 i = 0; i < quorumStrategiesConsideredAndMultipliers.length; i++) {
             quorumStrategiesConsideredAndMultipliers[i] = new IStakeRegistry.StrategyParams[](1);
             quorumStrategiesConsideredAndMultipliers[i][0] = IStakeRegistry.StrategyParams(
-                IStrategy(address(uint160(i))),
-                uint96(WEIGHTING_DIVISOR)
+                IStrategy(address(uint160(i))), uint96(WEIGHTING_DIVISOR)
             );
         }
 
         registryCoordinatorImplementation = new RegistryCoordinatorHarness(
-            serviceManager,
-            stakeRegistry,
-            blsApkRegistry,
-            indexRegistry
+            serviceManager, stakeRegistry, blsApkRegistry, indexRegistry
         );
         {
             delete operatorSetParams;
-            for (uint i = 0; i < numQuorumsToAdd; i++) {
+            for (uint256 i = 0; i < numQuorumsToAdd; i++) {
                 // hard code these for now
-                operatorSetParams.push(IRegistryCoordinator.OperatorSetParam({
-                    maxOperatorCount: defaultMaxOperatorCount,
-                    kickBIPsOfOperatorStake: defaultKickBIPsOfOperatorStake,
-                    kickBIPsOfTotalStake: defaultKickBIPsOfTotalStake
-                }));
+                operatorSetParams.push(
+                    IRegistryCoordinator.OperatorSetParam({
+                        maxOperatorCount: defaultMaxOperatorCount,
+                        kickBIPsOfOperatorStake: defaultKickBIPsOfOperatorStake,
+                        kickBIPsOfTotalStake: defaultKickBIPsOfTotalStake
+                    })
+                );
             }
 
             proxyAdmin.upgradeAndCall(
@@ -316,7 +302,7 @@ contract MockAVSDeployer is Test {
                     churnApprover,
                     ejector,
                     pauserRegistry,
-                    0/*initialPausedStatus*/,
+                    0, /*initialPausedStatus*/
                     operatorSetParams,
                     minimumStakeForQuorum,
                     quorumStrategiesConsideredAndMultipliers
@@ -332,75 +318,101 @@ contract MockAVSDeployer is Test {
     /**
      * @notice registers operator with coordinator
      */
-    function _registerOperatorWithCoordinator(address operator, uint256 quorumBitmap, BN254.G1Point memory pubKey) internal {
+    function _registerOperatorWithCoordinator(
+        address operator,
+        uint256 quorumBitmap,
+        BN254.G1Point memory pubKey
+    ) internal {
         _registerOperatorWithCoordinator(operator, quorumBitmap, pubKey, defaultStake);
     }
 
     /**
      * @notice registers operator with coordinator
      */
-    function _registerOperatorWithCoordinator(address operator, uint256 quorumBitmap, BN254.G1Point memory pubKey, uint96 stake) internal {
+    function _registerOperatorWithCoordinator(
+        address operator,
+        uint256 quorumBitmap,
+        BN254.G1Point memory pubKey,
+        uint96 stake
+    ) internal {
         // quorumBitmap can only have 192 least significant bits
         quorumBitmap &= MAX_QUORUM_BITMAP;
 
         blsApkRegistry.setBLSPublicKey(operator, pubKey);
 
         bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(quorumBitmap);
-        for (uint i = 0; i < quorumNumbers.length; i++) {
+        for (uint256 i = 0; i < quorumNumbers.length; i++) {
             _setOperatorWeight(operator, uint8(quorumNumbers[i]), stake);
         }
 
         ISignatureUtils.SignatureWithSaltAndExpiry memory emptySignatureAndExpiry;
         cheats.prank(operator);
-        registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySignatureAndExpiry);
+        registryCoordinator.registerOperator(
+            quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySignatureAndExpiry
+        );
     }
 
     /**
      * @notice registers operator with coordinator
      */
-    function _registerOperatorWithCoordinator(address operator, uint256 quorumBitmap, BN254.G1Point memory pubKey, uint96[] memory stakes) internal {
+    function _registerOperatorWithCoordinator(
+        address operator,
+        uint256 quorumBitmap,
+        BN254.G1Point memory pubKey,
+        uint96[] memory stakes
+    ) internal {
         // quorumBitmap can only have 192 least significant bits
         quorumBitmap &= MAX_QUORUM_BITMAP;
 
         blsApkRegistry.setBLSPublicKey(operator, pubKey);
 
         bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(quorumBitmap);
-        for (uint i = 0; i < quorumNumbers.length; i++) {
+        for (uint256 i = 0; i < quorumNumbers.length; i++) {
             _setOperatorWeight(operator, uint8(quorumNumbers[i]), stakes[uint8(quorumNumbers[i])]);
         }
 
         ISignatureUtils.SignatureWithSaltAndExpiry memory emptySignatureAndExpiry;
         cheats.prank(operator);
-        registryCoordinator.registerOperator(quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySignatureAndExpiry);
+        registryCoordinator.registerOperator(
+            quorumNumbers, defaultSocket, pubkeyRegistrationParams, emptySignatureAndExpiry
+        );
     }
 
-    function _registerRandomOperators(uint256 pseudoRandomNumber) internal returns(OperatorMetadata[] memory, uint256[][] memory) {
+    function _registerRandomOperators(uint256 pseudoRandomNumber)
+        internal
+        returns (OperatorMetadata[] memory, uint256[][] memory)
+    {
         OperatorMetadata[] memory operatorMetadatas = new OperatorMetadata[](maxOperatorsToRegister);
-        for (uint i = 0; i < operatorMetadatas.length; i++) {
+        for (uint256 i = 0; i < operatorMetadatas.length; i++) {
             // limit to 16 quorums so we don't run out of gas, make them all register for quorum 0 as well
-            operatorMetadatas[i].quorumBitmap = uint256(keccak256(abi.encodePacked("quorumBitmap", pseudoRandomNumber, i))) & (1 << maxQuorumsToRegisterFor - 1) | 1;
+            operatorMetadatas[i].quorumBitmap = uint256(
+                keccak256(abi.encodePacked("quorumBitmap", pseudoRandomNumber, i))
+            ) & (1 << maxQuorumsToRegisterFor - 1) | 1;
             operatorMetadatas[i].operator = _incrementAddress(defaultOperator, i);
-            operatorMetadatas[i].pubkey = BN254.hashToG1(keccak256(abi.encodePacked("pubkey", pseudoRandomNumber, i)));
+            operatorMetadatas[i].pubkey =
+                BN254.hashToG1(keccak256(abi.encodePacked("pubkey", pseudoRandomNumber, i)));
             operatorMetadatas[i].operatorId = operatorMetadatas[i].pubkey.hashG1Point();
             operatorMetadatas[i].stakes = new uint96[](maxQuorumsToRegisterFor);
-            for (uint j = 0; j < maxQuorumsToRegisterFor; j++) {
-                operatorMetadatas[i].stakes[j] = uint96(uint64(uint256(keccak256(abi.encodePacked("stakes", pseudoRandomNumber, i, j)))));
+            for (uint256 j = 0; j < maxQuorumsToRegisterFor; j++) {
+                operatorMetadatas[i].stakes[j] = uint96(
+                    uint64(uint256(keccak256(abi.encodePacked("stakes", pseudoRandomNumber, i, j))))
+                );
             }
         }
 
         // get the index in quorumBitmaps of each operator in each quorum in the order they will register
         uint256[][] memory expectedOperatorOverallIndices = new uint256[][](numQuorums);
-        for (uint i = 0; i < numQuorums; i++) {
+        for (uint256 i = 0; i < numQuorums; i++) {
             uint32 numOperatorsInQuorum;
             // for each quorumBitmap, check if the i'th bit is set
-            for (uint j = 0; j < operatorMetadatas.length; j++) {
+            for (uint256 j = 0; j < operatorMetadatas.length; j++) {
                 if (operatorMetadatas[j].quorumBitmap >> i & 1 == 1) {
                     numOperatorsInQuorum++;
                 }
             }
             expectedOperatorOverallIndices[i] = new uint256[](numOperatorsInQuorum);
             uint256 numOperatorCounter;
-            for (uint j = 0; j < operatorMetadatas.length; j++) {
+            for (uint256 j = 0; j < operatorMetadatas.length; j++) {
                 if (operatorMetadatas[j].quorumBitmap >> i & 1 == 1) {
                     expectedOperatorOverallIndices[i][numOperatorCounter] = j;
                     numOperatorCounter++;
@@ -409,10 +421,15 @@ contract MockAVSDeployer is Test {
         }
 
         // register operators
-        for (uint i = 0; i < operatorMetadatas.length; i++) {
+        for (uint256 i = 0; i < operatorMetadatas.length; i++) {
             cheats.roll(registrationBlockNumber + blocksBetweenRegistrations * i);
 
-            _registerOperatorWithCoordinator(operatorMetadatas[i].operator, operatorMetadatas[i].quorumBitmap, operatorMetadatas[i].pubkey, operatorMetadatas[i].stakes);
+            _registerOperatorWithCoordinator(
+                operatorMetadatas[i].operator,
+                operatorMetadatas[i].quorumBitmap,
+                operatorMetadatas[i].pubkey,
+                operatorMetadatas[i].stakes
+            );
         }
 
         return (operatorMetadatas, expectedOperatorOverallIndices);
@@ -424,7 +441,11 @@ contract MockAVSDeployer is Test {
      * Returns actual weight calculated set for operator shares in DelegationMock since multiplier and WEIGHTING_DIVISOR calculations
      * can give small rounding errors.
      */
-    function _setOperatorWeight(address operator, uint8 quorumNumber, uint96 weight) internal returns (uint96) {
+    function _setOperatorWeight(
+        address operator,
+        uint8 quorumNumber,
+        uint96 weight
+    ) internal returns (uint96) {
         // Set StakeRegistry operator weight by setting DelegationManager operator shares
         (IStrategy strategy, uint96 multiplier) = stakeRegistry.strategyParams(quorumNumber, 0);
         uint256 actualWeight = ((uint256(weight) * WEIGHTING_DIVISOR) / uint256(multiplier));
@@ -432,21 +453,23 @@ contract MockAVSDeployer is Test {
         return uint96(actualWeight);
     }
 
-    function _incrementAddress(address start, uint256 inc) internal pure returns(address) {
+    function _incrementAddress(address start, uint256 inc) internal pure returns (address) {
         return address(uint160(uint256(uint160(start) + inc)));
     }
 
-    function _incrementBytes32(bytes32 start, uint256 inc) internal pure returns(bytes32) {
+    function _incrementBytes32(bytes32 start, uint256 inc) internal pure returns (bytes32) {
         return bytes32(uint256(start) + inc);
     }
 
-    function _signOperatorChurnApproval(address registeringOperator, bytes32 registeringOperatorId, IRegistryCoordinator.OperatorKickParam[] memory operatorKickParams, bytes32 salt,  uint256 expiry) internal view returns(ISignatureUtils.SignatureWithSaltAndExpiry memory) {
+    function _signOperatorChurnApproval(
+        address registeringOperator,
+        bytes32 registeringOperatorId,
+        IRegistryCoordinator.OperatorKickParam[] memory operatorKickParams,
+        bytes32 salt,
+        uint256 expiry
+    ) internal view returns (ISignatureUtils.SignatureWithSaltAndExpiry memory) {
         bytes32 digestHash = registryCoordinator.calculateOperatorChurnApprovalDigestHash(
-            registeringOperator,
-            registeringOperatorId,
-            operatorKickParams,
-            salt,
-            expiry
+            registeringOperator, registeringOperatorId, operatorKickParams, salt, expiry
         );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(churnApproverPrivateKey, digestHash);
         return ISignatureUtils.SignatureWithSaltAndExpiry({


### PR DESCRIPTION
Currently, the entity responsible for posting the range payments is the `ServiceManager` Owner, but for practical purposes this responsibility will likely be delegated to a separate entity or smart contract. 

High level changes:
- creating `ServiceManagerBaseStorage.sol`
- adding `paymentInitiator` storage var to `ServiceManagerBaseStorage`
- adding ability for owner to change `paymentInitiator`
- testing changing and proper management of `paymentInitiator` role
- formatting based on forge fmt on contracts modified