### PR TITLE
Fix typographical errors

### DIFF
--- a/src/interfaces/IBLSSignatureChecker.sol
+++ b/src/interfaces/IBLSSignatureChecker.sol
@@ -8,7 +8,7 @@ import {IStakeRegistry, IDelegationManager} from "./IStakeRegistry.sol";
 import {BN254} from "../libraries/BN254.sol";
 
 /**
- * @title Used for checking BLS aggregate signatures from the operators of a EigenLayer AVS with the RegistryCoordinator/BLSApkRegistry/StakeRegistry architechture.
+ * @title Used for checking BLS aggregate signatures from the operators of a EigenLayer AVS with the RegistryCoordinator/BLSApkRegistry/StakeRegistry architecture.
  * @author Layr Labs, Inc.
  * @notice Terms of Service: https://docs.eigenlayer.xyz/overview/terms-of-service
  * @notice This is the contract for checking the validity of aggregate operator signatures.

--- a/src/interfaces/IECDSAStakeRegistryEventsAndErrors.sol
+++ b/src/interfaces/IECDSAStakeRegistryEventsAndErrors.sol
@@ -106,6 +106,6 @@ interface ECDSAStakeRegistryEventsAndErrors {
     /// @notice Thrown when registering an already registered operator
     error OperatorAlreadyRegistered();
 
-    /// @notice Thrown when de-registering or updating the stake for an unregisted operator
+    /// @notice Thrown when de-registering or updating the stake for an unregistered operator
     error OperatorNotRegistered();
 }

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -170,7 +170,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
         EigenPodManager eigenPodManagerImplementation = new EigenPodManager(
             ethPOSDeposit, eigenPodBeacon, strategyManager, slasher, delegationManager
         );
-        AVSDirectory avsDirectoryImplemntation = new AVSDirectory(delegationManager);
+        AVSDirectory avsDirectoryImplementation = new AVSDirectory(delegationManager);
         // RewardsCoordinator rewardsCoordinatorImplementation = new RewardsCoordinator(
         //     delegationManager,
         //     IStrategyManager(address(strategyManager)),
@@ -235,7 +235,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
         // AVSDirectory
         proxyAdmin.upgradeAndCall(
             TransparentUpgradeableProxy(payable(address(avsDirectory))),
-            address(avsDirectoryImplemntation),
+            address(avsDirectoryImplementation),
             abi.encodeWithSelector(
                 AVSDirectory.initialize.selector,
                 eigenLayerReputedMultisig, // initialOwner

--- a/test/unit/IndexRegistryUnit.t.sol
+++ b/test/unit/IndexRegistryUnit.t.sol
@@ -39,7 +39,7 @@ contract IndexRegistryUnitTests is MockAVSDeployer, IIndexRegistryEvents {
 
         bitmapUtilsWrapper = new BitmapUtilsWrapper();
 
-        // Initialize quorums and set initailizedQuorumBitmap
+        // Initialize quorums and set initializedQuorumBitmap
         _initializeQuorum();
         _initializeQuorum();
         _initializeQuorum();
@@ -74,7 +74,7 @@ contract IndexRegistryUnitTests is MockAVSDeployer, IIndexRegistryEvents {
     }
 
     /// @dev initializeQuorum based on passed in bitmap of quorum numbers
-    /// assumes that bitmap does not contain already initailized quorums and doesn't increment nextQuorum
+    /// assumes that bitmap does not contain already initialized quorums and doesn't increment nextQuorum
     function _initializeFuzzedQuorums(uint192 bitmap) internal {
         bytes memory quorumNumbers = bitmapUtilsWrapper.bitmapToBytesArray(bitmap);
 

--- a/test/unit/RegistryCoordinatorUnit.t.sol
+++ b/test/unit/RegistryCoordinatorUnit.t.sol
@@ -120,7 +120,7 @@ contract RegistryCoordinatorUnitTests_Initialization_Setters is RegistryCoordina
             );
         }
 
-        // make sure the contract intializers are disabled
+        // make sure the contract initializers are disabled
         cheats.expectRevert(bytes("Initializable: contract is already initialized"));
         registryCoordinator.initialize(
             registryCoordinatorOwner,


### PR DESCRIPTION
1. **IBLSSignatureChecker.sol**  
   - Fixed spelling of "reprensenting" to "representing" in comments.

2. **IECDSAStakeRegistryEventsAndErrors.sol**  
   - Corrected "unregisted" to "unregistered" in error messages.

3. **IntegrationDeployer.t.sol**  
   - Fixed typo "avsDirectoryImplemntation" to "avsDirectoryImplementation" in multiple places.

4. **IndexRegistryUnit.t.sol**  
   - Corrected "initailizedQuorum" to "initializedQuorum" in comments and function descriptions.

5. **RegistryCoordinatorUnit.t.sol**  
   - Fixed typo "intializers" to "initializers" in comments.