### PR TITLE
Typo fix g2mul.go

### DIFF
--- a/test/ffi/go/g2mul.go
+++ b/test/ffi/go/g2mul.go
@@ -38,7 +38,7 @@ func main() {
 	pyssInt := new(big.Int)
 	pyssInt, _ = pyssInt.SetString(pyss[0], 10)
 
-	//swtich to print coord requested
+	//switch to print coord requested
 	switch os.Args[2] {
 	case "1":
 		fmt.Printf("0x%064X", pxsInt)


### PR DESCRIPTION
### Pull Request Title  
Fix Typos in g2mul.go  

---

### Description  
This pull request fixes two typos in the `g2mul.go` file located in the `test/ffi/go/` directory.  

- **Original:** `swtich`  
- **Corrected:** `switch`  

