### PR TITLE
remove socket migration

### DIFF
--- a/src/SocketRegistry.sol
+++ b/src/SocketRegistry.sol
@@ -37,13 +37,6 @@ contract SocketRegistry is ISocketRegistry {
         operatorIdToSocket[_operatorId] = _socket;
     }
 
-    /// @notice migrates the sockets for a list of operators only callable by the owner of the RegistryCoordinator
-    function migrateOperatorSockets(bytes32[] memory _operatorIds, string[] memory _sockets) external onlyCoordinatorOwner {
-        for (uint256 i = 0; i < _operatorIds.length; i++) {
-            operatorIdToSocket[_operatorIds[i]] = _sockets[i];
-        }
-    }
-
     /// @notice gets the stored socket for an operator
     function getOperatorSocket(bytes32 _operatorId) external view returns (string memory) {
         return operatorIdToSocket[_operatorId];

--- a/test/unit/SocketRegistryUnit.t.sol
+++ b/test/unit/SocketRegistryUnit.t.sol
@@ -24,26 +24,4 @@ contract SocketRegistryUnitTests is MockAVSDeployer {
         socketRegistry.setOperatorSocket(defaultOperatorId, "testSocket");
     }
 
-    function test_migrateOperatorSockets() public {
-        bytes32[] memory operatorIds = new bytes32[](1);
-        operatorIds[0] = defaultOperatorId;
-        string[] memory sockets = new string[](1);
-        sockets[0] = "testSocket";
-
-        vm.startPrank(registryCoordinator.owner());
-        socketRegistry.migrateOperatorSockets(operatorIds, sockets);
-        assertEq(socketRegistry.getOperatorSocket(defaultOperatorId), "testSocket");
-    }
-
-    function test_migrateOperatorSockets_revert_notCoordinatorOwner() public {
-        bytes32[] memory operatorIds = new bytes32[](1);
-        operatorIds[0] = defaultOperatorId;
-        string[] memory sockets = new string[](1);
-        sockets[0] = "testSocket";
-
-        vm.startPrank(address(0));
-        vm.expectRevert("SocketRegistry.onlyCoordinatorOwner: caller is not the owner of the registryCoordinator");
-        socketRegistry.migrateOperatorSockets(operatorIds, sockets);
-    }
-
 }


### PR DESCRIPTION
sockets are no longer being migrated to socket registry by DA governance