### PR TITLE
refactor: VetoableSlasher

### DIFF
--- a/src/slashers/VetoableSlasher.sol
+++ b/src/slashers/VetoableSlasher.sol
@@ -20,8 +20,7 @@ contract VetoableSlasher is SlasherBase {
 
     constructor(
         IAllocationManager _allocationManager,
-        ISlashingRegistryCoordinator _slashingRegistryCoordinator,
-        address _slasher
+        ISlashingRegistryCoordinator _slashingRegistryCoordinator
     ) SlasherBase(_allocationManager, _slashingRegistryCoordinator) {}
 
     function initialize(address _vetoCommittee, address _slasher) external virtual initializer {

--- a/src/slashers/VetoableSlasher.sol
+++ b/src/slashers/VetoableSlasher.sol
@@ -29,7 +29,7 @@ contract VetoableSlasher is SlasherBase {
     }
 
     function queueSlashingRequest(
-        IAllocationManager.SlashingParams memory params
+        IAllocationManager.SlashingParams calldata params
     ) external virtual onlySlasher {
         _queueSlashingRequest(params);
     }
@@ -62,7 +62,7 @@ contract VetoableSlasher is SlasherBase {
     }
 
     function _queueSlashingRequest(
-        IAllocationManager.SlashingParams memory params
+        IAllocationManager.SlashingParams calldata params
     ) internal virtual {
         uint256 requestId = nextRequestId++;
         slashingRequests[requestId] = SlashingRequest({


### PR DESCRIPTION
This pull request includes changes to the `VetoableSlasher` contract in the `src/slashers/VetoableSlasher.sol` file. The most important changes involve modifying function parameters and the constructor.

Changes to function parameters and constructor:

* Removed the `_slasher` parameter from the constructor of `VetoableSlasher` (`src/slashers/VetoableSlasher.sol`).
* Changed the `params` parameter from `memory` to `calldata` in the `queueSlashingRequest` function (`src/slashers/VetoableSlasher.sol`).
* Changed the `params` parameter from `memory` to `calldata` in the `_queueSlashingRequest` function (`src/slashers/VetoableSlasher.sol`).