### PR TITLE
fix: service manager storage layout

### DIFF
--- a/src/ServiceManagerBase.sol
+++ b/src/ServiceManagerBase.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.12;
 
-import {OwnableUpgradeable} from "@openzeppelin-upgrades/contracts/access/OwnableUpgradeable.sol";
 import {Initializable} from "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";
 import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
 import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
@@ -18,7 +17,7 @@ import {BitmapUtils} from "./libraries/BitmapUtils.sol";
  * This contract can be inherited from or simply used as a point-of-reference.
  * @author Layr Labs, Inc.
  */
-abstract contract ServiceManagerBase is OwnableUpgradeable, ServiceManagerBaseStorage {
+abstract contract ServiceManagerBase is ServiceManagerBaseStorage {
     using BitmapUtils for *;
 
     /// @notice when applied to a function, only allows the RegistryCoordinator to call it

--- a/src/ServiceManagerBaseStorage.sol
+++ b/src/ServiceManagerBaseStorage.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.12;
 
+import {OwnableUpgradeable} from "@openzeppelin-upgrades/contracts/access/OwnableUpgradeable.sol";
+
 import {IServiceManager} from "./interfaces/IServiceManager.sol";
 import {IRegistryCoordinator} from "./interfaces/IRegistryCoordinator.sol";
 import {IStakeRegistry} from "./interfaces/IStakeRegistry.sol";
@@ -13,7 +15,7 @@ import {IRewardsCoordinator} from "eigenlayer-contracts/src/contracts/interfaces
  * @author Layr Labs, Inc.
  * @notice This storage contract is separate from the logic to simplify the upgrade process.
  */
-abstract contract ServiceManagerBaseStorage is IServiceManager {
+abstract contract ServiceManagerBaseStorage is IServiceManager, OwnableUpgradeable {
     /**
      *
      *                            CONSTANTS AND IMMUTABLES


### PR DESCRIPTION
Updated inheritance such that the EigenDAServiceManager maintains its current storage layout. This broke in the separation of the ServiceManagerBase from its ServiceManagerBaseStorage