### PR TITLE
feat: ejection policy change

### DIFF
--- a/src/EjectionManager.sol
+++ b/src/EjectionManager.sol
@@ -28,9 +28,6 @@ contract EjectionManager is IEjectionManager, OwnableUpgradeable{
     /// @notice Ratelimit parameters for each quorum
     mapping(uint8 => QuorumEjectionParams) public quorumEjectionParams;
 
-    /// @notice mapping from quorum number to operator stake cap percentage
-    mapping(uint8 => uint256) public operatorStakeCapPercent;
-
     constructor(
         IRegistryCoordinator _registryCoordinator,
         IStakeRegistry _stakeRegistry
@@ -49,8 +46,7 @@ contract EjectionManager is IEjectionManager, OwnableUpgradeable{
     function initialize(
         address _owner,
         address[] memory _ejectors,
-        QuorumEjectionParams[] memory _quorumEjectionParams,
-        uint256[] memory _operatorStakeCapPercent
+        QuorumEjectionParams[] memory _quorumEjectionParams
     ) external initializer {
         _transferOwnership(_owner);
         for(uint8 i = 0; i < _ejectors.length; i++) {
@@ -58,9 +54,6 @@ contract EjectionManager is IEjectionManager, OwnableUpgradeable{
         }
         for(uint8 i = 0; i < _quorumEjectionParams.length; i++) {
             _setQuorumEjectionParams(i, _quorumEjectionParams[i]);
-        }
-        for(uint8 i = 0; i < _operatorStakeCapPercent.length; i++) {
-            _setOperatorStakeCapPercent(i, _operatorStakeCapPercent[i]);
         }
     }
 
@@ -76,13 +69,7 @@ contract EjectionManager is IEjectionManager, OwnableUpgradeable{
         for(uint i = 0; i < _operatorIds.length; ++i) {
             uint8 quorumNumber = uint8(i);
 
-            (uint256 amountEjectable, uint256 totalQuorumStake) = amountEjectableForQuorum(quorumNumber);
-
-            uint256 operatorStakeCap = type(uint256).max;
-            if(operatorStakeCapPercent[quorumNumber] > 0) {
-                operatorStakeCap = operatorStakeCapPercent[quorumNumber] * totalQuorumStake / uint256(BIPS_DENOMINATOR);
-            }
-
+            uint256 amountEjectable = amountEjectableForQuorum(quorumNumber);
             uint256 stakeForEjection;
             uint32 ejectedOperators;
 
@@ -90,22 +77,24 @@ contract EjectionManager is IEjectionManager, OwnableUpgradeable{
             for(uint8 j = 0; j < _operatorIds[i].length; ++j) {
                 uint256 operatorStake = stakeRegistry.getCurrentStake(_operatorIds[i][j], quorumNumber);
 
-                if(operatorStake > operatorStakeCap) {
-                    emit OperatorStakeCapHit(_operatorIds[i][j], operatorStake, operatorStakeCap);
-                    operatorStake = operatorStakeCap;
-                }
-
                 //if caller is ejector enforce ratelimit
                 if(
                     isEjector[msg.sender] &&
                     quorumEjectionParams[quorumNumber].rateLimitWindow > 0 &&
                     stakeForEjection + operatorStake > amountEjectable
                 ){
-                    stakeEjectedForQuorum[quorumNumber].push(StakeEjection({
-                        timestamp: block.timestamp,
-                        stakeEjected: stakeForEjection
-                    }));
                     ratelimitHit = true;
+
+                    stakeForEjection += operatorStake;
+                    ++ejectedOperators;
+
+                    registryCoordinator.ejectOperator(
+                        registryCoordinator.getOperatorFromId(_operatorIds[i][j]),
+                        abi.encodePacked(quorumNumber)
+                    );
+
+                    emit OperatorEjected(_operatorIds[i][j], quorumNumber);
+
                     break;
                 }
 
@@ -121,7 +110,7 @@ contract EjectionManager is IEjectionManager, OwnableUpgradeable{
             }
 
             //record the stake ejected if ejector and ratelimit enforced
-            if(!ratelimitHit && isEjector[msg.sender]){
+            if(isEjector[msg.sender]){
                 stakeEjectedForQuorum[quorumNumber].push(StakeEjection({
                     timestamp: block.timestamp,
                     stakeEjected: stakeForEjection
@@ -150,15 +139,6 @@ contract EjectionManager is IEjectionManager, OwnableUpgradeable{
         _setEjector(_ejector, _status);
     }
 
-    /**
-     * @notice Sets the operator stake cap percent for a quorum
-     * @param _quorumNumber The quorum number to set the operator stake cap percent for
-     * @param _operatorStakeCapPercent The operator stake cap percent to set for the given quorum
-     */
-    function setOperatorStakeCapPercent(uint8 _quorumNumber, uint256 _operatorStakeCapPercent) external onlyOwner() {
-        _setOperatorStakeCapPercent(_quorumNumber, _operatorStakeCapPercent);
-    }
-
     ///@dev internal function to set the quorum ejection params
     function _setQuorumEjectionParams(uint8 _quorumNumber, QuorumEjectionParams memory _quorumEjectionParams) internal {
         quorumEjectionParams[_quorumNumber] = _quorumEjectionParams;
@@ -171,25 +151,17 @@ contract EjectionManager is IEjectionManager, OwnableUpgradeable{
         emit EjectorUpdated(_ejector, _status);
     }
 
-    /// @dev internal function to set the operator stake cap percent
-    function _setOperatorStakeCapPercent(uint8 _quorumNumber, uint256 _operatorStakeCapPercent) internal {
-        operatorStakeCapPercent[_quorumNumber] = _operatorStakeCapPercent;
-        emit OperatorStakeCapPercentSet(_quorumNumber, _operatorStakeCapPercent);
-    }
-
     /**
      * @notice Returns the amount of stake that can be ejected for a quorum at the current block.timestamp
      * @param _quorumNumber The quorum number to view ejectable stake for
      */
-    function amountEjectableForQuorum(uint8 _quorumNumber) public view returns (uint256 ejectableStake, uint256 totalStake) {
+    function amountEjectableForQuorum(uint8 _quorumNumber) public view returns (uint256) {
         uint256 cutoffTime = block.timestamp - quorumEjectionParams[_quorumNumber].rateLimitWindow;
-        totalStake = uint256(stakeRegistry.getCurrentTotalStake(_quorumNumber));
-        uint256 totalEjectable = uint256(quorumEjectionParams[_quorumNumber].ejectableStakePercent) * totalStake / uint256(BIPS_DENOMINATOR);
-
+        uint256 totalEjectable = uint256(quorumEjectionParams[_quorumNumber].ejectableStakePercent) * uint256(stakeRegistry.getCurrentTotalStake(_quorumNumber)) / uint256(BIPS_DENOMINATOR);
         uint256 totalEjected;
         uint256 i;
         if (stakeEjectedForQuorum[_quorumNumber].length == 0) {
-            return (totalEjectable, totalStake);
+            return totalEjectable;
         }
         i = stakeEjectedForQuorum[_quorumNumber].length - 1;
 
@@ -203,8 +175,8 @@ contract EjectionManager is IEjectionManager, OwnableUpgradeable{
         }
 
         if(totalEjected >= totalEjectable){
-            return (0, totalStake);
+            return 0;
         }
-        return (totalEjectable - totalEjected, totalStake);
+        return totalEjectable - totalEjected;
     }
 }

--- a/src/interfaces/IEjectionManager.sol
+++ b/src/interfaces/IEjectionManager.sol
@@ -27,6 +27,10 @@ interface IEjectionManager {
     event OperatorEjected(bytes32 operatorId, uint8 quorumNumber);
     ///@notice Emitted when operators are ejected for a quroum 
     event QuorumEjection(uint32 ejectedOperators, bool ratelimitHit);
+    ///@notice Emitted when the operator stake cap percent for a quorum is set
+    event OperatorStakeCapPercentSet(uint8 quorumNumber, uint256 operatorStakeCapPercent);
+    ///@notice Emitted when the operator stake cap is hit
+    event OperatorStakeCapHit(bytes32 operatorId, uint256 operatorStake, uint256 operatorStakeCap);
 
    /**
      * @notice Ejects operators from the AVSs registryCoordinator under a ratelimit
@@ -48,8 +52,15 @@ interface IEjectionManager {
     function setEjector(address _ejector, bool _status) external;
 
     /**
+     * @notice Sets the operator stake cap percent for a quorum
+     * @param _quorumNumber The quorum number to set the operator stake cap percent for
+     * @param _operatorStakeCapPercent The operator stake cap percent to set for the given quorum
+     */
+    function setOperatorStakeCapPercent(uint8 _quorumNumber, uint256 _operatorStakeCapPercent) external;
+
+    /**
      * @notice Returns the amount of stake that can be ejected for a quorum at the current block.timestamp
      * @param _quorumNumber The quorum number to view ejectable stake for
      */
-    function amountEjectableForQuorum(uint8 _quorumNumber) external view returns (uint256);
+    function amountEjectableForQuorum(uint8 _quorumNumber) external view returns (uint256 ejectableStake, uint256 totalStake);
 }

--- a/src/interfaces/IEjectionManager.sol
+++ b/src/interfaces/IEjectionManager.sol
@@ -27,10 +27,6 @@ interface IEjectionManager {
     event OperatorEjected(bytes32 operatorId, uint8 quorumNumber);
     ///@notice Emitted when operators are ejected for a quroum 
     event QuorumEjection(uint32 ejectedOperators, bool ratelimitHit);
-    ///@notice Emitted when the operator stake cap percent for a quorum is set
-    event OperatorStakeCapPercentSet(uint8 quorumNumber, uint256 operatorStakeCapPercent);
-    ///@notice Emitted when the operator stake cap is hit
-    event OperatorStakeCapHit(bytes32 operatorId, uint256 operatorStake, uint256 operatorStakeCap);
 
    /**
      * @notice Ejects operators from the AVSs registryCoordinator under a ratelimit
@@ -52,15 +48,8 @@ interface IEjectionManager {
     function setEjector(address _ejector, bool _status) external;
 
     /**
-     * @notice Sets the operator stake cap percent for a quorum
-     * @param _quorumNumber The quorum number to set the operator stake cap percent for
-     * @param _operatorStakeCapPercent The operator stake cap percent to set for the given quorum
-     */
-    function setOperatorStakeCapPercent(uint8 _quorumNumber, uint256 _operatorStakeCapPercent) external;
-
-    /**
      * @notice Returns the amount of stake that can be ejected for a quorum at the current block.timestamp
      * @param _quorumNumber The quorum number to view ejectable stake for
      */
-    function amountEjectableForQuorum(uint8 _quorumNumber) external view returns (uint256 ejectableStake, uint256 totalStake);
+    function amountEjectableForQuorum(uint8 _quorumNumber) external view returns (uint256);
 }

--- a/test/unit/EjectionManagerUnit.t.sol
+++ b/test/unit/EjectionManagerUnit.t.sol
@@ -12,17 +12,15 @@ contract EjectionManagerUnitTests is MockAVSDeployer {
     event EjectorUpdated(address ejector, bool status);
     event QuorumEjectionParamsSet(uint8 quorumNumber, uint32 rateLimitWindow, uint16 ejectableStakePercent);
     event OperatorEjected(bytes32 operatorId, uint8 quorumNumber);
-    event OperatorStakeCapHit(bytes32 operatorId, uint256 operatorStake, uint256 operatorStakeCap);
+    event FailedOperatorEjection(bytes32 operatorId, uint8 quorumNumber, bytes err);
 
     EjectionManager public ejectionManager;
     IEjectionManager public ejectionManagerImplementation;
 
     IEjectionManager.QuorumEjectionParams[] public quorumEjectionParams;
-    uint256[] public operatorStakeCapPercents;
 
     uint32 public ratelimitWindow = 1 days;
-    uint16 public ejectableStakePercent = 3300;
-    uint256 public operatorStakeCapPercent = 2000;
+    uint16 public ejectableStakePercent = 1000;
 
     function setUp() virtual public {
         for(uint8 i = 0; i < numQuorums; i++) {
@@ -30,7 +28,6 @@ contract EjectionManagerUnitTests is MockAVSDeployer {
                 rateLimitWindow: ratelimitWindow,
                 ejectableStakePercent: ejectableStakePercent
             }));
-            operatorStakeCapPercents.push(operatorStakeCapPercent);
         }
 
         defaultMaxOperatorCount = 200;
@@ -57,8 +54,7 @@ contract EjectionManagerUnitTests is MockAVSDeployer {
                 EjectionManager.initialize.selector,
                 registryCoordinatorOwner,
                 ejectors,
-                quorumEjectionParams,
-                operatorStakeCapPercents
+                quorumEjectionParams
             )
         );
 
@@ -131,7 +127,7 @@ contract EjectionManagerUnitTests is MockAVSDeployer {
     }
 
     function testEjectOperators_MultipleOperatorOutsideRatelimit() public {
-        uint8 operatorsCanEject = 3;
+        uint8 operatorsCanEject = 2;
         uint8 operatorsToEject = 10;
         uint8 numOperators = 10;
         uint96 stake = 1 ether;
@@ -391,29 +387,6 @@ contract EjectionManagerUnitTests is MockAVSDeployer {
         stakeRegistry.recordTotalStakeUpdate(1, 2_000_000_000 * 1 ether);
 
         ejectionManager.amountEjectableForQuorum(1);
-    }
-
-    function testOperatorStakeCapHit() public {
-        _registerOperaters(100, 1 ether);
-        BN254.G1Point memory pubKey = BN254.hashToG1(keccak256(abi.encodePacked(uint256(420))));
-        address operator = _incrementAddress(defaultOperator, 420);
-        _registerOperatorWithCoordinator(operator, MAX_QUORUM_BITMAP, pubKey, 100 ether);
-
-        bytes32[][] memory operatorIds = new bytes32[][](numQuorums);
-        for (uint8 i = 0; i < numQuorums; i++) {
-            operatorIds[i] = new bytes32[](1);
-            operatorIds[i][0] = registryCoordinator.getOperatorId(operator);
-        }
-
-        for(uint8 i = 0; i < numQuorums; i++) {
-            cheats.expectEmit(true, true, true, true, address(ejectionManager));
-            emit OperatorStakeCapHit(operatorIds[i][0], 100 ether, 40 ether); //total stake 200 ether at 20% stake cap is 40 ether
-            cheats.expectEmit(true, true, true, true, address(ejectionManager));
-            emit OperatorEjected(operatorIds[i][0], i);
-        }
-
-        cheats.prank(ejector);
-        ejectionManager.ejectOperators(operatorIds);
     }
 
     function _registerOperaters(uint8 numOperators, uint96 stake) internal {


### PR DESCRIPTION
Changes the EjectionManager behavior to eject the operator that trips the ratelimit but no further