### PR TITLE
fix: remove unused OnlySlasher error

### DIFF
--- a/src/interfaces/IServiceManager.sol
+++ b/src/interfaces/IServiceManager.sol
@@ -19,8 +19,6 @@ interface IServiceManagerErrors {
     error OnlyRewardsInitiator();
     /// @notice Thrown when a function is called by an address that is not the StakeRegistry.
     error OnlyStakeRegistry();
-    /// @notice Thrown when a function is called by an address that is not the Slasher.
-    error OnlySlasher();
     /// @notice Thrown when a slashing proposal delay has not been met yet.
     error DelayPeriodNotPassed();
 }


### PR DESCRIPTION
## Overview
This pull request makes a small but important update to the IServiceManager.sol file, specifically within the IServiceManagerErrors interface. It removes the OnlySlasher error definition to resolve a conflict caused by having the same error identifier in another interface.

## Error Details

```
Error (9097): Identifier already declared.
  --> lib/eigenlayer-middleware/src/interfaces/IServiceManager.sol:23:5:
   |
23 |     error OnlySlasher();
   |     ^^^^^^^^^^^^^^^^^^^^
```

This error indicates that the `OnlySlasher` identifier has been declared more than once across the inherited interfaces, which is not permissible in Solidity.

## Resolution
The duplication occurs because `IServiceManagerErrors` and `ISlasherErrors` both declare the `OnlySlasher` error. To resolve this, we can remove the declaration from `IServiceManagerErrors`.