### PR TITLE
fix: deprecated struct field for earning receiver

### DIFF
--- a/test/integration/CoreRegistration.t.sol
+++ b/test/integration/CoreRegistration.t.sol
@@ -102,7 +102,7 @@ contract Test_CoreRegistration is MockAVSDeployer {
         cheats.prank(operator);
         delegationManager.registerAsOperator(
             IDelegationManager.OperatorDetails({
-                earningsReceiver: operator,
+                __deprecated_earningsReceiver: operator,
                 delegationApprover: address(0),
                 stakerOptOutWindowBlocks: 0
             }),

--- a/test/integration/User.t.sol
+++ b/test/integration/User.t.sol
@@ -244,7 +244,7 @@ contract User is Test {
         _log("registerAsOperator (core)");
 
         IDelegationManager.OperatorDetails memory details = IDelegationManager.OperatorDetails({
-            earningsReceiver: address(this),
+            __deprecated_earningsReceiver: address(this),
             delegationApprover: address(0),
             stakerOptOutWindowBlocks: 0
         });

--- a/test/mocks/DelegationMock.sol
+++ b/test/mocks/DelegationMock.sol
@@ -58,7 +58,7 @@ contract DelegationMock is IDelegationManager {
 
     function operatorDetails(address operator) external pure returns (OperatorDetails memory) {
         OperatorDetails memory returnValue = OperatorDetails({
-            earningsReceiver: operator,
+           __deprecated_earningsReceiver: operator,
             delegationApprover: operator,
             stakerOptOutWindowBlocks: 0
         });
@@ -171,8 +171,6 @@ contract DelegationMock is IDelegationManager {
         bool[] calldata receiveAsTokens
     ) external {}
 
-    function migrateQueuedWithdrawals(IStrategyManager.DeprecatedStruct_QueuedWithdrawal[] memory withdrawalsToQueue) external {}
-    
     // onlyDelegationManager functions in StrategyManager
     function addShares(
         IStrategyManager strategyManager,


### PR DESCRIPTION
Fixes tests and CI for the deprecated field of the OperatorDetails struct