### PR TITLE
feat: emit QuorumCreated on initializeQuorum

### DIFF
--- a/src/StakeRegistry.sol
+++ b/src/StakeRegistry.sol
@@ -195,6 +195,7 @@ contract StakeRegistry is StakeRegistryStorage {
         StrategyParams[] memory _strategyParams
     ) public virtual onlyRegistryCoordinator {
         require(!_quorumExists(quorumNumber), "StakeRegistry.initializeQuorum: quorum already exists");
+        emit QuorumCreated(quorumNumber);
         _addStrategyParams(quorumNumber, _strategyParams);
         _setMinimumStakeForQuorum(quorumNumber, minimumStake);
 


### PR DESCRIPTION
I realized the event `QuorumCreated` is present on IStakeRegistry.sol, but is not emited on its implementation, StakeRegistry.sol.

Took the liberty to add it.

Thank you