### PR TITLE
feat: poc for OperatorSets

### DIFF
--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -495,18 +495,15 @@ contract RegistryCoordinator is
         emit OperatorSocketUpdate(operatorId, socket);
 
         // If the operator wasn't registered for any quorums, update their status
-        // and register them with this AVS in EigenLayer core (DelegationManager)
         if (_operatorInfo[operator].status != OperatorStatus.REGISTERED) {
             _operatorInfo[operator] = OperatorInfo({
                 operatorId: operatorId,
                 status: OperatorStatus.REGISTERED
             });
-
-            // Register the operator with the EigenLayer core contracts via this AVS's ServiceManager
-            serviceManager.registerOperatorToAVS(operator, operatorSignature);
-
-            emit OperatorRegistered(operator, operatorId);
         }
+        // Register the operator with the EigenLayer core contracts via this AVS's ServiceManager
+        serviceManager.registerOperatorToOperatorSets(operator, quorumNumbers, operatorSignature);
+        emit OperatorRegistered(operator, operatorId, quorumNumbers);
 
         // Register the operator with the BLSApkRegistry, StakeRegistry, and IndexRegistry
         blsApkRegistry.registerOperator(operator, quorumNumbers);
@@ -612,13 +609,12 @@ contract RegistryCoordinator is
             newBitmap: newBitmap
         });
 
-        // If the operator is no longer registered for any quorums, update their status and deregister 
-        // them from the AVS via the EigenLayer core contracts
+        // If the operator is no longer registered for any quorums, update their status
         if (newBitmap.isEmpty()) {
             operatorInfo.status = OperatorStatus.DEREGISTERED;
-            serviceManager.deregisterOperatorFromAVS(operator);
-            emit OperatorDeregistered(operator, operatorId);
         }
+        serviceManager.deregisterOperatorFromOperatorSets(operator, quorumNumbers);
+        emit OperatorDeregistered(operator, operatorId, quorumNumbers);
 
         // Deregister operator with each of the registry contracts
         blsApkRegistry.deregisterOperator(operator, quorumNumbers);

--- a/src/ServiceManagerBase.sol
+++ b/src/ServiceManagerBase.sol
@@ -163,13 +163,13 @@ abstract contract ServiceManagerBase is OwnableUpgradeable, ServiceManagerBaseSt
             operatorSetId < _registryCoordinator.quorumCount(),
             "ServiceManagerBase.ejectNonmigratedOperators: operatorSet does not exist"
         );
-        IOperatorSetManager.OperatorSet memory operatorSet = IOperatorSetManager.OperatorSet({
-            avs: address(this),
-            id: operatorSetId
-        });
+        IOperatorSetManager.OperatorSet memory operatorSet =
+            IOperatorSetManager.OperatorSet({avs: address(this), id: operatorSetId});
         for (uint256 i = 0; i < operators.length; ++i) {
             require(
-                !_operatorSetManager.isOperatorInOperatorSet(operators[i], operatorSet),
+                _operatorSetManager.avsOperatorStatus(address(this), operator)
+                    == IOperatorSetManager.OperatorAVSRegistrationStatus.REGISTERED
+                    && !_operatorSetManager.isOperatorInOperatorSet(operators[i], operatorSet),
                 "ServiceManagerBase.removeNonmigratedOperators: operator already registered to operator set"
             );
             bytes32 operatorId = _registryCoordinator.getOperatorId(operators[i]);

--- a/src/ServiceManagerBase.sol
+++ b/src/ServiceManagerBase.sol
@@ -108,6 +108,7 @@ abstract contract ServiceManagerBase is OwnableUpgradeable, ServiceManagerBaseSt
             }
 
             _operatorSetManager.addStrategiesToOperatorSet(uint32(i), strategies);
+            emit OperatorSetStrategiesMigrated(uint32(i), strategies);
         }
         isStrategiesMigrated = true;
     }
@@ -117,15 +118,17 @@ abstract contract ServiceManagerBase is OwnableUpgradeable, ServiceManagerBaseSt
      * for. This can be called externally by getOperatorSetIds
      */
     function migrateOperatorToOperatorSets(
+        address operator,
         ISignatureUtils.SignatureWithSaltAndExpiry memory signature
     ) external {
         require(
-            !isOperatorMigrated[msg.sender],
+            !isOperatorMigrated[operator],
             "ServiceManagerBase.migrateOperatorToOperatorSets: already migrated"
         );
-        uint32[] memory operatorSetIds = getOperatorSetIds(msg.sender);
+        uint32[] memory operatorSetIds = getOperatorSetIds(operator);
 
-        _operatorSetManager.registerOperatorToOperatorSets(msg.sender, operatorSetIds, signature);
+        _operatorSetManager.registerOperatorToOperatorSets(operator, operatorSetIds, signature);
+        emit OperatorMigratedToOperatorSets(operator, operatorSetIds);
     }
 
     /**
@@ -322,6 +325,7 @@ abstract contract ServiceManagerBase is OwnableUpgradeable, ServiceManagerBaseSt
         return operatorSetIds;
     }
 
+    /// @notice Returns the operator set IDs for the given operator address by querying the RegistryCoordinator
     function getOperatorSetIds(address operator) public view returns (uint32[] memory) {
         bytes32 operatorId = _registryCoordinator.getOperatorId(operator);
         uint192 operatorBitmap = _registryCoordinator.getCurrentQuorumBitmap(operatorId);

--- a/src/ServiceManagerBase.sol
+++ b/src/ServiceManagerBase.sol
@@ -98,6 +98,10 @@ abstract contract ServiceManagerBase is OwnableUpgradeable, ServiceManagerBaseSt
 
     /// @notice migrates all existing operators and strategies to operator sets
     function migrateStrategiesToOperatorSets() external {
+        require(
+            !isStrategiesMigrated,
+            "ServiceManagerBase.migrateStrategiesToOperatorSets: already migrated"
+        );
         uint8 quorumCount = _registryCoordinator.quorumCount();
         for (uint8 i = 0; i < quorumCount; ++i) {
             uint256 numStrategies = _stakeRegistry.strategyParamsLength(i);

--- a/src/ServiceManagerBaseStorage.sol
+++ b/src/ServiceManagerBaseStorage.sol
@@ -5,7 +5,7 @@ import {IServiceManager} from "./interfaces/IServiceManager.sol";
 import {IRegistryCoordinator} from "./interfaces/IRegistryCoordinator.sol";
 import {IStakeRegistry} from "./interfaces/IStakeRegistry.sol";
 
-import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
+import {IOperatorSetManager} from "./interfaces/IOperatorSetManager.sol"; // should be later changed to be import from core
 import {IRewardsCoordinator} from "eigenlayer-contracts/src/contracts/interfaces/IRewardsCoordinator.sol";
 
 /**
@@ -19,7 +19,7 @@ abstract contract ServiceManagerBaseStorage is IServiceManager {
      *                            CONSTANTS AND IMMUTABLES
      *
      */
-    IAVSDirectory internal immutable _avsDirectory;
+    IOperatorSetManager internal immutable _operatorSetManager;
     IRewardsCoordinator internal immutable _rewardsCoordinator;
     IRegistryCoordinator internal immutable _registryCoordinator;
     IStakeRegistry internal immutable _stakeRegistry;
@@ -33,14 +33,16 @@ abstract contract ServiceManagerBaseStorage is IServiceManager {
     /// @notice The address of the entity that can initiate rewards
     address public rewardsInitiator;
 
+    bool internal isStrategiesMigrated;
+
     /// @notice Sets the (immutable) `_avsDirectory`, `_rewardsCoordinator`, `_registryCoordinator`, and `_stakeRegistry` addresses
     constructor(
-        IAVSDirectory __avsDirectory,
+        IOperatorSetManager __operatorSetManager,
         IRewardsCoordinator __rewardsCoordinator,
         IRegistryCoordinator __registryCoordinator,
         IStakeRegistry __stakeRegistry
     ) {
-        _avsDirectory = __avsDirectory;
+        _operatorSetManager = __operatorSetManager;
         _rewardsCoordinator = __rewardsCoordinator;
         _registryCoordinator = __registryCoordinator;
         _stakeRegistry = __stakeRegistry;

--- a/src/ServiceManagerBaseStorage.sol
+++ b/src/ServiceManagerBaseStorage.sol
@@ -35,6 +35,8 @@ abstract contract ServiceManagerBaseStorage is IServiceManager {
 
     bool internal isStrategiesMigrated;
 
+    mapping(address => bool) isOperatorMigrated;
+
     /// @notice Sets the (immutable) `_avsDirectory`, `_rewardsCoordinator`, `_registryCoordinator`, and `_stakeRegistry` addresses
     constructor(
         IOperatorSetManager __operatorSetManager,
@@ -49,5 +51,5 @@ abstract contract ServiceManagerBaseStorage is IServiceManager {
     }
 
     // storage gap for upgradeability
-    uint256[49] private __GAP;
+    uint256[47] private __GAP;
 }

--- a/src/ServiceManagerBaseStorage.sol
+++ b/src/ServiceManagerBaseStorage.sol
@@ -33,10 +33,6 @@ abstract contract ServiceManagerBaseStorage is IServiceManager {
     /// @notice The address of the entity that can initiate rewards
     address public rewardsInitiator;
 
-    bool internal isStrategiesMigrated;
-
-    mapping(address => bool) isOperatorMigrated;
-
     /// @notice Sets the (immutable) `_avsDirectory`, `_rewardsCoordinator`, `_registryCoordinator`, and `_stakeRegistry` addresses
     constructor(
         IOperatorSetManager __operatorSetManager,
@@ -51,5 +47,5 @@ abstract contract ServiceManagerBaseStorage is IServiceManager {
     }
 
     // storage gap for upgradeability
-    uint256[47] private __GAP;
+    uint256[49] private __GAP;
 }

--- a/src/StakeRegistry.sol
+++ b/src/StakeRegistry.sol
@@ -42,10 +42,9 @@ contract StakeRegistry is StakeRegistryStorage {
     }
 
     constructor(
-        IServiceManager _serviceManager,
         IRegistryCoordinator _registryCoordinator,
         IDelegationManager _delegationManager
-    ) StakeRegistryStorage(_serviceManager, _registryCoordinator, _delegationManager) {}
+    ) StakeRegistryStorage(_registryCoordinator, _delegationManager) {}
 
     /*******************************************************************************
                       EXTERNAL FUNCTIONS - REGISTRY COORDINATOR

--- a/src/StakeRegistryStorage.sol
+++ b/src/StakeRegistryStorage.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.12;
 import {IDelegationManager} from "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
 import {IStrategyManager, IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategyManager.sol";
 
+import {IServiceManager} from "./interfaces/IServiceManager.sol";
 import {IRegistryCoordinator} from "./interfaces/IRegistryCoordinator.sol";
 import {IStakeRegistry} from  "./interfaces/IStakeRegistry.sol";
 
@@ -23,6 +24,9 @@ abstract contract StakeRegistryStorage is IStakeRegistry {
 
     /// @notice The address of the Delegation contract for EigenLayer.
     IDelegationManager public immutable delegation;
+
+    /// @notice the serviceManager contract that this registry is associated with
+    IServiceManager public immutable serviceManager;
 
     /// @notice the coordinator contract that this registry is associated with
     address public immutable registryCoordinator;
@@ -46,9 +50,15 @@ abstract contract StakeRegistryStorage is IStakeRegistry {
 
 
     constructor(
+        IServiceManager _serviceManager,
         IRegistryCoordinator _registryCoordinator, 
         IDelegationManager _delegationManager
     ) {
+        require(
+            _registryCoordinator.serviceManager() == _serviceManager,
+            "StakeRegistryStorage: serviceManager does not match with registryCoordinator"
+        );
+        serviceManager = _serviceManager;
         registryCoordinator = address(_registryCoordinator);
         delegation = _delegationManager;
     }

--- a/src/StakeRegistryStorage.sol
+++ b/src/StakeRegistryStorage.sol
@@ -50,15 +50,10 @@ abstract contract StakeRegistryStorage is IStakeRegistry {
 
 
     constructor(
-        IServiceManager _serviceManager,
         IRegistryCoordinator _registryCoordinator, 
         IDelegationManager _delegationManager
     ) {
-        require(
-            _registryCoordinator.serviceManager() == _serviceManager,
-            "StakeRegistryStorage: serviceManager does not match with registryCoordinator"
-        );
-        serviceManager = _serviceManager;
+        serviceManager = _registryCoordinator.serviceManager();
         registryCoordinator = address(_registryCoordinator);
         delegation = _delegationManager;
     }

--- a/src/interfaces/IOperatorSetManager.sol
+++ b/src/interfaces/IOperatorSetManager.sol
@@ -4,13 +4,12 @@ pragma solidity >=0.5.0;
 import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
 import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategyManager.sol";
 
-
 interface IOperatorSetManager is ISignatureUtils {
-
-
-    /*******************************************************************************
-                            OperatorSetManager Interface
-    *******************************************************************************/
+    /**
+     *
+     *                         OperatorSetManager Interface
+     *
+     */
 
     /// STRUCTS
 
@@ -18,7 +17,7 @@ interface IOperatorSetManager is ISignatureUtils {
         address avs;
         uint32 id;
     }
-    
+
     /**
      * @notice this struct is used by allocators in order to specify whether they want to register for particular operator sets
      * @param operatorSet the operator set to change registration parameters for
@@ -28,7 +27,7 @@ interface IOperatorSetManager is ISignatureUtils {
         OperatorSet operatorSet;
         bool allowedToRegister;
     }
-    
+
     /**
      * @notice this struct is used in SlashingMagnitudeParam in order to specify an operator's slashability for a certain operator set
      * @param operatorSet the operator set to change slashing parameters for
@@ -36,7 +35,7 @@ interface IOperatorSetManager is ISignatureUtils {
      */
     struct OperatorSetSlashingParam {
         OperatorSet operatorSet;
-        uint64 slashableMagnitude; 
+        uint64 slashableMagnitude;
     }
 
     /**
@@ -48,17 +47,21 @@ interface IOperatorSetManager is ISignatureUtils {
     struct SlashingMagnitudeParam {
         IStrategy strategy;
         uint64 totalMagnitude;
-        OperatorSetSlashingParam[] operatorSetSlashingParams; 
+        OperatorSetSlashingParam[] operatorSetSlashingParams;
     }
 
     /// EVENTS
-    
+
     event RegistrationParamsUpdated(
         address operator, OperatorSet operatorSet, bool allowedToRegister
     );
 
     event SlashableMagnitudeUpdated(
-        address operator, IStrategy strategy, OperatorSet operatorSet, uint64 slashableMagnitude, uint32 effectEpoch
+        address operator,
+        IStrategy strategy,
+        OperatorSet operatorSet,
+        uint64 slashableMagnitude,
+        uint32 effectEpoch
     );
 
     event TotalMagnitudeUpdated(
@@ -66,79 +69,79 @@ interface IOperatorSetManager is ISignatureUtils {
     );
 
     /// EXTERNAL - STATE MODIFYING
-    
-    /**
-	 * @notice Called by AVSs to add an operator to an operator set
-	 * 
-	 * @param operator the address of the operator to be added to the operator set
-	 * @param operatorSetIDs the IDs of the operator sets
-	 * @param signature the signature of the operator on their intent to register
-	 * @dev msg.sender is used as the AVS
-	 * @dev operator must not have a pending a deregistration from the operator sets
-	 * @dev if this is the first operator set in the AVS that the operator is 
-	 * registering for, a OperatorAVSRegistrationStatusUpdated event is emitted with 
-	 * a REGISTERED status
-	 */
-	function registerOperatorToOperatorSets(
-		address operator,
-		uint32[] calldata operatorSetIDs,
-		ISignatureUtils.SignatureWithSaltAndExpiry memory signature
-	) external;
 
     /**
-	 * @notice Called by AVSs or operators to remove an operator to from operator set
-	 * 
-	 * @param operator the address of the operator to be removed from the 
-	 * operator set
-	 * @param operatorSetIDs the ID of the operator set
-	 * 
-	 * @dev msg.sender is used as the AVS
-	 * @dev operator must be registered for msg.sender AVS and the given 
-	 * operator set
-         * @dev if this removes operator from all operator sets for the msg.sender AVS
-         * then an OperatorAVSRegistrationStatusUpdated event is emitted with a DEREGISTERED
-         * status
-	 */
-	function deregisterOperatorFromOperatorSets(
-		address operator, 
-		uint32[] calldata operatorSetIDs
-	) external;
+     * @notice Called by AVSs to add an operator to an operator set
+     *
+     * @param operator the address of the operator to be added to the operator set
+     * @param operatorSetIDs the IDs of the operator sets
+     * @param signature the signature of the operator on their intent to register
+     * @dev msg.sender is used as the AVS
+     * @dev operator must not have a pending a deregistration from the operator sets
+     * @dev if this is the first operator set in the AVS that the operator is
+     * registering for, a OperatorAVSRegistrationStatusUpdated event is emitted with
+     * a REGISTERED status
+     */
+    function registerOperatorToOperatorSets(
+        address operator,
+        uint32[] calldata operatorSetIDs,
+        ISignatureUtils.SignatureWithSaltAndExpiry memory signature
+    ) external;
 
-    /**	
- 	 * @notice Called by AVSs to add a strategy to its operator set
-	 * 
-	 * @param operatorSetID the ID of the operator set
-	 * @param strategies the list strategies of the operator set to add
-	 *
-	 * @dev msg.sender is used as the AVS
-	 * @dev no storage is updated as the event is used by off-chain services
-	 */
-	function addStrategiesToOperatorSet(
-		uint32 operatorSetID,
-		IStrategy[] calldata strategies
-	) external;
+    /**
+     * @notice Called by AVSs or operators to remove an operator to from operator set
+     *
+     * @param operator the address of the operator to be removed from the
+     * operator set
+     * @param operatorSetIDs the ID of the operator set
+     *
+     * @dev msg.sender is used as the AVS
+     * @dev operator must be registered for msg.sender AVS and the given
+     * operator set
+     * @dev if this removes operator from all operator sets for the msg.sender AVS
+     * then an OperatorAVSRegistrationStatusUpdated event is emitted with a DEREGISTERED
+     * status
+     */
+    function deregisterOperatorFromOperatorSets(
+        address operator,
+        uint32[] calldata operatorSetIDs
+    ) external;
 
-    /**	
- 	 * @notice Called by AVSs to remove a strategy to its operator set
-	 * 
-	 * @param operatorSetID the ID of the operator set
-	 * @param strategies the list strategie of the operator set to remove
-	 *
-	 * @dev msg.sender is used as the AVS
-	 * @dev no storage is updated as the event is used by off-chain services
-	 */
-	function removeStrategiesFromOperatorSet(
-		uint32 operatorSetID,
-		IStrategy[] calldata strategies
-	) external;
+    /**
+     * @notice Called by AVSs to add a strategy to its operator set
+     *
+     * @param operatorSetID the ID of the operator set
+     * @param strategies the list strategies of the operator set to add
+     *
+     * @dev msg.sender is used as the AVS
+     * @dev no storage is updated as the event is used by off-chain services
+     */
+    function addStrategiesToOperatorSet(
+        uint32 operatorSetID,
+        IStrategy[] calldata strategies
+    ) external;
+
+    /**
+     * @notice Called by AVSs to remove a strategy to its operator set
+     *
+     * @param operatorSetID the ID of the operator set
+     * @param strategies the list strategie of the operator set to remove
+     *
+     * @dev msg.sender is used as the AVS
+     * @dev no storage is updated as the event is used by off-chain services
+     */
+    function removeStrategiesFromOperatorSet(
+        uint32 operatorSetID,
+        IStrategy[] calldata strategies
+    ) external;
 
     /// VIEW
-    
+
     /**
      * @param operator the operator to get allowedToRegister for
      * @param operatorSet the operator set to get allowedToRegister for
      *
-     * @return allowedToRegister whether or not operatorSet.avs is allowed to 
+     * @return allowedToRegister whether or not operatorSet.avs is allowed to
      * add them to the given operator set if they are not registered for it
      */
     function getAllowedToRegister(
@@ -162,17 +165,17 @@ interface IOperatorSetManager is ISignatureUtils {
         uint32 epoch
     ) external returns (uint16 slashableBips);
 
-    
-    /*******************************************************************************
-                            AVSDirectory Interface
-    *******************************************************************************/
-
-
+    /**
+     *
+     *                         AVSDirectory Interface
+     *
+     */
 
     /// @notice Enum representing the status of an operator's registration with an AVS
     enum OperatorAVSRegistrationStatus {
-        UNREGISTERED,       // Operator not registered to AVS
-        REGISTERED          // Operator registered to AVS
+        UNREGISTERED, // Operator not registered to AVS
+        REGISTERED // Operator registered to AVS
+
     }
 
     /**
@@ -182,7 +185,9 @@ interface IOperatorSetManager is ISignatureUtils {
     event AVSMetadataURIUpdated(address indexed avs, string metadataURI);
 
     /// @notice Emitted when an operator's registration status for an AVS is updated
-    event OperatorAVSRegistrationStatusUpdated(address indexed operator, address indexed avs, OperatorAVSRegistrationStatus status);
+    event OperatorAVSRegistrationStatusUpdated(
+        address indexed operator, address indexed avs, OperatorAVSRegistrationStatus status
+    );
 
     /**
      * @notice Called by an avs to register an operator with the avs.

--- a/src/interfaces/IOperatorSetManager.sol
+++ b/src/interfaces/IOperatorSetManager.sol
@@ -68,51 +68,41 @@ interface IOperatorSetManager is ISignatureUtils {
     /// EXTERNAL - STATE MODIFYING
     
     /**
-     * @notice updates the registration parameters for an operator for a set of 
-     * operator sets. whether or not the AVS is allowed to add them to the given 
-     * operator set if they are not registered for it
-     *
-     * @param operator the operator whom the registration parameters are being 
-     * changed
-     * @param registrationParams the new registration parameters
-     * @param allocatorSignature if non-empty is the signature of the allocator on 
-     * the modification. if empty, the msg.sender must be the allocator for the 
-     * operator
-     *
-     * @dev changes take effect immediately
-     */
-    function updateRegistrationParams(
-        address operator,
-        RegistrationParam[] calldata registrationParams,
-        SignatureWithExpiry calldata allocatorSignature
-    ) external;
-    
+	 * @notice Called by AVSs to add an operator to an operator set
+	 * 
+	 * @param operator the address of the operator to be added to the operator set
+	 * @param operatorSetIDs the IDs of the operator sets
+	 * @param signature the signature of the operator on their intent to register
+	 * @dev msg.sender is used as the AVS
+	 * @dev operator must not have a pending a deregistration from the operator sets
+	 * @dev if this is the first operator set in the AVS that the operator is 
+	 * registering for, a OperatorAVSRegistrationStatusUpdated event is emitted with 
+	 * a REGISTERED status
+	 */
+	function registerOperatorToOperatorSets(
+		address operator,
+		uint32[] calldata operatorSetIDs,
+		ISignatureUtils.SignatureWithSaltAndExpiry memory signature
+	) external;
+
     /**
-     * @notice updates the slashing magnitudes for an operator for a set of 
-     * operator sets
-     * 
-     * @param operator the operator whom the slashing parameters are being 
-     * changed
-     * @param slashingMagnitudeParams the new slashing parameters
-     * @param allocatorSignature if non-empty is the signature of the allocator on 
-     * the modification. if empty, the msg.sender must be the allocator for the 
-     * operator
-     *
-     * @dev changes take effect in 3 epochs for when this function is called
-     */
-    function updateSlashingMagnitudes(
-        address operator,
-        SlashingMagnitudeParam[] calldata slashingMagnitudeParams,
-        SignatureWithExpiry calldata allocatorSignature
-    ) external returns(uint32 effectEpoch);
-    
-    /// @notice a batch call of updateRegistrationParams and updateSlashingMagnitudes
-    function updateRegistrationParamsAndSlashingMagnitudes(
-        address operator,
-        RegistrationParam[] calldata registrationParams,
-        SlashingMagnitudeParam[] calldata slashingMagnitudeParams,
-        SignatureWithExpiry calldata allocatorSignature
-    ) external returns(uint32 effectEpoch);
+	 * @notice Called by AVSs or operators to remove an operator to from operator set
+	 * 
+	 * @param operator the address of the operator to be removed from the 
+	 * operator set
+	 * @param operatorSetIDs the ID of the operator set
+	 * 
+	 * @dev msg.sender is used as the AVS
+	 * @dev operator must be registered for msg.sender AVS and the given 
+	 * operator set
+         * @dev if this removes operator from all operator sets for the msg.sender AVS
+         * then an OperatorAVSRegistrationStatusUpdated event is emitted with a DEREGISTERED
+         * status
+	 */
+	function deregisterOperatorFromOperatorSets(
+		address operator, 
+		uint32[] calldata operatorSetIDs
+	) external;
 
     /**	
  	 * @notice Called by AVSs to add a strategy to its operator set

--- a/src/interfaces/IOperatorSetManager.sol
+++ b/src/interfaces/IOperatorSetManager.sol
@@ -150,6 +150,20 @@ interface IOperatorSetManager is ISignatureUtils {
 	) external view returns(bool);
 
     /**
+     * @notice retrieve the operator status for a given AVS, returns enum for either 
+     * DEREGISTERED or REGISTERED
+     * @param avs the AVS to get the operator status for
+     * @param operator the operator to get the status for
+     */
+    function avsOperatorStatus(address avs, address operator) external view returns (OperatorAVSRegistrationStatus);
+
+    /// @notice number of operatorSets the operator is registered for a given AVS
+    function operatorAVSOperatorSetCount(address avs, address operator) external view returns (uint256);
+
+    /// @notice mapping bool returning whether a strategy is part of an OperatorSet
+    function operatorSetStrategies(address avs, uint32 operatorSetId, IStrategy strategy) external view returns (bool);
+
+    /**
      * @param operator the operator to get allowedToRegister for
      * @param operatorSet the operator set to get allowedToRegister for
      *

--- a/src/interfaces/IOperatorSetManager.sol
+++ b/src/interfaces/IOperatorSetManager.sol
@@ -137,6 +137,18 @@ interface IOperatorSetManager is ISignatureUtils {
 
     /// VIEW
 
+
+	/**
+	 * @param operator the operator to get the status of
+	 * @param operatorSet the operator set to check whether the operator was in
+	 * 
+	 * @return whether the operator was in a given operator set
+	 */
+	function isOperatorInOperatorSet(
+		address operator, 
+		OperatorSet calldata operatorSet
+	) external view returns(bool);
+
     /**
      * @param operator the operator to get allowedToRegister for
      * @param operatorSet the operator set to get allowedToRegister for

--- a/src/interfaces/IOperatorSetManager.sol
+++ b/src/interfaces/IOperatorSetManager.sol
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.5.0;
+
+import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
+import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategyManager.sol";
+
+
+interface IOperatorSetManager is ISignatureUtils {
+
+
+    /*******************************************************************************
+                            OperatorSetManager Interface
+    *******************************************************************************/
+
+    /// STRUCTS
+
+    struct OperatorSet {
+        address avs;
+        uint32 id;
+    }
+    
+    /**
+     * @notice this struct is used by allocators in order to specify whether they want to register for particular operator sets
+     * @param operatorSet the operator set to change registration parameters for
+     * @param allowedToRegister whether or not the AVS is allowed to add them to the given operator set if they are not registered for it
+     */
+    struct RegistrationParam {
+        OperatorSet operatorSet;
+        bool allowedToRegister;
+    }
+    
+    /**
+     * @notice this struct is used in SlashingMagnitudeParam in order to specify an operator's slashability for a certain operator set
+     * @param operatorSet the operator set to change slashing parameters for
+     * @param slashableMagnitude the proportional parts of the totalMagnitude that the operator set is getting. This ultimately determines how much slashable stake is delegated to a given AVS. (slashableMagnitude / totalMagnitude) of an operator's delegated stake.
+     */
+    struct OperatorSetSlashingParam {
+        OperatorSet operatorSet;
+        uint64 slashableMagnitude; 
+    }
+
+    /**
+     * @notice A structure defining a set of operator-based slashing configurations to manage slashable stake
+     * @param strategy each slashable stake is defined within a single strategy
+     * @param totalMagnitude a virtual "denominator" magnitude from which to base portions of slashable stake to AVSs.
+     * @param operatorSetSlashingParams the fine grained parameters deiniting the AVSs ability to slash and register the operator for the operator set
+     */
+    struct SlashingMagnitudeParam {
+        IStrategy strategy;
+        uint64 totalMagnitude;
+        OperatorSetSlashingParam[] operatorSetSlashingParams; 
+    }
+
+    /// EVENTS
+    
+    event RegistrationParamsUpdated(
+        address operator, OperatorSet operatorSet, bool allowedToRegister
+    );
+
+    event SlashableMagnitudeUpdated(
+        address operator, IStrategy strategy, OperatorSet operatorSet, uint64 slashableMagnitude, uint32 effectEpoch
+    );
+
+    event TotalMagnitudeUpdated(
+        address operator, IStrategy strategy, uint64 totalMagnitude, uint32 effectEpoch
+    );
+
+    /// EXTERNAL - STATE MODIFYING
+    
+    /**
+     * @notice updates the registration parameters for an operator for a set of 
+     * operator sets. whether or not the AVS is allowed to add them to the given 
+     * operator set if they are not registered for it
+     *
+     * @param operator the operator whom the registration parameters are being 
+     * changed
+     * @param registrationParams the new registration parameters
+     * @param allocatorSignature if non-empty is the signature of the allocator on 
+     * the modification. if empty, the msg.sender must be the allocator for the 
+     * operator
+     *
+     * @dev changes take effect immediately
+     */
+    function updateRegistrationParams(
+        address operator,
+        RegistrationParam[] calldata registrationParams,
+        SignatureWithExpiry calldata allocatorSignature
+    ) external;
+    
+    /**
+     * @notice updates the slashing magnitudes for an operator for a set of 
+     * operator sets
+     * 
+     * @param operator the operator whom the slashing parameters are being 
+     * changed
+     * @param slashingMagnitudeParams the new slashing parameters
+     * @param allocatorSignature if non-empty is the signature of the allocator on 
+     * the modification. if empty, the msg.sender must be the allocator for the 
+     * operator
+     *
+     * @dev changes take effect in 3 epochs for when this function is called
+     */
+    function updateSlashingMagnitudes(
+        address operator,
+        SlashingMagnitudeParam[] calldata slashingMagnitudeParams,
+        SignatureWithExpiry calldata allocatorSignature
+    ) external returns(uint32 effectEpoch);
+    
+    /// @notice a batch call of updateRegistrationParams and updateSlashingMagnitudes
+    function updateRegistrationParamsAndSlashingMagnitudes(
+        address operator,
+        RegistrationParam[] calldata registrationParams,
+        SlashingMagnitudeParam[] calldata slashingMagnitudeParams,
+        SignatureWithExpiry calldata allocatorSignature
+    ) external returns(uint32 effectEpoch);
+
+    /**	
+ 	 * @notice Called by AVSs to add a strategy to its operator set
+	 * 
+	 * @param operatorSetID the ID of the operator set
+	 * @param strategies the list strategies of the operator set to add
+	 *
+	 * @dev msg.sender is used as the AVS
+	 * @dev no storage is updated as the event is used by off-chain services
+	 */
+	function addStrategiesToOperatorSet(
+		uint32 operatorSetID,
+		IStrategy[] calldata strategies
+	) external;
+
+    /**	
+ 	 * @notice Called by AVSs to remove a strategy to its operator set
+	 * 
+	 * @param operatorSetID the ID of the operator set
+	 * @param strategies the list strategie of the operator set to remove
+	 *
+	 * @dev msg.sender is used as the AVS
+	 * @dev no storage is updated as the event is used by off-chain services
+	 */
+	function removeStrategiesFromOperatorSet(
+		uint32 operatorSetID,
+		IStrategy[] calldata strategies
+	) external;
+
+    /// VIEW
+    
+    /**
+     * @param operator the operator to get allowedToRegister for
+     * @param operatorSet the operator set to get allowedToRegister for
+     *
+     * @return allowedToRegister whether or not operatorSet.avs is allowed to 
+     * add them to the given operator set if they are not registered for it
+     */
+    function getAllowedToRegister(
+        address operator,
+        OperatorSet calldata operatorSet
+    ) external returns (bool allowedToRegister);
+
+    /**
+     * @param operator the operator to get the slashable bips for
+     * @param operatorSet the operator set to get the slashable bips for
+     * @param strategy the strategy to get the slashable bips for
+     * @param epoch the epoch to get the slashable bips for for
+     *
+     * @return slashableBips the slashable bips of the given strategy owned by
+     * the given OperatorSet for the given operator and epoch
+     */
+    function getSlashableBips(
+        address operator,
+        OperatorSet calldata operatorSet,
+        IStrategy strategy,
+        uint32 epoch
+    ) external returns (uint16 slashableBips);
+
+    
+    /*******************************************************************************
+                            AVSDirectory Interface
+    *******************************************************************************/
+
+
+
+    /// @notice Enum representing the status of an operator's registration with an AVS
+    enum OperatorAVSRegistrationStatus {
+        UNREGISTERED,       // Operator not registered to AVS
+        REGISTERED          // Operator registered to AVS
+    }
+
+    /**
+     * @notice Emitted when @param avs indicates that they are updating their MetadataURI string
+     * @dev Note that these strings are *never stored in storage* and are instead purely emitted in events for off-chain indexing
+     */
+    event AVSMetadataURIUpdated(address indexed avs, string metadataURI);
+
+    /// @notice Emitted when an operator's registration status for an AVS is updated
+    event OperatorAVSRegistrationStatusUpdated(address indexed operator, address indexed avs, OperatorAVSRegistrationStatus status);
+
+    /**
+     * @notice Called by an avs to register an operator with the avs.
+     * @param operator The address of the operator to register.
+     * @param operatorSignature The signature, salt, and expiry of the operator's signature.
+     */
+    function registerOperatorToAVS(
+        address operator,
+        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
+    ) external;
+
+    /**
+     * @notice Called by an avs to deregister an operator with the avs.
+     * @param operator The address of the operator to deregister.
+     */
+    function deregisterOperatorFromAVS(address operator) external;
+
+    /**
+     * @notice Called by an AVS to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
+     * @param metadataURI The URI for metadata associated with an AVS
+     * @dev Note that the `metadataURI` is *never stored * and is only emitted in the `AVSMetadataURIUpdated` event
+     */
+    function updateAVSMetadataURI(string calldata metadataURI) external;
+
+    /**
+     * @notice Returns whether or not the salt has already been used by the operator.
+     * @dev Salts is used in the `registerOperatorToAVS` function.
+     */
+    function operatorSaltIsSpent(address operator, bytes32 salt) external view returns (bool);
+
+    /**
+     * @notice Calculates the digest hash to be signed by an operator to register with an AVS
+     * @param operator The account registering as an operator
+     * @param avs The AVS the operator is registering to
+     * @param salt A unique and single use value associated with the approver signature.
+     * @param expiry Time after which the approver's signature becomes invalid
+     */
+    function calculateOperatorAVSRegistrationDigestHash(
+        address operator,
+        address avs,
+        bytes32 salt,
+        uint256 expiry
+    ) external view returns (bytes32);
+
+    /// @notice The EIP-712 typehash for the Registration struct used by the contract
+    function OPERATOR_AVS_REGISTRATION_TYPEHASH() external view returns (bytes32);
+}

--- a/src/interfaces/IRegistryCoordinator.sol
+++ b/src/interfaces/IRegistryCoordinator.sol
@@ -15,10 +15,10 @@ interface IRegistryCoordinator {
     // EVENTS
 
     /// Emits when an operator is registered
-    event OperatorRegistered(address indexed operator, bytes32 indexed operatorId);
+    event OperatorRegistered(address indexed operator, bytes32 indexed operatorId, bytes indexed quorumNumbers);
 
     /// Emits when an operator is deregistered
-    event OperatorDeregistered(address indexed operator, bytes32 indexed operatorId);
+    event OperatorDeregistered(address indexed operator, bytes32 indexed operatorId, bytes indexed quorumNumbers);
 
     event OperatorSetParamsUpdated(uint8 indexed quorumNumber, OperatorSetParam operatorSetParams);
 

--- a/src/interfaces/IRegistryCoordinator.sol
+++ b/src/interfaces/IRegistryCoordinator.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.12;
 
+import {IServiceManager} from "./IServiceManager.sol";
 import {IBLSApkRegistry} from "./IBLSApkRegistry.sol";
 import {IStakeRegistry} from "./IStakeRegistry.sol";
 import {IIndexRegistry} from "./IIndexRegistry.sol";
@@ -83,6 +84,8 @@ interface IRegistryCoordinator {
 
     /// @notice Returns the operator set params for the given `quorumNumber`
     function getOperatorSetParams(uint8 quorumNumber) external view returns (OperatorSetParam memory);
+    /// @notice the ServiceManager for this AVS, which forwards calls onto EigenLayer's core contracts
+    function serviceManager() external view returns (IServiceManager);
     /// @notice the Stake registry contract that will keep track of operators' stakes
     function stakeRegistry() external view returns (IStakeRegistry);
     /// @notice the BLS Aggregate Pubkey Registry contract that will keep track of operators' BLS aggregate pubkeys per quorum

--- a/src/interfaces/IServiceManager.sol
+++ b/src/interfaces/IServiceManager.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.5.0;
 
 import {IRewardsCoordinator} from "eigenlayer-contracts/src/contracts/interfaces/IRewardsCoordinator.sol";
+import {IStrategy} from "./IOperatorSetManager.sol"; // should be later changed to be import from core
 import {IServiceManagerUI} from "./IServiceManagerUI.sol";
 
 /**
@@ -20,7 +21,21 @@ interface IServiceManager is IServiceManagerUI {
      * @dev This function will revert if the `rewardsSubmission` is malformed,
      * e.g. if the `strategies` and `weights` arrays are of non-equal lengths
      */
-    function createAVSRewardsSubmission(IRewardsCoordinator.RewardsSubmission[] calldata rewardsSubmissions) external;
+    function createAVSRewardsSubmission(
+        IRewardsCoordinator.RewardsSubmission[] calldata rewardsSubmissions
+    ) external;
+
+    /// TODO: natspec
+    function addStrategiesToOperatorSet(
+		uint32 operatorSetID,
+		IStrategy[] calldata strategies
+	) external;
+
+    /// TODO: natspec
+    function removeStrategiesFromOperatorSet(
+		uint32 operatorSetID,
+		IStrategy[] calldata strategies
+	) external;
 
     // EVENTS
     event RewardsInitiatorUpdated(address prevRewardsInitiator, address newRewardsInitiator);

--- a/src/interfaces/IServiceManager.sol
+++ b/src/interfaces/IServiceManager.sol
@@ -28,15 +28,15 @@ interface IServiceManager is IServiceManagerUI {
 
     /// TODO: natspec
     function addStrategiesToOperatorSet(
-		uint32 operatorSetID,
-		IStrategy[] calldata strategies
-	) external;
+        uint32 operatorSetID,
+        IStrategy[] calldata strategies
+    ) external;
 
     /// TODO: natspec
     function removeStrategiesFromOperatorSet(
-		uint32 operatorSetID,
-		IStrategy[] calldata strategies
-	) external;
+        uint32 operatorSetID,
+        IStrategy[] calldata strategies
+    ) external;
 
     /// @notice migrates all existing operators and strategies to operator sets
     function migrateStrategiesToOperatorSets() external;
@@ -45,44 +45,46 @@ interface IServiceManager is IServiceManagerUI {
      * @notice the operator needs to provide a signature over the operatorSetIds they will be registering
      * for. This can be called externally by getOperatorSetIds
      */
-    function migrateOperatorToOperatorSets(ISignatureUtils.SignatureWithSaltAndExpiry memory signature) external;
+    function migrateOperatorToOperatorSets(
+        ISignatureUtils.SignatureWithSaltAndExpiry memory signature
+    ) external;
 
     /**
-	 * @notice Called by this AVS's RegistryCoordinator to register an operator for its registering operatorSets
-	 * 
-	 * @param operator the address of the operator to be added to the operator set
-	 * @param quorumNumbers quorums/operatorSetIds to add the operator to
-	 * @param signature the signature of the operator on their intent to register
-	 * @dev msg.sender is used as the AVS
-	 * @dev operator must not have a pending a deregistration from the operator set
-	 * @dev if this is the first operator set in the AVS that the operator is 
-	 * registering for, a OperatorAVSRegistrationStatusUpdated event is emitted with 
-	 * a REGISTERED status
-	 */
-	function registerOperatorToOperatorSets(
-		address operator,
-		bytes calldata quorumNumbers,
-		ISignatureUtils.SignatureWithSaltAndExpiry memory signature
-	) external;
+     * @notice Called by this AVS's RegistryCoordinator to register an operator for its registering operatorSets
+     *
+     * @param operator the address of the operator to be added to the operator set
+     * @param quorumNumbers quorums/operatorSetIds to add the operator to
+     * @param signature the signature of the operator on their intent to register
+     * @dev msg.sender is used as the AVS
+     * @dev operator must not have a pending a deregistration from the operator set
+     * @dev if this is the first operator set in the AVS that the operator is
+     * registering for, a OperatorAVSRegistrationStatusUpdated event is emitted with
+     * a REGISTERED status
+     */
+    function registerOperatorToOperatorSets(
+        address operator,
+        bytes calldata quorumNumbers,
+        ISignatureUtils.SignatureWithSaltAndExpiry memory signature
+    ) external;
 
     /**
-	 * @notice Called by this AVS's RegistryCoordinator to deregister an operator for its operatorSets
-	 * 
-	 * @param operator the address of the operator to be removed from the 
-	 * operator set
-	 * @param quorumNumbers the quorumNumbers/operatorSetIds to deregister the operator for
-	 * 
-	 * @dev msg.sender is used as the AVS
-	 * @dev operator must be registered for msg.sender AVS and the given 
-	 * operator set
+     * @notice Called by this AVS's RegistryCoordinator to deregister an operator for its operatorSets
+     *
+     * @param operator the address of the operator to be removed from the
+     * operator set
+     * @param quorumNumbers the quorumNumbers/operatorSetIds to deregister the operator for
+     *
+     * @dev msg.sender is used as the AVS
+     * @dev operator must be registered for msg.sender AVS and the given
+     * operator set
      * @dev if this removes operator from all operator sets for the msg.sender AVS
      * then an OperatorAVSRegistrationStatusUpdated event is emitted with a DEREGISTERED
      * status
-	 */
-	function deregisterOperatorFromOperatorSets(
-		address operator,
+     */
+    function deregisterOperatorFromOperatorSets(
+        address operator,
         bytes calldata quorumNumbers
-	) external;
+    ) external;
 
     // EVENTS
     event RewardsInitiatorUpdated(address prevRewardsInitiator, address newRewardsInitiator);

--- a/src/interfaces/IServiceManager.sol
+++ b/src/interfaces/IServiceManager.sol
@@ -82,12 +82,12 @@ interface IServiceManager is IServiceManagerUI {
      * The ServiceManager owner can eject any operators that have yet to completely migrate fully to operator sets.
      * This final step of the migration process will ensure the full migration of all operators to operator sets.
      * @param operators The list of operators to eject for the given OperatorSet
-     * @param operatorSet The OperatorSet to eject the operators from
+     * @param operatorSetId This AVS's operatorSetId to eject operators from
      * @dev The RegistryCoordinator MUST set this ServiceManager contract to be the ejector address for this call to succeed
      */
     function ejectNonmigratedOperators(
         address[] calldata operators,
-        IOperatorSetManager.OperatorSet calldata operatorSet
+        uint32 operatorSetId
     ) external;
 
     /**

--- a/src/interfaces/IServiceManager.sol
+++ b/src/interfaces/IServiceManager.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
+import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
 import {IRewardsCoordinator} from "eigenlayer-contracts/src/contracts/interfaces/IRewardsCoordinator.sol";
 import {IStrategy} from "./IOperatorSetManager.sol"; // should be later changed to be import from core
 import {IServiceManagerUI} from "./IServiceManagerUI.sol";
@@ -24,6 +25,43 @@ interface IServiceManager is IServiceManagerUI {
     function createAVSRewardsSubmission(
         IRewardsCoordinator.RewardsSubmission[] calldata rewardsSubmissions
     ) external;
+
+    /**
+	 * @notice Called by this AVS's RegistryCoordinator to register an operator for its registering operatorSets
+	 * 
+	 * @param operator the address of the operator to be added to the operator set
+	 * @param quorumNumbers quorums/operatorSetIds to add the operator to
+	 * @param signature the signature of the operator on their intent to register
+	 * @dev msg.sender is used as the AVS
+	 * @dev operator must not have a pending a deregistration from the operator set
+	 * @dev if this is the first operator set in the AVS that the operator is 
+	 * registering for, a OperatorAVSRegistrationStatusUpdated event is emitted with 
+	 * a REGISTERED status
+	 */
+	function registerOperatorToOperatorSets(
+		address operator,
+		bytes calldata quorumNumbers,
+		ISignatureUtils.SignatureWithSaltAndExpiry memory signature
+	) external;
+
+    /**
+	 * @notice Called by this AVS's RegistryCoordinator to deregister an operator for its operatorSets
+	 * 
+	 * @param operator the address of the operator to be removed from the 
+	 * operator set
+	 * @param quorumNumbers the quorumNumbers/operatorSetIds to deregister the operator for
+	 * 
+	 * @dev msg.sender is used as the AVS
+	 * @dev operator must be registered for msg.sender AVS and the given 
+	 * operator set
+     * @dev if this removes operator from all operator sets for the msg.sender AVS
+     * then an OperatorAVSRegistrationStatusUpdated event is emitted with a DEREGISTERED
+     * status
+	 */
+	function deregisterOperatorFromOperatorSets(
+		address operator,
+        bytes calldata quorumNumbers
+	) external;
 
     /// TODO: natspec
     function addStrategiesToOperatorSet(

--- a/src/interfaces/IServiceManager.sol
+++ b/src/interfaces/IServiceManager.sol
@@ -26,6 +26,27 @@ interface IServiceManager is IServiceManagerUI {
         IRewardsCoordinator.RewardsSubmission[] calldata rewardsSubmissions
     ) external;
 
+    /// TODO: natspec
+    function addStrategiesToOperatorSet(
+		uint32 operatorSetID,
+		IStrategy[] calldata strategies
+	) external;
+
+    /// TODO: natspec
+    function removeStrategiesFromOperatorSet(
+		uint32 operatorSetID,
+		IStrategy[] calldata strategies
+	) external;
+
+    /// @notice migrates all existing operators and strategies to operator sets
+    function migrateStrategiesToOperatorSets() external;
+
+    /**
+     * @notice the operator needs to provide a signature over the operatorSetIds they will be registering
+     * for. This can be called externally by getOperatorSetIds
+     */
+    function migrateOperatorToOperatorSets(ISignatureUtils.SignatureWithSaltAndExpiry memory signature) external;
+
     /**
 	 * @notice Called by this AVS's RegistryCoordinator to register an operator for its registering operatorSets
 	 * 
@@ -61,18 +82,6 @@ interface IServiceManager is IServiceManagerUI {
 	function deregisterOperatorFromOperatorSets(
 		address operator,
         bytes calldata quorumNumbers
-	) external;
-
-    /// TODO: natspec
-    function addStrategiesToOperatorSet(
-		uint32 operatorSetID,
-		IStrategy[] calldata strategies
-	) external;
-
-    /// TODO: natspec
-    function removeStrategiesFromOperatorSet(
-		uint32 operatorSetID,
-		IStrategy[] calldata strategies
 	) external;
 
     // EVENTS

--- a/src/interfaces/IServiceManager.sol
+++ b/src/interfaces/IServiceManager.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.5.0;
 
 import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
 import {IRewardsCoordinator} from "eigenlayer-contracts/src/contracts/interfaces/IRewardsCoordinator.sol";
-import {IStrategy} from "./IOperatorSetManager.sol"; // should be later changed to be import from core
+import {IOperatorSetManager, IStrategy} from "./IOperatorSetManager.sol"; // should be later changed to be import from core
 import {IServiceManagerUI} from "./IServiceManagerUI.sol";
 
 /**
@@ -75,6 +75,19 @@ interface IServiceManager is IServiceManagerUI {
     function migrateOperatorToOperatorSets(
         address operator,
         ISignatureUtils.SignatureWithSaltAndExpiry memory signature
+    ) external;
+
+    /**
+     * @notice Once strategies have been migrated and operators have been migrated to operator sets.
+     * The ServiceManager owner can eject any operators that have yet to completely migrate fully to operator sets.
+     * This final step of the migration process will ensure the full migration of all operators to operator sets.
+     * @param operators The list of operators to eject for the given OperatorSet
+     * @param operatorSet The OperatorSet to eject the operators from
+     * @dev The RegistryCoordinator MUST set this ServiceManager contract to be the ejector address for this call to succeed
+     */
+    function ejectNonmigratedOperators(
+        address[] calldata operators,
+        IOperatorSetManager.OperatorSet calldata operatorSet
     ) external;
 
     /**

--- a/src/interfaces/IServiceManagerUI.sol
+++ b/src/interfaces/IServiceManagerUI.sol
@@ -57,6 +57,6 @@ interface IServiceManagerUI {
      */
     function getRestakeableStrategies() external view returns (address[] memory);
 
-    /// @notice Returns the EigenLayer AVSDirectory contract.
-    function avsDirectory() external view returns (address);
+    /// @notice Returns the EigenLayer OperatorSetManager contract.
+    function operatorSetManager() external view returns (address);
 }

--- a/src/interfaces/IServiceManagerUI.sol
+++ b/src/interfaces/IServiceManagerUI.sol
@@ -24,21 +24,21 @@ interface IServiceManagerUI {
      */
     function updateAVSMetadataURI(string memory _metadataURI) external;
 
-    /**
-     * @notice Forwards a call to EigenLayer's DelegationManager contract to confirm operator registration with the AVS
-     * @param operator The address of the operator to register.
-     * @param operatorSignature The signature, salt, and expiry of the operator's signature.
-     */
-    function registerOperatorToAVS(
-        address operator,
-        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
-    ) external;
+    // /**
+    //  * @notice Forwards a call to EigenLayer's DelegationManager contract to confirm operator registration with the AVS
+    //  * @param operator The address of the operator to register.
+    //  * @param operatorSignature The signature, salt, and expiry of the operator's signature.
+    //  */
+    // function registerOperatorToAVS(
+    //     address operator,
+    //     ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
+    // ) external;
 
-    /**
-     * @notice Forwards a call to EigenLayer's DelegationManager contract to confirm operator deregistration from the AVS
-     * @param operator The address of the operator to deregister.
-     */
-    function deregisterOperatorFromAVS(address operator) external;
+    // /**
+    //  * @notice Forwards a call to EigenLayer's DelegationManager contract to confirm operator deregistration from the AVS
+    //  * @param operator The address of the operator to deregister.
+    //  */
+    // function deregisterOperatorFromAVS(address operator) external;
 
     /**
      * @notice Returns the list of strategies that the operator has potentially restaked on the AVS

--- a/src/unaudited/ECDSAServiceManagerBase.sol
+++ b/src/unaudited/ECDSAServiceManagerBase.sol
@@ -86,20 +86,20 @@ abstract contract ECDSAServiceManagerBase is
         _createAVSRewardsSubmission(rewardsSubmissions);
     }
 
-    /// @inheritdoc IServiceManagerUI
-    function registerOperatorToAVS(
-        address operator,
-        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
-    ) external virtual onlyStakeRegistry {
-        _registerOperatorToAVS(operator, operatorSignature);
-    }
+    // /// @inheritdoc IServiceManagerUI
+    // function registerOperatorToAVS(
+    //     address operator,
+    //     ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
+    // ) external virtual onlyStakeRegistry {
+    //     _registerOperatorToAVS(operator, operatorSignature);
+    // }
 
-    /// @inheritdoc IServiceManagerUI
-    function deregisterOperatorFromAVS(
-        address operator
-    ) external virtual onlyStakeRegistry {
-        _deregisterOperatorFromAVS(operator);
-    }
+    // /// @inheritdoc IServiceManagerUI
+    // function deregisterOperatorFromAVS(
+    //     address operator
+    // ) external virtual onlyStakeRegistry {
+    //     _deregisterOperatorFromAVS(operator);
+    // }
 
     /// @inheritdoc IServiceManagerUI
     function getRestakeableStrategies()

--- a/src/unaudited/ECDSAStakeRegistry.sol
+++ b/src/unaudited/ECDSAStakeRegistry.sol
@@ -350,7 +350,7 @@ contract ECDSAStakeRegistry is
         delete _operatorRegistered[_operator];
         int256 delta = _updateOperatorWeight(_operator);
         _updateTotalWeight(delta);
-        IServiceManager(_serviceManager).deregisterOperatorFromAVS(_operator);
+        // IServiceManager(_serviceManager).deregisterOperatorFromAVS(_operator);
         emit OperatorDeregistered(_operator, address(_serviceManager));
     }
 
@@ -370,10 +370,10 @@ contract ECDSAStakeRegistry is
         int256 delta = _updateOperatorWeight(_operator);
         _updateTotalWeight(delta);
         _updateOperatorSigningKey(_operator, _signingKey);
-        IServiceManager(_serviceManager).registerOperatorToAVS(
-            _operator,
-            _operatorSignature
-        );
+        // IServiceManager(_serviceManager).registerOperatorToAVS(
+        //     _operator,
+        //     _operatorSignature
+        // );
         emit OperatorRegistered(_operator, _serviceManager);
     }
 

--- a/test/harnesses/StakeRegistryHarness.sol
+++ b/test/harnesses/StakeRegistryHarness.sol
@@ -8,10 +8,9 @@ import {IServiceManager} from "../../src/interfaces/IServiceManager.sol";
 // wrapper around the StakeRegistry contract that exposes the internal functions for unit testing.
 contract StakeRegistryHarness is StakeRegistry {
     constructor(
-        IServiceManager _serviceManager,
         IRegistryCoordinator _registryCoordinator,
         IDelegationManager _delegationManager
-    ) StakeRegistry(_serviceManager, _registryCoordinator, _delegationManager) {
+    ) StakeRegistry(_registryCoordinator, _delegationManager) {
     }
 
     function recordOperatorStakeUpdate(bytes32 operatorId, uint8 quorumNumber, uint96 newStake) external returns(int256) {

--- a/test/harnesses/StakeRegistryHarness.sol
+++ b/test/harnesses/StakeRegistryHarness.sol
@@ -2,13 +2,16 @@
 pragma solidity ^0.8.12;
 
 import "../../src/StakeRegistry.sol";
+import {IServiceManager} from "../../src/interfaces/IServiceManager.sol";
+
 
 // wrapper around the StakeRegistry contract that exposes the internal functions for unit testing.
 contract StakeRegistryHarness is StakeRegistry {
     constructor(
+        IServiceManager _serviceManager,
         IRegistryCoordinator _registryCoordinator,
         IDelegationManager _delegationManager
-    ) StakeRegistry(_registryCoordinator, _delegationManager) {
+    ) StakeRegistry(_serviceManager, _registryCoordinator, _delegationManager) {
     }
 
     function recordOperatorStakeUpdate(bytes32 operatorId, uint8 quorumNumber, uint96 newStake) external returns(int256) {

--- a/test/integration/CoreRegistration.t.sol
+++ b/test/integration/CoreRegistration.t.sol
@@ -69,7 +69,7 @@ contract Test_CoreRegistration is MockAVSDeployer {
 
         // Deploy New ServiceManager & RegistryCoordinator implementations
         serviceManagerImplementation = new ServiceManagerMock(
-            avsDirectory,
+            operatorSetManagerMock,
             rewardsCoordinatorMock,
             registryCoordinator,
             stakeRegistry

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -32,6 +32,8 @@ import "src/StakeRegistry.sol";
 import "src/IndexRegistry.sol";
 import "src/BLSApkRegistry.sol";
 import "test/mocks/ServiceManagerMock.sol";
+import "src/interfaces/IOperatorSetManager.sol";
+import "test/mocks/OperatorSetManagerMock.sol";
 import "src/OperatorStateRetriever.sol";
 
 // Mocks and More
@@ -50,6 +52,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
     // Core contracts to deploy
     DelegationManager delegationManager;
     AVSDirectory public avsDirectory;
+    IOperatorSetManager operatorSetManager;
     StrategyManager strategyManager;
     EigenPodManager eigenPodManager;
     RewardsCoordinator rewardsCoordinator;
@@ -119,6 +122,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
         pauserRegistry = new PauserRegistry(pausers, unpauser);
 
         // Deploy mocks
+        operatorSetManager = new OperatorSetManagerMock();
         EmptyContract emptyContract = new EmptyContract();
         ethPOSDeposit = new ETHPOSDepositMock();
         beaconChainOracle = new BeaconChainOracleMock();
@@ -269,6 +273,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
                 0 // initialPausedStatus
             )
         );
+        
         // // RewardsCoordinator
         // proxyAdmin.upgradeAndCall(
         //     TransparentUpgradeableProxy(payable(address(rewardsCoordinator))),
@@ -330,14 +335,14 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
         cheats.stopPrank();
 
         StakeRegistry stakeRegistryImplementation = new StakeRegistry(
-            IRegistryCoordinator(registryCoordinator), IDelegationManager(delegationManager)
+            serviceManager, IRegistryCoordinator(registryCoordinator), IDelegationManager(delegationManager)
         );
         BLSApkRegistry blsApkRegistryImplementation =
             new BLSApkRegistry(IRegistryCoordinator(registryCoordinator));
         IndexRegistry indexRegistryImplementation =
             new IndexRegistry(IRegistryCoordinator(registryCoordinator));
         ServiceManagerMock serviceManagerImplementation = new ServiceManagerMock(
-            IAVSDirectory(avsDirectory),
+            operatorSetManager,
             rewardsCoordinator,
             IRegistryCoordinator(registryCoordinator),
             stakeRegistry

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -335,7 +335,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
         cheats.stopPrank();
 
         StakeRegistry stakeRegistryImplementation = new StakeRegistry(
-            serviceManager, IRegistryCoordinator(registryCoordinator), IDelegationManager(delegationManager)
+            IRegistryCoordinator(registryCoordinator), IDelegationManager(delegationManager)
         );
         BLSApkRegistry blsApkRegistryImplementation =
             new BLSApkRegistry(IRegistryCoordinator(registryCoordinator));

--- a/test/integration/User.t.sol
+++ b/test/integration/User.t.sol
@@ -48,7 +48,7 @@ contract User is Test {
     // Core contracts
     DelegationManager delegationManager;
     StrategyManager strategyManager;
-    AVSDirectory avsDirectory;
+    // AVSDirectory avsDirectory;
 
     // Middleware contracts
     RegistryCoordinator registryCoordinator;
@@ -77,7 +77,7 @@ contract User is Test {
         IUserDeployer deployer = IUserDeployer(msg.sender);
 
         registryCoordinator = deployer.registryCoordinator();
-        avsDirectory = deployer.avsDirectory();
+        // avsDirectory = deployer.avsDirectory();
         serviceManager = ServiceManagerBase(address(registryCoordinator.serviceManager()));
 
         blsApkRegistry = BLSApkRegistry(address(registryCoordinator.blsApkRegistry()));
@@ -86,7 +86,7 @@ contract User is Test {
 
         delegationManager = DelegationManager(address(stakeRegistry.delegation()));
         strategyManager = StrategyManager(address(delegationManager.strategyManager()));
-        avsDirectory = AVSDirectory(address(serviceManager.avsDirectory()));
+        // avsDirectory = AVSDirectory(address(serviceManager.avsDirectory()));
 
         timeMachine = deployer.timeMachine();
 

--- a/test/integration/User.t.sol
+++ b/test/integration/User.t.sol
@@ -48,7 +48,7 @@ contract User is Test {
     // Core contracts
     DelegationManager delegationManager;
     StrategyManager strategyManager;
-    // AVSDirectory avsDirectory;
+    AVSDirectory avsDirectory;
 
     // Middleware contracts
     RegistryCoordinator registryCoordinator;
@@ -77,7 +77,7 @@ contract User is Test {
         IUserDeployer deployer = IUserDeployer(msg.sender);
 
         registryCoordinator = deployer.registryCoordinator();
-        // avsDirectory = deployer.avsDirectory();
+        avsDirectory = deployer.avsDirectory();
         serviceManager = ServiceManagerBase(address(registryCoordinator.serviceManager()));
 
         blsApkRegistry = BLSApkRegistry(address(registryCoordinator.blsApkRegistry()));

--- a/test/mocks/OperatorSetManagerMock.sol
+++ b/test/mocks/OperatorSetManagerMock.sol
@@ -56,6 +56,17 @@ contract OperatorSetManagerMock is IOperatorSetManager {
         SignatureWithExpiry calldata allocatorSignature
     ) external returns(uint32 effectEpoch) {}
 
+	function registerOperatorToOperatorSets(
+		address operator,
+		uint32[] calldata operatorSetIDs,
+		ISignatureUtils.SignatureWithSaltAndExpiry memory signature
+	) external {}
+
+	function deregisterOperatorFromOperatorSets(
+		address operator, 
+		uint32[] calldata operatorSetIDs
+	) external {}
+
     /**	
  	 * @notice Called by AVSs to add a strategy to its operator set
 	 * 

--- a/test/mocks/OperatorSetManagerMock.sol
+++ b/test/mocks/OperatorSetManagerMock.sol
@@ -95,7 +95,21 @@ contract OperatorSetManagerMock is IOperatorSetManager {
 		IStrategy[] calldata strategies
 	) external {}
 
-        /**
+    /**
+     * @notice retrieve the operator status for a given AVS, returns enum for either 
+     * DEREGISTERED or REGISTERED
+     * @param avs the AVS to get the operator status for
+     * @param operator the operator to get the status for
+     */
+    function avsOperatorStatus(address avs, address operator) external view returns (OperatorAVSRegistrationStatus) {}
+
+    /// @notice number of operatorSets the operator is registered for a given AVS
+    function operatorAVSOperatorSetCount(address avs, address operator) external view returns (uint256) {}
+
+    /// @notice mapping bool returning whether a strategy is part of an OperatorSet
+    function operatorSetStrategies(address avs, uint32 operatorSetId, IStrategy strategy) external view returns (bool) {}
+
+    /**
      * @param operator the operator to get allowedToRegister for
      * @param operatorSet the operator set to get allowedToRegister for
      *

--- a/test/mocks/OperatorSetManagerMock.sol
+++ b/test/mocks/OperatorSetManagerMock.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.12;
+
+import {
+    IOperatorSetManager,
+    ISignatureUtils,
+    IStrategy
+} from "../../src/interfaces/IOperatorSetManager.sol";
+
+contract OperatorSetManagerMock is IOperatorSetManager {
+
+    /**
+     * @notice updates the registration parameters for an operator for a set of 
+     * operator sets. whether or not the AVS is allowed to add them to the given 
+     * operator set if they are not registered for it
+     *
+     * @param operator the operator whom the registration parameters are being 
+     * changed
+     * @param registrationParams the new registration parameters
+     * @param allocatorSignature if non-empty is the signature of the allocator on 
+     * the modification. if empty, the msg.sender must be the allocator for the 
+     * operator
+     *
+     * @dev changes take effect immediately
+     */
+    function updateRegistrationParams(
+        address operator,
+        RegistrationParam[] calldata registrationParams,
+        SignatureWithExpiry calldata allocatorSignature
+    ) external {}
+    
+    /**
+     * @notice updates the slashing magnitudes for an operator for a set of 
+     * operator sets
+     * 
+     * @param operator the operator whom the slashing parameters are being 
+     * changed
+     * @param slashingMagnitudeParams the new slashing parameters
+     * @param allocatorSignature if non-empty is the signature of the allocator on 
+     * the modification. if empty, the msg.sender must be the allocator for the 
+     * operator
+     *
+     * @dev changes take effect in 3 epochs for when this function is called
+     */
+    function updateSlashingMagnitudes(
+        address operator,
+        SlashingMagnitudeParam[] calldata slashingMagnitudeParams,
+        SignatureWithExpiry calldata allocatorSignature
+    ) external returns(uint32 effectEpoch) {}
+    
+    /// @notice a batch call of updateRegistrationParams and updateSlashingMagnitudes
+    function updateRegistrationParamsAndSlashingMagnitudes(
+        address operator,
+        RegistrationParam[] calldata registrationParams,
+        SlashingMagnitudeParam[] calldata slashingMagnitudeParams,
+        SignatureWithExpiry calldata allocatorSignature
+    ) external returns(uint32 effectEpoch) {}
+
+    /**	
+ 	 * @notice Called by AVSs to add a strategy to its operator set
+	 * 
+	 * @param operatorSetID the ID of the operator set
+	 * @param strategies the list strategies of the operator set to add
+	 *
+	 * @dev msg.sender is used as the AVS
+	 * @dev no storage is updated as the event is used by off-chain services
+	 */
+	function addStrategiesToOperatorSet(
+		uint32 operatorSetID,
+		IStrategy[] calldata strategies
+	) external {}
+
+    /**	
+ 	 * @notice Called by AVSs to remove a strategy to its operator set
+	 * 
+	 * @param operatorSetID the ID of the operator set
+	 * @param strategies the list strategie of the operator set to remove
+	 *
+	 * @dev msg.sender is used as the AVS
+	 * @dev no storage is updated as the event is used by off-chain services
+	 */
+	function removeStrategiesFromOperatorSet(
+		uint32 operatorSetID,
+		IStrategy[] calldata strategies
+	) external {}
+
+        /**
+     * @param operator the operator to get allowedToRegister for
+     * @param operatorSet the operator set to get allowedToRegister for
+     *
+     * @return allowedToRegister whether or not operatorSet.avs is allowed to 
+     * add them to the given operator set if they are not registered for it
+     */
+    function getAllowedToRegister(
+        address operator,
+        OperatorSet calldata operatorSet
+    ) external returns (bool allowedToRegister) {}
+
+    /**
+     * @param operator the operator to get the slashable bips for
+     * @param operatorSet the operator set to get the slashable bips for
+     * @param strategy the strategy to get the slashable bips for
+     * @param epoch the epoch to get the slashable bips for for
+     *
+     * @return slashableBips the slashable bips of the given strategy owned by
+     * the given OperatorSet for the given operator and epoch
+     */
+    function getSlashableBips(
+        address operator,
+        OperatorSet calldata operatorSet,
+        IStrategy strategy,
+        uint32 epoch
+    ) external returns (uint16 slashableBips) {}
+
+
+
+    /**
+     * @notice Called by an avs to register an operator with the avs.
+     * @param operator The address of the operator to register.
+     * @param operatorSignature The signature, salt, and expiry of the operator's signature.
+     */
+    function registerOperatorToAVS(
+        address operator,
+        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
+    ) external {}
+
+    /**
+     * @notice Called by an avs to deregister an operator with the avs.
+     * @param operator The address of the operator to deregister.
+     */
+    function deregisterOperatorFromAVS(address operator) external {}
+
+    /**
+     * @notice Called by an AVS to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
+     * @param metadataURI The URI for metadata associated with an AVS
+     * @dev Note that the `metadataURI` is *never stored * and is only emitted in the `AVSMetadataURIUpdated` event
+     */
+    function updateAVSMetadataURI(string calldata metadataURI) external {}
+
+    /**
+     * @notice Returns whether or not the salt has already been used by the operator.
+     * @dev Salts is used in the `registerOperatorToAVS` function.
+     */
+    function operatorSaltIsSpent(address operator, bytes32 salt) external view returns (bool) {}
+
+    /**
+     * @notice Calculates the digest hash to be signed by an operator to register with an AVS
+     * @param operator The account registering as an operator
+     * @param avs The AVS the operator is registering to
+     * @param salt A unique and single use value associated with the approver signature.
+     * @param expiry Time after which the approver's signature becomes invalid
+     */
+    function calculateOperatorAVSRegistrationDigestHash(
+        address operator,
+        address avs,
+        bytes32 salt,
+        uint256 expiry
+    ) external view returns (bytes32) {}
+
+    /// @notice The EIP-712 typehash for the Registration struct used by the contract
+    function OPERATOR_AVS_REGISTRATION_TYPEHASH() external view returns (bytes32) {}
+} 

--- a/test/mocks/OperatorSetManagerMock.sol
+++ b/test/mocks/OperatorSetManagerMock.sol
@@ -123,7 +123,10 @@ contract OperatorSetManagerMock is IOperatorSetManager {
         uint32 epoch
     ) external returns (uint16 slashableBips) {}
 
-
+    function isOperatorInOperatorSet(
+		address operator, 
+		OperatorSet calldata operatorSet
+	) external view returns(bool) {}
 
     /**
      * @notice Called by an avs to register an operator with the avs.

--- a/test/mocks/RegistryCoordinatorMock.sol
+++ b/test/mocks/RegistryCoordinatorMock.sol
@@ -6,6 +6,9 @@ import "../../src/interfaces/IRegistryCoordinator.sol";
 
 
 contract RegistryCoordinatorMock is IRegistryCoordinator {
+
+    function serviceManager() external view returns (IServiceManager) {}
+
     function blsApkRegistry() external view returns (IBLSApkRegistry) {}
 
     function ejectOperator(

--- a/test/mocks/ServiceManagerMock.sol
+++ b/test/mocks/ServiceManagerMock.sol
@@ -5,12 +5,12 @@ import "../../src/ServiceManagerBase.sol";
 
 contract ServiceManagerMock is ServiceManagerBase {
     constructor(
-        IAVSDirectory _avsDirectory,
+        IOperatorSetManager _operatorSetManager,
         IRewardsCoordinator _rewardsCoordinator,
         IRegistryCoordinator _registryCoordinator,
         IStakeRegistry _stakeRegistry
     )
-        ServiceManagerBase(_avsDirectory, _rewardsCoordinator, _registryCoordinator, _stakeRegistry)
+        ServiceManagerBase(_operatorSetManager, _rewardsCoordinator, _registryCoordinator, _stakeRegistry)
     {}
 
     function initialize(

--- a/test/unit/ServiceManagerBase.t.sol
+++ b/test/unit/ServiceManagerBase.t.sol
@@ -77,7 +77,7 @@ contract ServiceManagerBase_UnitTests is MockAVSDeployer, IServiceManagerBaseEve
         );
         // Deploy ServiceManager
         serviceManagerImplementation = new ServiceManagerMock(
-            avsDirectory,
+            operatorSetManagerMock,
             rewardsCoordinator,
             registryCoordinatorImplementation,
             stakeRegistryImplementation

--- a/test/unit/ServiceManagerRouter.t.sol
+++ b/test/unit/ServiceManagerRouter.t.sol
@@ -16,7 +16,7 @@ contract ServiceManagerRouter_UnitTests is MockAVSDeployer {
 
         // Deploy dummy serviceManager
         dummyServiceManager = new ServiceManagerMock(
-            avsDirectory,
+            operatorSetManagerMock,
             rewardsCoordinatorImplementation,
             registryCoordinatorImplementation,
             stakeRegistryImplementation

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -52,7 +52,6 @@ contract StakeRegistryUnitTests is MockAVSDeployer, IStakeRegistryEvents {
         );
 
         stakeRegistryImplementation = new StakeRegistryHarness(
-            serviceManager,
             IRegistryCoordinator(address(registryCoordinator)),
             delegationMock
         );

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -52,6 +52,7 @@ contract StakeRegistryUnitTests is MockAVSDeployer, IStakeRegistryEvents {
         );
 
         stakeRegistryImplementation = new StakeRegistryHarness(
+            serviceManager,
             IRegistryCoordinator(address(registryCoordinator)),
             delegationMock
         );

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -28,6 +28,7 @@ import {IServiceManager} from "../../src/interfaces/IServiceManager.sol";
 import {StrategyManagerMock} from "eigenlayer-contracts/src/test/mocks/StrategyManagerMock.sol";
 import {EigenPodManagerMock} from "eigenlayer-contracts/src/test/mocks/EigenPodManagerMock.sol";
 import {AVSDirectoryMock} from "../mocks/AVSDirectoryMock.sol";
+import {OperatorSetManagerMock} from "../mocks/OperatorSetManagerMock.sol";
 import {DelegationMock} from "../mocks/DelegationMock.sol";
 import {AVSDirectory} from "eigenlayer-contracts/src/contracts/core/AVSDirectory.sol";
 import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
@@ -76,6 +77,9 @@ contract MockAVSDeployer is Test {
     AVSDirectory public avsDirectory;
     AVSDirectory public avsDirectoryImplementation;
     AVSDirectoryMock public avsDirectoryMock;
+    // OperatorSetManager public operatorSetManager;
+    // OperatorSetManager public operatorSetManagerImplementation;
+    OperatorSetManagerMock public operatorSetManagerMock;
     RewardsCoordinator public rewardsCoordinator;
     RewardsCoordinator public rewardsCoordinatorImplementation;
     RewardsCoordinatorMock public rewardsCoordinatorMock;
@@ -147,6 +151,7 @@ contract MockAVSDeployer is Test {
 
         delegationMock = new DelegationMock();
         avsDirectoryMock = new AVSDirectoryMock();
+        operatorSetManagerMock = new OperatorSetManagerMock();
         eigenPodManagerMock = new EigenPodManagerMock();
         strategyManagerMock = new StrategyManagerMock();
         slasherImplementation = new Slasher(strategyManagerMock, delegationMock);
@@ -164,7 +169,6 @@ contract MockAVSDeployer is Test {
                 )
             )
         );
-        avsDirectoryMock = new AVSDirectoryMock();
         avsDirectoryImplementation = new AVSDirectory(delegationMock);
         avsDirectory = AVSDirectory(
             address(
@@ -221,7 +225,7 @@ contract MockAVSDeployer is Test {
         cheats.startPrank(proxyAdminOwner);
 
         stakeRegistryImplementation =
-            new StakeRegistryHarness(IRegistryCoordinator(registryCoordinator), delegationMock);
+            new StakeRegistryHarness(serviceManager, IRegistryCoordinator(registryCoordinator), delegationMock);
 
         proxyAdmin.upgrade(
             TransparentUpgradeableProxy(payable(address(stakeRegistry))),
@@ -243,7 +247,7 @@ contract MockAVSDeployer is Test {
         );
 
         serviceManagerImplementation = new ServiceManagerMock(
-            avsDirectoryMock,
+            operatorSetManagerMock,
             IRewardsCoordinator(address(rewardsCoordinatorMock)),
             registryCoordinator,
             stakeRegistry

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -225,7 +225,7 @@ contract MockAVSDeployer is Test {
         cheats.startPrank(proxyAdminOwner);
 
         stakeRegistryImplementation =
-            new StakeRegistryHarness(serviceManager, IRegistryCoordinator(registryCoordinator), delegationMock);
+            new StakeRegistryHarness(IRegistryCoordinator(registryCoordinator), delegationMock);
 
         proxyAdmin.upgrade(
             TransparentUpgradeableProxy(payable(address(stakeRegistry))),


### PR DESCRIPTION
Disregard the changed files not in `/src`, changes were only made to make all contracts build

TODO before merge:
- [X] Draft OperatorSets implementation with migration flow
- [ ] Unit tests
- [ ] Update core-repo submodule import to use actual IOperatorSetManager interface once a agreed upon POC is complete
