### PR TITLE
test: integration with slashingRegistryCoordinator

### DIFF
--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -2,8 +2,10 @@
 pragma solidity ^0.8.27;
 
 import {IPauserRegistry} from "eigenlayer-contracts/src/contracts/interfaces/IPauserRegistry.sol";
-import {IAllocationManager} from
-    "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {
+    IAllocationManager,
+    OperatorSet
+} from "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 import {IBLSApkRegistry, IBLSApkRegistryTypes} from "./interfaces/IBLSApkRegistry.sol";
 import {IStakeRegistry} from "./interfaces/IStakeRegistry.sol";
 import {IIndexRegistry} from "./interfaces/IIndexRegistry.sol";
@@ -198,6 +200,44 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
         // them from the AVS via the EigenLayer core contracts
         if (operatorM2QuorumBitmap.isEmpty()) {
             serviceManager.deregisterOperatorFromAVS(operator);
+        }
+    }
+
+    /**
+     * @dev Helper function to update operator stakes and deregister loiterers
+     * Loiterers are AVS registered operators who have force deregistered from the OperatorSet/quorum
+     * in the core EigenLayer contract AllocationManager but not deregistered from the OperatorSet/quorum
+     * in this contract. Potentially due to out of gas errors in the deregistration callback. This function
+     * will handle that edge case by deregistering the operator from the AVS if they are no longer registered
+     * in the AllocationManager.
+     */
+    function _updateStakesAndDeregisterLoiterers(
+        address[] memory operators,
+        bytes32[] memory operatorIds,
+        uint8 quorumNumber
+    ) internal virtual override {
+        bytes memory singleQuorumNumber = new bytes(1);
+        singleQuorumNumber[0] = bytes1(quorumNumber);
+        bool[] memory doesNotMeetStakeThreshold =
+            stakeRegistry.updateOperatorsStake(operators, operatorIds, quorumNumber);
+        for (uint256 j = 0; j < operators.length; ++j) {
+            // whether the operator is registered in the core EigenLayer contract AllocationManager
+            bool registeredInCore = allocationManager.isMemberOfOperatorSet(
+                operators[j], OperatorSet({avs: accountIdentifier, id: uint32(quorumNumber)})
+            );
+
+            // If the operator does not have the minimum stake, they need to be force deregistered.
+            // Additionally, it is possible for an operator to have deregistered from an OperatorSet
+            // in the core EigenLayer contract AllocationManager but not have the deregistration
+            // callback succeed here in `deregisterOperator` due to out of gas errors. If that is the case,
+            // we need to deregister the operator from the OperatorSet in this contract
+            if (doesNotMeetStakeThreshold[j] || (!registeredInCore && !_isM2Quorum(quorumNumber))) {
+                _deregisterOperator({
+                    operator: operators[j],
+                    quorumNumbers: singleQuorumNumber,
+                    shouldForceDeregister: registeredInCore && !_isM2Quorum(quorumNumber)
+                });
+            }
         }
     }
 

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -220,22 +220,31 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
         singleQuorumNumber[0] = bytes1(quorumNumber);
         bool[] memory doesNotMeetStakeThreshold =
             stakeRegistry.updateOperatorsStake(operators, operatorIds, quorumNumber);
-        for (uint256 j = 0; j < operators.length; ++j) {
-            // whether the operator is registered in the core EigenLayer contract AllocationManager
-            bool registeredInCore = allocationManager.isMemberOfOperatorSet(
-                operators[j], OperatorSet({avs: accountIdentifier, id: uint32(quorumNumber)})
-            );
 
+        for (uint256 j = 0; j < operators.length; ++j) {
+            bool isM2Quorum = _isM2Quorum(quorumNumber);
+            bool registeredInCore;
+            // If its an operatorSet quorum, its possible for registeredInCore to be true/false
+            // so check for operatorSet inclusion in the AllocationManager
+            if (!isM2Quorum) {
+                registeredInCore = allocationManager.isMemberOfOperatorSet(
+                    operators[j], OperatorSet({avs: accountIdentifier, id: uint32(quorumNumber)})
+                );
+            }
+
+            // Determine if the operator should be deregistered
             // If the operator does not have the minimum stake, they need to be force deregistered.
             // Additionally, it is possible for an operator to have deregistered from an OperatorSet
             // in the core EigenLayer contract AllocationManager but not have the deregistration
             // callback succeed here in `deregisterOperator` due to out of gas errors. If that is the case,
             // we need to deregister the operator from the OperatorSet in this contract
-            if (doesNotMeetStakeThreshold[j] || (!registeredInCore && !_isM2Quorum(quorumNumber))) {
+            bool shouldDeregister = doesNotMeetStakeThreshold[j] || (!registeredInCore && !isM2Quorum);
+            
+            if (shouldDeregister) {
                 _deregisterOperator({
                     operator: operators[j],
                     quorumNumbers: singleQuorumNumber,
-                    shouldForceDeregister: registeredInCore && !_isM2Quorum(quorumNumber)
+                    shouldForceDeregister: registeredInCore
                 });
             }
         }

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -238,8 +238,9 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
             // in the core EigenLayer contract AllocationManager but not have the deregistration
             // callback succeed here in `deregisterOperator` due to out of gas errors. If that is the case,
             // we need to deregister the operator from the OperatorSet in this contract
-            bool shouldDeregister = doesNotMeetStakeThreshold[j] || (!registeredInCore && !isM2Quorum);
-            
+            bool shouldDeregister =
+                doesNotMeetStakeThreshold[j] || (!registeredInCore && !isM2Quorum);
+
             if (shouldDeregister) {
                 _deregisterOperator({
                     operator: operators[j],

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -221,14 +221,14 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
         bool[] memory doesNotMeetStakeThreshold =
             stakeRegistry.updateOperatorsStake(operators, operatorIds, quorumNumber);
 
-        for (uint256 j = 0; j < operators.length; ++j) {
+        for (uint256 i = 0; i < operators.length; ++i) {
             bool isM2Quorum = _isM2Quorum(quorumNumber);
             bool registeredInCore;
             // If its an operatorSet quorum, its possible for registeredInCore to be true/false
             // so check for operatorSet inclusion in the AllocationManager
             if (!isM2Quorum) {
                 registeredInCore = allocationManager.isMemberOfOperatorSet(
-                    operators[j], OperatorSet({avs: accountIdentifier, id: uint32(quorumNumber)})
+                    operators[i], OperatorSet({avs: accountIdentifier, id: uint32(quorumNumber)})
                 );
             }
 
@@ -239,11 +239,11 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
             // callback succeed here in `deregisterOperator` due to out of gas errors. If that is the case,
             // we need to deregister the operator from the OperatorSet in this contract
             bool shouldDeregister =
-                doesNotMeetStakeThreshold[j] || (!registeredInCore && !isM2Quorum);
+                doesNotMeetStakeThreshold[i] || (!registeredInCore && !isM2Quorum);
 
             if (shouldDeregister) {
                 _deregisterOperator({
-                    operator: operators[j],
+                    operator: operators[i],
                     quorumNumbers: singleQuorumNumber,
                     shouldForceDeregister: registeredInCore
                 });

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -132,7 +132,11 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
             OnlyM2QuorumsAllowed()
         );
 
-        _deregisterOperator({operator: msg.sender, quorumNumbers: quorumNumbers});
+        _deregisterOperator({
+            operator: msg.sender,
+            quorumNumbers: quorumNumbers,
+            shouldForceDeregister: false
+        });
     }
 
     /// @inheritdoc IRegistryCoordinator

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -252,13 +252,24 @@ contract SlashingRegistryCoordinator is
                     singleOperator, singleOperatorId, quorumNumber
                 );
 
-                if (shouldBeDeregistered[0]) {
+                // whether the operator is registered in the core EigenLayer contract AllocationManager
+                bool registeredInCore = allocationManager.isMemberOfOperatorSet(
+                    operators[i], OperatorSet({avs: accountIdentifier, id: uint32(quorumNumber)})
+                );
+
+                // If the operator does not have the minimum stake, they need to be force deregistered.
+                // Additionally, it is possible for an operator to have deregistered from an OperatorSet
+                // in the core EigenLayer contract AllocationManager but not have the deregistration
+                // callback succeed here in `deregisterOperator` due to out of gas errors. If that is the case,
+                // we need to deregister the operator from the OperatorSet in this contract
+                if (shouldBeDeregistered[0] || !registeredInCore) {
+                    // The operator should be deregistered from this quorum
                     bytes memory singleQuorumNumber = new bytes(1);
                     singleQuorumNumber[0] = quorumNumbers[j];
                     _deregisterOperator({
                         operator: operators[i],
                         quorumNumbers: singleQuorumNumber,
-                        shouldForceDeregister: true
+                        shouldForceDeregister: registeredInCore
                     });
                 }
             }
@@ -612,6 +623,9 @@ contract SlashingRegistryCoordinator is
     /**
      * @notice Helper function to handle operator set deregistration for OperatorSets quorums. This is used
      * when an operator is force-deregistered from a set of quorums.
+     * Due to deregistration being possible in the AllocationManager but not in the AVS as a result of the
+     * try/catch in `AllocationManager.deregisterFromOperatorSets`, we need to first check that the operator
+     * is not already deregistered from the OperatorSet in the AllocationManager.
      * @param operator The operator to deregister
      * @param quorumNumbers The quorum numbers the operator is force-deregistered from
      */
@@ -619,6 +633,25 @@ contract SlashingRegistryCoordinator is
         address operator,
         bytes memory quorumNumbers
     ) internal virtual {
+        uint32[] memory operatorSetIds = new uint32[](quorumNumbers.length);
+        uint256 numDeregister = 0;
+        for (uint256 i = 0; i < quorumNumbers.length; ++i) {
+            uint32 operatorSetId = uint32(uint8(quorumNumbers[i]));
+            if (
+                allocationManager.isMemberOfOperatorSet(
+                    operator, OperatorSet({avs: accountIdentifier, id: operatorSetId})
+                )
+            ) {
+                operatorSetIds[numDeregister] = operatorSetId;
+                numDeregister++;
+            }
+        }
+
+        // resize operatorSetIds array length to numDeregister
+        assembly {
+            mstore(operatorSetIds, numDeregister)
+        }
+
         allocationManager.deregisterFromOperatorSets(
             IAllocationManagerTypes.DeregisterParams({
                 operator: operator,

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -247,31 +247,11 @@ contract SlashingRegistryCoordinator is
             bytes memory quorumNumbers = currentBitmap.bitmapToBytesArray();
             for (uint256 j = 0; j < quorumNumbers.length; j++) {
                 // update the operator's stake for each quorum
-                uint8 quorumNumber = uint8(quorumNumbers[j]);
-                bool[] memory shouldBeDeregistered = stakeRegistry.updateOperatorsStake(
-                    singleOperator, singleOperatorId, quorumNumber
+                _updateStakesAndDeregisterLoiterers(
+                    singleOperator,
+                    singleOperatorId,
+                    uint8(quorumNumbers[j])
                 );
-
-                // whether the operator is registered in the core EigenLayer contract AllocationManager
-                bool registeredInCore = allocationManager.isMemberOfOperatorSet(
-                    operators[i], OperatorSet({avs: accountIdentifier, id: uint32(quorumNumber)})
-                );
-
-                // If the operator does not have the minimum stake, they need to be force deregistered.
-                // Additionally, it is possible for an operator to have deregistered from an OperatorSet
-                // in the core EigenLayer contract AllocationManager but not have the deregistration
-                // callback succeed here in `deregisterOperator` due to out of gas errors. If that is the case,
-                // we need to deregister the operator from the OperatorSet in this contract
-                if (shouldBeDeregistered[0] || !registeredInCore) {
-                    // The operator should be deregistered from this quorum
-                    bytes memory singleQuorumNumber = new bytes(1);
-                    singleQuorumNumber[0] = quorumNumbers[j];
-                    _deregisterOperator({
-                        operator: operators[i],
-                        quorumNumbers: singleQuorumNumber,
-                        shouldForceDeregister: registeredInCore
-                    });
-                }
             }
         }
     }
@@ -322,17 +302,11 @@ contract SlashingRegistryCoordinator is
                 prevOperatorAddress = operator;
             }
 
-            bool[] memory shouldBeDeregistered =
-                stakeRegistry.updateOperatorsStake(currQuorumOperators, operatorIds, quorumNumber);
-            for (uint256 j = 0; j < currQuorumOperators.length; ++j) {
-                if (shouldBeDeregistered[j]) {
-                    _deregisterOperator({
-                        operator: currQuorumOperators[j],
-                        quorumNumbers: quorumNumbers[i:i + 1],
-                        shouldForceDeregister: true
-                    });
-                }
-            }
+            _updateStakesAndDeregisterLoiterers(
+                currQuorumOperators,
+                operatorIds,
+                quorumNumber
+            );
 
             // Update timestamp that all operators in quorum have been updated all at once
             quorumUpdateBlockNumber[quorumNumber] = block.number;
@@ -659,6 +633,36 @@ contract SlashingRegistryCoordinator is
                 operatorSetIds: _getOperatorSetIds(quorumNumbers)
             })
         );
+    }
+
+    function _updateStakesAndDeregisterLoiterers(
+        address[] memory operators,
+        bytes32[] memory operatorIds,
+        uint8 quorumNumber
+    ) internal {
+        bytes memory singleQuorumNumber = new bytes(1);
+        singleQuorumNumber[0] = bytes1(quorumNumber);
+        bool[] memory doesNotMeetStakeThreshold =
+            stakeRegistry.updateOperatorsStake(operators, operatorIds, quorumNumber);
+        for (uint256 j = 0; j < operators.length; ++j) {
+            // whether the operator is registered in the core EigenLayer contract AllocationManager
+            bool registeredInCore = allocationManager.isMemberOfOperatorSet(
+                operators[j], OperatorSet({avs: accountIdentifier, id: uint32(quorumNumber)})
+            );
+
+            // If the operator does not have the minimum stake, they need to be force deregistered.
+            // Additionally, it is possible for an operator to have deregistered from an OperatorSet
+            // in the core EigenLayer contract AllocationManager but not have the deregistration
+            // callback succeed here in `deregisterOperator` due to out of gas errors. If that is the case,
+            // we need to deregister the operator from the OperatorSet in this contract
+            if (doesNotMeetStakeThreshold[j] || !registeredInCore) {
+                _deregisterOperator({
+                    operator: operators[j],
+                    quorumNumbers: singleQuorumNumber,
+                    shouldForceDeregister: true
+                });
+            }
+        }
     }
 
     /**

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -225,7 +225,11 @@ contract SlashingRegistryCoordinator is
         uint32[] memory operatorSetIds
     ) external override onlyAllocationManager onlyWhenNotPaused(PAUSED_DEREGISTER_OPERATOR) {
         bytes memory quorumNumbers = _getQuorumNumbers(operatorSetIds);
-        _deregisterOperator(operator, quorumNumbers);
+        _deregisterOperator({
+            operator: operator,
+            quorumNumbers: quorumNumbers,
+            shouldForceDeregister: false
+        });
     }
 
     /// @inheritdoc ISlashingRegistryCoordinator
@@ -251,7 +255,11 @@ contract SlashingRegistryCoordinator is
                 if (shouldBeDeregistered[0]) {
                     bytes memory singleQuorumNumber = new bytes(1);
                     singleQuorumNumber[0] = quorumNumbers[j];
-                    _deregisterOperator(operators[i], singleQuorumNumber);
+                    _deregisterOperator({
+                        operator: operators[i],
+                        quorumNumbers: singleQuorumNumber,
+                        shouldForceDeregister: true
+                    });
                 }
             }
         }
@@ -307,7 +315,11 @@ contract SlashingRegistryCoordinator is
                 stakeRegistry.updateOperatorsStake(currQuorumOperators, operatorIds, quorumNumber);
             for (uint256 j = 0; j < currQuorumOperators.length; ++j) {
                 if (shouldBeDeregistered[j]) {
-                    _deregisterOperator(currQuorumOperators[j], quorumNumbers[i:i + 1]);
+                    _deregisterOperator({
+                        operator: currQuorumOperators[j],
+                        quorumNumbers: quorumNumbers[i:i + 1],
+                        shouldForceDeregister: true
+                    });
                 }
             }
 
@@ -344,7 +356,11 @@ contract SlashingRegistryCoordinator is
             operatorInfo.status == OperatorStatus.REGISTERED && !quorumsToRemove.isEmpty()
                 && quorumsToRemove.isSubsetOf(currentBitmap)
         ) {
-            _deregisterOperator({operator: operator, quorumNumbers: quorumNumbers});
+            _deregisterOperator({
+                operator: operator,
+                quorumNumbers: quorumNumbers,
+                shouldForceDeregister: true
+            });
         }
     }
 
@@ -522,7 +538,11 @@ contract SlashingRegistryCoordinator is
 
                 bytes memory singleQuorumNumber = new bytes(1);
                 singleQuorumNumber[0] = quorumNumbers[i];
-                _deregisterOperator(operatorKickParams[i].operator, singleQuorumNumber);
+                _deregisterOperator({
+                    operator: operatorKickParams[i].operator,
+                    quorumNumbers: singleQuorumNumber,
+                    shouldForceDeregister: true
+                });
             }
         }
     }
@@ -531,8 +551,16 @@ contract SlashingRegistryCoordinator is
      * @dev Deregister the operator from one or more quorums
      * This method updates the operator's quorum bitmap and status, then deregisters
      * the operator with the BLSApkRegistry, IndexRegistry, and StakeRegistry
+     * @param operator the operator to deregister
+     * @param quorumNumbers the quorum numbers to deregister from
+     * @param shouldForceDeregister whether the operator needs to be deregistered from the OperatorSets of
+     * the core EigenLayer contract AllocationManager
      */
-    function _deregisterOperator(address operator, bytes memory quorumNumbers) internal virtual {
+    function _deregisterOperator(
+        address operator,
+        bytes memory quorumNumbers,
+        bool shouldForceDeregister
+    ) internal virtual {
         // Fetch the operator's info and ensure they are registered
         OperatorInfo storage operatorInfo = _operatorInfo[operator];
         bytes32 operatorId = operatorInfo.operatorId;
@@ -571,8 +599,9 @@ contract SlashingRegistryCoordinator is
         stakeRegistry.deregisterOperator(operatorId, quorumNumbers);
         indexRegistry.deregisterOperator(operatorId, quorumNumbers);
 
-        // If the caller is not the allocationManager, then this is a force deregistration not consented by the operator
-        if (msg.sender != address(allocationManager)) {
+        // If the operator is not deregistered from the EigenLayer core protocol, then we need to force deregister them
+        // from their respective OperatorSets in the AllocationManager
+        if (shouldForceDeregister) {
             _forceDeregisterOperator(operator, quorumNumbers);
         }
 

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -659,7 +659,7 @@ contract SlashingRegistryCoordinator is
                 _deregisterOperator({
                     operator: operators[j],
                     quorumNumbers: singleQuorumNumber,
-                    shouldForceDeregister: true
+                    shouldForceDeregister: registeredInCore
                 });
             }
         }

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -629,11 +629,19 @@ contract SlashingRegistryCoordinator is
         );
     }
 
+    /**
+     * @dev Helper function to update operator stakes and deregister loiterers
+     * Loiterers are AVS registered operators who have force deregistered from the OperatorSet/quorum
+     * in the core EigenLayer contract AllocationManager but not deregistered from the OperatorSet/quorum
+     * in this contract. Potentially due to out of gas errors in the deregistration callback. This function
+     * will handle that edge case by deregistering the operator from the AVS if they are no longer registered
+     * in the AllocationManager.
+     */
     function _updateStakesAndDeregisterLoiterers(
         address[] memory operators,
         bytes32[] memory operatorIds,
         uint8 quorumNumber
-    ) internal {
+    ) internal virtual {
         bytes memory singleQuorumNumber = new bytes(1);
         singleQuorumNumber[0] = bytes1(quorumNumber);
         bool[] memory doesNotMeetStakeThreshold =

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -248,9 +248,7 @@ contract SlashingRegistryCoordinator is
             for (uint256 j = 0; j < quorumNumbers.length; j++) {
                 // update the operator's stake for each quorum
                 _updateStakesAndDeregisterLoiterers(
-                    singleOperator,
-                    singleOperatorId,
-                    uint8(quorumNumbers[j])
+                    singleOperator, singleOperatorId, uint8(quorumNumbers[j])
                 );
             }
         }
@@ -302,11 +300,7 @@ contract SlashingRegistryCoordinator is
                 prevOperatorAddress = operator;
             }
 
-            _updateStakesAndDeregisterLoiterers(
-                currQuorumOperators,
-                operatorIds,
-                quorumNumber
-            );
+            _updateStakesAndDeregisterLoiterers(currQuorumOperators, operatorIds, quorumNumber);
 
             // Update timestamp that all operators in quorum have been updated all at once
             quorumUpdateBlockNumber[quorumNumber] = block.number;

--- a/src/interfaces/IInstantSlasher.sol
+++ b/src/interfaces/IInstantSlasher.sol
@@ -9,12 +9,6 @@ import {ISlasher} from "./ISlasher.sol";
 /// @notice A slashing contract that immediately executes slashing requests without any delay or veto period
 /// @dev Extends base interfaces to provide access controlled slashing functionality
 interface IInstantSlasher is ISlasher {
-    /// @notice Initializes the contract with a slasher address
-    /// @param _slasher Address authorized to create and fulfill slashing requests
-    function initialize(
-        address _slasher
-    ) external;
-
     /// @notice Immediately executes a slashing request
     /// @param _slashingParams Parameters defining the slashing request including operator and amount
     /// @dev Can only be called by the authorized slasher

--- a/src/interfaces/ISlasher.sol
+++ b/src/interfaces/ISlasher.sol
@@ -33,4 +33,7 @@ interface ISlasherEvents is ISlasherTypes {
 interface ISlasher is ISlasherErrors, ISlasherEvents {
     /// @notice Returns the address authorized to create and fulfill slashing requests
     function slasher() external view returns (address);
+
+    /// @notice Returns the next slashing request ID
+    function nextRequestId() external view returns (uint256);
 }

--- a/src/interfaces/IVetoableSlasher.sol
+++ b/src/interfaces/IVetoableSlasher.sol
@@ -63,11 +63,6 @@ interface IVetoableSlasher is
     /// @notice Address of the committee that has veto power over slashing requests
     function vetoCommittee() external view returns (address);
 
-    /// @notice Initializes the contract with a veto committee and slasher address
-    /// @param _vetoCommittee Address of the committee that can veto slashing requests
-    /// @param _slasher Address authorized to create and fulfill slashing requests
-    function initialize(address _vetoCommittee, address _slasher) external;
-
     /// @notice Queues a new slashing request
     /// @param params Parameters defining the slashing request including operator and amount
     /// @dev Can only be called by the authorized slasher

--- a/src/interfaces/IVetoableSlasher.sol
+++ b/src/interfaces/IVetoableSlasher.sol
@@ -29,7 +29,7 @@ interface IVetoableSlasherTypes {
     /// @notice Structure containing details about a vetoable slashing request
     struct VetoableSlashingRequest {
         IAllocationManager.SlashingParams params;
-        uint256 requestTimestamp;
+        uint256 requestBlock;
         SlashingStatus status;
     }
 }
@@ -58,8 +58,7 @@ interface IVetoableSlasher is
     IVetoableSlasherEvents
 {
     /// @notice Duration of the veto period during which the veto committee can cancel slashing requests
-    /// @dev Set to 3 days (259,200 seconds)
-    function VETO_PERIOD() external view returns (uint256);
+    function vetoWindowBlocks() external view returns (uint32);
 
     /// @notice Address of the committee that has veto power over slashing requests
     function vetoCommittee() external view returns (address);

--- a/src/slashers/InstantSlasher.sol
+++ b/src/slashers/InstantSlasher.sol
@@ -16,14 +16,7 @@ contract InstantSlasher is IInstantSlasher, SlasherBase {
         IAllocationManager _allocationManager,
         ISlashingRegistryCoordinator _slashingRegistryCoordinator,
         address _slasher
-    ) SlasherBase(_allocationManager, _slashingRegistryCoordinator) {}
-
-    /// @inheritdoc IInstantSlasher
-    function initialize(
-        address _slasher
-    ) external override initializer {
-        __SlasherBase_init(_slasher);
-    }
+    ) SlasherBase(_allocationManager, _slashingRegistryCoordinator, _slasher) {}
 
     /// @inheritdoc IInstantSlasher
     function fulfillSlashingRequest(

--- a/src/slashers/VetoableSlasher.sol
+++ b/src/slashers/VetoableSlasher.sol
@@ -16,7 +16,7 @@ contract VetoableSlasher is IVetoableSlasher, SlasherBase {
     uint32 public immutable override vetoWindowBlocks;
 
     /// @inheritdoc IVetoableSlasher
-    address public override vetoCommittee;
+    address public immutable override vetoCommittee;
 
     /// @notice Mapping of request IDs to their corresponding slashing request details
     mapping(uint256 => IVetoableSlasherTypes.VetoableSlashingRequest) public slashingRequests;
@@ -30,17 +30,11 @@ contract VetoableSlasher is IVetoableSlasher, SlasherBase {
     constructor(
         IAllocationManager _allocationManager,
         ISlashingRegistryCoordinator _slashingRegistryCoordinator,
-        uint32 _vetoWindowBlocks
-    ) SlasherBase(_allocationManager, _slashingRegistryCoordinator) {
-        vetoWindowBlocks = _vetoWindowBlocks;
-    }
-
-    /// @inheritdoc IVetoableSlasher
-    function initialize(
+        address _slasher,
         address _vetoCommittee,
-        address _slasher
-    ) external virtual override initializer {
-        __SlasherBase_init(_slasher);
+        uint32 _vetoWindowBlocks
+    ) SlasherBase(_allocationManager, _slashingRegistryCoordinator, _slasher) {
+        vetoWindowBlocks = _vetoWindowBlocks;
         vetoCommittee = _vetoCommittee;
     }
 

--- a/src/slashers/VetoableSlasher.sol
+++ b/src/slashers/VetoableSlasher.sol
@@ -13,7 +13,7 @@ import {IVetoableSlasher, IVetoableSlasherTypes} from "../interfaces/IVetoableSl
 /// @dev Extends SlasherBase and adds a veto period during which slashing requests can be cancelled
 contract VetoableSlasher is IVetoableSlasher, SlasherBase {
     /// @inheritdoc IVetoableSlasher
-    uint256 public constant override VETO_PERIOD = 3 days;
+    uint32 public immutable override vetoWindowBlocks;
 
     /// @inheritdoc IVetoableSlasher
     address public override vetoCommittee;
@@ -29,8 +29,11 @@ contract VetoableSlasher is IVetoableSlasher, SlasherBase {
 
     constructor(
         IAllocationManager _allocationManager,
-        ISlashingRegistryCoordinator _slashingRegistryCoordinator
-    ) SlasherBase(_allocationManager, _slashingRegistryCoordinator) {}
+        ISlashingRegistryCoordinator _slashingRegistryCoordinator,
+        uint32 _vetoWindowBlocks
+    ) SlasherBase(_allocationManager, _slashingRegistryCoordinator) {
+        vetoWindowBlocks = _vetoWindowBlocks;
+    }
 
     /// @inheritdoc IVetoableSlasher
     function initialize(
@@ -52,15 +55,6 @@ contract VetoableSlasher is IVetoableSlasher, SlasherBase {
     function cancelSlashingRequest(
         uint256 requestId
     ) external virtual override onlyVetoCommittee {
-        require(
-            block.timestamp < slashingRequests[requestId].requestTimestamp + VETO_PERIOD,
-            VetoPeriodPassed()
-        );
-        require(
-            slashingRequests[requestId].status == IVetoableSlasherTypes.SlashingStatus.Requested,
-            SlashingRequestNotRequested()
-        );
-
         _cancelSlashingRequest(requestId);
     }
 
@@ -68,27 +62,18 @@ contract VetoableSlasher is IVetoableSlasher, SlasherBase {
     function fulfillSlashingRequest(
         uint256 requestId
     ) external virtual override onlySlasher {
-        IVetoableSlasherTypes.VetoableSlashingRequest storage request = slashingRequests[requestId];
-        require(block.timestamp >= request.requestTimestamp + VETO_PERIOD, VetoPeriodNotPassed());
-        require(
-            request.status == IVetoableSlasherTypes.SlashingStatus.Requested,
-            SlashingRequestIsCancelled()
-        );
-
-        request.status = IVetoableSlasherTypes.SlashingStatus.Completed;
-
-        _fulfillSlashingRequest(requestId, request.params);
+        _fulfillSlashingRequestAndMarkAsCompleted(requestId);
     }
 
     /// @notice Internal function to create and store a new slashing request
     /// @param params Parameters defining the slashing request
     function _queueSlashingRequest(
-        IAllocationManager.SlashingParams calldata params
+        IAllocationManager.SlashingParams memory params
     ) internal virtual {
         uint256 requestId = nextRequestId++;
         slashingRequests[requestId] = IVetoableSlasherTypes.VetoableSlashingRequest({
             params: params,
-            requestTimestamp: block.timestamp,
+            requestBlock: block.number,
             status: IVetoableSlasherTypes.SlashingStatus.Requested
         });
 
@@ -102,8 +87,34 @@ contract VetoableSlasher is IVetoableSlasher, SlasherBase {
     function _cancelSlashingRequest(
         uint256 requestId
     ) internal virtual {
+        require(
+            block.number < slashingRequests[requestId].requestBlock + vetoWindowBlocks,
+            VetoPeriodPassed()
+        );
+        require(
+            slashingRequests[requestId].status == IVetoableSlasherTypes.SlashingStatus.Requested,
+            SlashingRequestNotRequested()
+        );
+
         slashingRequests[requestId].status = IVetoableSlasherTypes.SlashingStatus.Cancelled;
         emit SlashingRequestCancelled(requestId);
+    }
+
+    /// @notice Internal function to fullfill a slashing request and mark it as completed
+    /// @param requestId The ID of the slashing request to fulfill
+    function _fulfillSlashingRequestAndMarkAsCompleted(
+        uint256 requestId
+    ) internal virtual {
+        IVetoableSlasherTypes.VetoableSlashingRequest storage request = slashingRequests[requestId];
+        require(block.number >= request.requestBlock + vetoWindowBlocks, VetoPeriodNotPassed());
+        require(
+            request.status == IVetoableSlasherTypes.SlashingStatus.Requested,
+            SlashingRequestIsCancelled()
+        );
+
+        request.status = IVetoableSlasherTypes.SlashingStatus.Completed;
+
+        _fulfillSlashingRequest(requestId, request.params);
     }
 
     /// @notice Internal function to verify if an account is the veto committee

--- a/src/slashers/base/SlasherBase.sol
+++ b/src/slashers/base/SlasherBase.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {Initializable} from "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";
 import {SlasherStorage, ISlashingRegistryCoordinator} from "./SlasherStorage.sol";
 import {
     IAllocationManagerTypes,
@@ -12,7 +11,7 @@ import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy
 /// @title SlasherBase
 /// @notice Base contract for implementing slashing functionality in EigenLayer middleware
 /// @dev Provides core slashing functionality and interfaces with EigenLayer's AllocationManager
-abstract contract SlasherBase is Initializable, SlasherStorage {
+abstract contract SlasherBase is SlasherStorage {
     /// @notice Ensures only the authorized slasher can call certain functions
     modifier onlySlasher() {
         _checkSlasher(msg.sender);
@@ -22,20 +21,12 @@ abstract contract SlasherBase is Initializable, SlasherStorage {
     /// @notice Constructs the base slasher contract
     /// @param _allocationManager The EigenLayer allocation manager contract
     /// @param _registryCoordinator The registry coordinator for this middleware
+    /// @param _slasher The address of the slasher
     constructor(
         IAllocationManager _allocationManager,
-        ISlashingRegistryCoordinator _registryCoordinator
-    ) SlasherStorage(_allocationManager, _registryCoordinator) {
-        _disableInitializers();
-    }
-
-    /// @notice Initializes the slasher contract with authorized slasher address
-    /// @param _slasher Address authorized to create and fulfill slashing requests
-    function __SlasherBase_init(
+        ISlashingRegistryCoordinator _registryCoordinator,
         address _slasher
-    ) internal onlyInitializing {
-        slasher = _slasher;
-    }
+    ) SlasherStorage(_allocationManager, _registryCoordinator, _slasher) {}
 
     /// @notice Internal function to execute a slashing request
     /// @param _requestId The ID of the slashing request to fulfill

--- a/src/slashers/base/SlasherStorage.sol
+++ b/src/slashers/base/SlasherStorage.sol
@@ -20,17 +20,19 @@ abstract contract SlasherStorage is ISlasher {
     IAllocationManager public immutable allocationManager;
     /// @notice the SlashingRegistryCoordinator for this AVS
     ISlashingRegistryCoordinator public immutable slashingRegistryCoordinator;
-
-    address public slasher;
+    /// @notice the address of the slasher
+    address public immutable slasher;
 
     uint256 public nextRequestId;
 
     constructor(
         IAllocationManager _allocationManager,
-        ISlashingRegistryCoordinator _slashingRegistryCoordinator
+        ISlashingRegistryCoordinator _slashingRegistryCoordinator,
+        address _slasher
     ) {
         allocationManager = _allocationManager;
         slashingRegistryCoordinator = _slashingRegistryCoordinator;
+        slasher = _slasher;
     }
 
     uint256[48] private __gap;

--- a/src/slashers/base/SlasherStorage.sol
+++ b/src/slashers/base/SlasherStorage.sol
@@ -35,5 +35,5 @@ abstract contract SlasherStorage is ISlasher {
         slasher = _slasher;
     }
 
-    uint256[48] private __gap;
+    uint256[49] private __gap;
 }

--- a/test/ffi/UpdateOperators.t.sol
+++ b/test/ffi/UpdateOperators.t.sol
@@ -1077,7 +1077,8 @@ contract Integration_AVS_Sync_GasCosts_FFI is IntegrationChecks {
                 numQuorums: ONE,
                 numStrategies: TWENTYFIVE,
                 minimumStake: NO_MINIMUM,
-                fillTypes: FULL
+                fillTypes: FULL,
+                quorumType: DELEGATED_STAKE
             })
         });
         _updateOperators_SingleQuorum();
@@ -1093,7 +1094,8 @@ contract Integration_AVS_Sync_GasCosts_FFI is IntegrationChecks {
                 numQuorums: ONE,
                 numStrategies: TWENTY,
                 minimumStake: NO_MINIMUM,
-                fillTypes: FULL
+                fillTypes: FULL,
+                quorumType: DELEGATED_STAKE
             })
         });
 
@@ -1109,7 +1111,8 @@ contract Integration_AVS_Sync_GasCosts_FFI is IntegrationChecks {
                 numQuorums: ONE,
                 numStrategies: FIFTEEN,
                 minimumStake: NO_MINIMUM,
-                fillTypes: FULL
+                fillTypes: FULL,
+                quorumType: DELEGATED_STAKE
             })
         });
         _updateOperators_SingleQuorum();

--- a/test/harnesses/RegistryCoordinatorHarness.t.sol
+++ b/test/harnesses/RegistryCoordinatorHarness.t.sol
@@ -60,7 +60,7 @@ contract RegistryCoordinatorHarness is RegistryCoordinator, Test {
 
     // @notice exposes the internal `_deregisterOperator` function, overriding all access controls
     function _deregisterOperatorExternal(address operator, bytes calldata quorumNumbers) external {
-        _deregisterOperator(operator, quorumNumbers);
+        _deregisterOperator(operator, quorumNumbers, false);
     }
 
     // @notice exposes the internal `_updateOperatorBitmap` function, overriding all access controls

--- a/test/integration/IntegrationBase.t.sol
+++ b/test/integration/IntegrationBase.t.sol
@@ -22,7 +22,7 @@ abstract contract IntegrationBase is IntegrationConfig {
 
     function assert_HasOperatorInfoWithId(User user, string memory err) internal {
         bytes32 expectedId = user.operatorId();
-        bytes32 actualId = registryCoordinator.getOperatorId(address(user));
+        bytes32 actualId = slashingRegistryCoordinator.getOperatorId(address(user));
 
         assertEq(expectedId, actualId, err);
     }
@@ -39,20 +39,20 @@ abstract contract IntegrationBase is IntegrationConfig {
 
     function assert_HasRegisteredStatus(User user, string memory err) internal {
         ISlashingRegistryCoordinatorTypes.OperatorStatus status =
-            registryCoordinator.getOperatorStatus(address(user));
+            slashingRegistryCoordinator.getOperatorStatus(address(user));
 
         assertTrue(status == ISlashingRegistryCoordinatorTypes.OperatorStatus.REGISTERED, err);
     }
 
     function assert_HasDeregisteredStatus(User user, string memory err) internal {
         ISlashingRegistryCoordinatorTypes.OperatorStatus status =
-            registryCoordinator.getOperatorStatus(address(user));
+            slashingRegistryCoordinator.getOperatorStatus(address(user));
 
         assertTrue(status == ISlashingRegistryCoordinatorTypes.OperatorStatus.DEREGISTERED, err);
     }
 
     function assert_EmptyQuorumBitmap(User user, string memory err) internal {
-        uint192 bitmap = registryCoordinator.getCurrentQuorumBitmap(user.operatorId());
+        uint192 bitmap = slashingRegistryCoordinator.getCurrentQuorumBitmap(user.operatorId());
 
         assertTrue(bitmap == 0, err);
     }
@@ -62,7 +62,7 @@ abstract contract IntegrationBase is IntegrationConfig {
         bytes memory quorums,
         string memory err
     ) internal {
-        uint192 bitmap = registryCoordinator.getCurrentQuorumBitmap(user.operatorId());
+        uint192 bitmap = slashingRegistryCoordinator.getCurrentQuorumBitmap(user.operatorId());
 
         for (uint256 i = 0; i < quorums.length; i++) {
             uint8 quorum = uint8(quorums[i]);
@@ -77,15 +77,30 @@ abstract contract IntegrationBase is IntegrationConfig {
         bytes memory quorums,
         string memory err
     ) internal {
-        uint192 currentBitmap = registryCoordinator.getCurrentQuorumBitmap(user.operatorId());
+        uint192 currentBitmap =
+            slashingRegistryCoordinator.getCurrentQuorumBitmap(user.operatorId());
         uint192 subsetBitmap = uint192(quorums.orderedBytesArrayToBitmap());
 
         assertTrue(subsetBitmap.isSubsetOf(currentBitmap), err);
     }
 
+    /// @dev Checks that the user is registered for each of the operator sets in the AllocationManager
+    function assert_RegisteredForOperatorSets(
+        User user,
+        bytes memory operatorSetIds,
+        string memory err
+    ) internal {
+        for (uint256 i = 0; i < operatorSetIds.length; i++) {
+            uint32 operatorSetId = uint32(uint8(operatorSetIds[i]));
+            OperatorSet memory operatorSet =
+                OperatorSet({avs: avsAccountIdentifier, id: operatorSetId});
+            assertTrue(allocationManager.isMemberOfOperatorSet(address(user), operatorSet), err);
+        }
+    }
+
     /// @dev Checks whether each of the quorums has been initialized in the RegistryCoordinator
     function assert_QuorumsExist(bytes memory quorums, string memory err) internal {
-        uint8 count = registryCoordinator.quorumCount();
+        uint8 count = slashingRegistryCoordinator.quorumCount();
         for (uint256 i = 0; i < quorums.length; i++) {
             uint8 quorum = uint8(quorums[i]);
 
@@ -176,7 +191,7 @@ abstract contract IntegrationBase is IntegrationConfig {
             uint8 quorum = uint8(quorums[i]);
 
             uint32 maxOperatorCount =
-                registryCoordinator.getOperatorSetParams(quorum).maxOperatorCount;
+                slashingRegistryCoordinator.getOperatorSetParams(quorum).maxOperatorCount;
             uint32 curOperatorCount = indexRegistry.totalOperatorsForQuorum(quorum);
 
             assertTrue(curOperatorCount < maxOperatorCount, err);
@@ -242,6 +257,20 @@ abstract contract IntegrationBase is IntegrationConfig {
         // were set in the previous bitmap, and are NOT set in the current bitmap
         assertTrue(quorumsRemoved.isSubsetOf(prevBitmap), err);
         assertTrue(quorumsRemoved.noBitsInCommon(curBitmap), err);
+    }
+
+    /// @dev Checks that user has deregistered from all operator sets in the AllocationManager
+    function assert_Snap_Deregistered_FromOperatorSets(
+        User user,
+        bytes memory quorums,
+        string memory err
+    ) internal {
+        for (uint256 i = 0; i < quorums.length; i++) {
+            uint32 operatorSetId = uint32(uint8(quorums[i]));
+            OperatorSet memory operatorSet =
+                OperatorSet({avs: avsAccountIdentifier, id: operatorSetId});
+            assertFalse(allocationManager.isMemberOfOperatorSet(address(user), operatorSet), err);
+        }
     }
 
     function assert_Snap_Unchanged_OperatorInfo(User user, string memory err) internal {
@@ -869,7 +898,7 @@ abstract contract IntegrationBase is IntegrationConfig {
     function _getOperatorInfo(
         User user
     ) internal view returns (ISlashingRegistryCoordinatorTypes.OperatorInfo memory) {
-        return registryCoordinator.getOperator(address(user));
+        return slashingRegistryCoordinator.getOperator(address(user));
     }
 
     function _getPrevOperatorInfo(
@@ -881,7 +910,7 @@ abstract contract IntegrationBase is IntegrationConfig {
     function _getQuorumBitmap(
         bytes32 operatorId
     ) internal view returns (uint192) {
-        return registryCoordinator.getCurrentQuorumBitmap(operatorId);
+        return slashingRegistryCoordinator.getCurrentQuorumBitmap(operatorId);
     }
 
     function _getPrevQuorumBitmap(

--- a/test/integration/IntegrationChecks.t.sol
+++ b/test/integration/IntegrationChecks.t.sol
@@ -39,6 +39,11 @@ contract IntegrationChecks is IntegrationBase {
     function check_Register_State(User operator, bytes memory quorums) internal {
         _log("check_Register_State", operator);
 
+        // AllocationManager
+        assert_RegisteredForOperatorSets(
+            operator, quorums, "operator did not register for all operator sets"
+        );
+
         // RegistryCoordinator
         assert_HasOperatorInfoWithId(operator, "operatorInfo should have operatorId");
         assert_HasRegisteredStatus(operator, "operatorInfo status should be REGISTERED");
@@ -74,7 +79,7 @@ contract IntegrationChecks is IntegrationBase {
         );
 
         // AVSDirectory
-        assert_IsRegisteredToAVS(operator, "operator should be registered to AVS");
+        // assert_IsRegisteredToAVS(operator, "operator should be registered to AVS");
     }
 
     /// @dev Combines many checks of check_Register_State and check_Deregister_State
@@ -153,7 +158,7 @@ contract IntegrationChecks is IntegrationBase {
         );
 
         // AVSDirectory
-        assert_IsRegisteredToAVS(incomingOperator, "operator should be registered to AVS");
+        // assert_IsRegisteredToAVS(incomingOperator, "operator should be registered to AVS");
 
         // Check that churnedOperators are deregistered from churnedQuorums
         for (uint256 i = 0; i < churnedOperators.length; i++) {
@@ -175,6 +180,13 @@ contract IntegrationChecks is IntegrationBase {
                 churnedOperator,
                 churnedQuorum,
                 "churned operator did not deregister from churned quorum"
+            );
+
+            // AllocationManager
+            assert_Snap_Deregistered_FromOperatorSets(
+                churnedOperator,
+                churnedQuorum,
+                "churned operator did not deregister from operatorSets"
             );
 
             // BLSApkRegistry
@@ -276,7 +288,7 @@ contract IntegrationChecks is IntegrationBase {
         );
 
         // AVSDirectory
-        assert_IsRegisteredToAVS(operator, "operator should be registered to AVS");
+        // assert_IsRegisteredToAVS(operator, "operator should be registered to AVS");
     }
 
     /// @dev Validate state directly after the operator exits from Eigenlayer core (by queuing withdrawals)
@@ -319,6 +331,11 @@ contract IntegrationChecks is IntegrationBase {
     /// NOTE: This is a combination of check_Deregister_State and check_CompleteDeregister_State
     function check_WithdrawUpdate_State(User operator, bytes memory quorums) internal {
         _log("check_WithdrawUpdate_State", operator);
+
+        // AllocationManager
+        assert_Snap_Deregistered_FromOperatorSets(
+            operator, quorums, "operator did not deregister from all operator sets"
+        );
 
         // RegistryCoordinator
         assert_HasOperatorInfoWithId(operator, "operatorInfo should still have operatorId");
@@ -392,6 +409,11 @@ contract IntegrationChecks is IntegrationBase {
     /// @dev Check that the operator correctly deregistered from some quorums
     function check_Deregister_State(User operator, bytes memory quorums) internal {
         _log("check_Deregister_State", operator);
+
+        // AllocationManager
+        assert_Snap_Deregistered_FromOperatorSets(
+            operator, quorums, "operator did not deregister from all operator sets"
+        );
 
         // RegistryCoordinator
         assert_HasOperatorInfoWithId(operator, "operatorInfo should still have operatorId");

--- a/test/integration/IntegrationConfig.t.sol
+++ b/test/integration/IntegrationConfig.t.sol
@@ -47,12 +47,16 @@ contract IntegrationConfig is IntegrationDeployer, G2Operations, Constants {
     bytes numStrategyFlags;
     bytes minStakeFlags;
     bytes fillTypeFlags;
-
+    bytes quorumTypeFlags;
     uint256 constant FLAG = 1;
 
     /// @dev Flags for userTypes
     uint256 constant DEFAULT = (FLAG << 0);
     uint256 constant ALT_METHODS = (FLAG << 1);
+
+    /// @dev Flags for using SlashingRegistryCoordinator or RegistryCoordinator (M2)
+    uint256 constant SLASHING = (FLAG << 0);
+    uint256 constant M2 = (FLAG << 1);
 
     /// @dev Flags for numQuorums and numStrategies
     uint256 constant ONE = (FLAG << 0);
@@ -70,6 +74,11 @@ contract IntegrationConfig is IntegrationDeployer, G2Operations, Constants {
     uint256 constant EMPTY = (FLAG << 0);
     uint256 constant SOME_FILL = (FLAG << 1);
     uint256 constant FULL = (FLAG << 2);
+
+    /// @dev Flags for quorumType
+    uint256 constant DELEGATED_STAKE = (FLAG << 0);
+    uint256 constant SLASHABLE_STAKE = (FLAG << 1);
+    uint256 constant BOTH = (FLAG << 2);
 
     /// @dev Tracking variables for pregenerated BLS keypairs:
     /// (See _fetchKeypair)
@@ -121,6 +130,8 @@ contract IntegrationConfig is IntegrationDeployer, G2Operations, Constants {
         /// @dev Whether each quorum created is pre-populated with operators
         /// NOTE: Default
         uint256 fillTypes; // EMPTY | SOME_FILL | FULL
+        /// @dev Whether quorums created are delegated stake quorum, slashable stake quorums, or both
+        uint256 quorumType; // DELEGATED_STAKE | SLASHABLE_STAKE | BOTH
     }
 
     /**
@@ -143,7 +154,7 @@ contract IntegrationConfig is IntegrationDeployer, G2Operations, Constants {
         numStrategyFlags = _bitmapToBytes(_quorumConfig.numStrategies);
         minStakeFlags = _bitmapToBytes(_quorumConfig.minimumStake);
         fillTypeFlags = _bitmapToBytes(_quorumConfig.fillTypes);
-
+        quorumTypeFlags = _bitmapToBytes(_quorumConfig.quorumType);
         // Sanity check config
         assertTrue(userFlags.length != 0, "_configRand: invalid _userTypes, no flags passed");
         assertTrue(numQuorumFlags.length != 0, "_configRand: invalid numQuorums, no flags passed");
@@ -152,7 +163,7 @@ contract IntegrationConfig is IntegrationDeployer, G2Operations, Constants {
         );
         assertTrue(minStakeFlags.length != 0, "_configRand: invalid minimumStake, no flags passed");
         assertTrue(fillTypeFlags.length != 0, "_configRand: invalid fillTypes, no flags passed");
-
+        assertTrue(quorumTypeFlags.length != 0, "_configRand: invalid quorumType, no flags passed");
         // Decide how many quorums to initialize
         quorumCount = _randQuorumCount();
         quorumBitmap = uint192((1 << quorumCount) - 1);
@@ -172,13 +183,52 @@ contract IntegrationConfig is IntegrationDeployer, G2Operations, Constants {
             IStakeRegistryTypes.StrategyParams[] memory strategyParams = _randStrategyParams();
             uint96 minimumStake = _randMinStake();
 
+            uint256 quorumType = _randValue(quorumTypeFlags);
+
             emit log_named_uint("_configRand: creating quorum", i);
             emit log_named_uint("- Max operator count", operatorSet.maxOperatorCount);
             emit log_named_uint("- Num strategies considered", strategyParams.length);
             emit log_named_uint("- Minimum stake", minimumStake);
+            emit log_named_uint("- Quorum type", quorumType);
+
+            if (quorumType == DELEGATED_STAKE) {
+                cheats.prank(registryCoordinatorOwner);
+                slashingRegistryCoordinator.createTotalDelegatedStakeQuorum({
+                    operatorSetParams: operatorSet,
+                    minimumStake: minimumStake,
+                    strategyParams: strategyParams
+                });
+            } else if (quorumType == SLASHABLE_STAKE) {
+                cheats.prank(registryCoordinatorOwner);
+                slashingRegistryCoordinator.createSlashableStakeQuorum({
+                    operatorSetParams: operatorSet,
+                    minimumStake: minimumStake,
+                    strategyParams: strategyParams,
+                    lookAheadPeriod: 0
+                });
+            } else if (quorumType == BOTH) {
+                // randomly choose one of the two
+                uint256 randomChoice = _randValue(quorumTypeFlags);
+                if (randomChoice == DELEGATED_STAKE) {
+                    cheats.prank(registryCoordinatorOwner);
+                    slashingRegistryCoordinator.createTotalDelegatedStakeQuorum({
+                        operatorSetParams: operatorSet,
+                        minimumStake: minimumStake,
+                        strategyParams: strategyParams
+                    });
+                } else if (randomChoice == SLASHABLE_STAKE) {
+                    cheats.prank(registryCoordinatorOwner);
+                    slashingRegistryCoordinator.createSlashableStakeQuorum({
+                        operatorSetParams: operatorSet,
+                        minimumStake: minimumStake,
+                        strategyParams: strategyParams,
+                        lookAheadPeriod: 0
+                    });
+                }
+            }
 
             cheats.prank(registryCoordinatorOwner);
-            registryCoordinator.createTotalDelegatedStakeQuorum({
+            slashingRegistryCoordinator.createTotalDelegatedStakeQuorum({
                 operatorSetParams: operatorSet,
                 minimumStake: minimumStake,
                 strategyParams: strategyParams
@@ -250,10 +300,10 @@ contract IntegrationConfig is IntegrationDeployer, G2Operations, Constants {
         uint256 userType = _randValue(userFlags);
 
         if (userType == DEFAULT) {
-            user = new User(name, privKey, pubkey);
+            user = new OperatorSetUser(name, privKey, pubkey);
         } else if (userType == ALT_METHODS) {
             name = string.concat(name, "_Alt");
-            user = new User_AltMethods(name, privKey, pubkey);
+            user = new OperatorSetUser_AltMethods(name, privKey, pubkey);
         }
 
         emit log_named_string("_randUser: Created user", user.NAME());
@@ -329,7 +379,7 @@ contract IntegrationConfig is IntegrationDeployer, G2Operations, Constants {
             uint8 quorum = uint8(churnQuorums[i]);
 
             ISlashingRegistryCoordinatorTypes.OperatorSetParam memory params =
-                registryCoordinator.getOperatorSetParams(quorum);
+                slashingRegistryCoordinator.getOperatorSetParams(quorum);
 
             // Sanity check - make sure we're at the operator cap
             uint32 curNumOperators = indexRegistry.totalOperatorsForQuorum(quorum);
@@ -402,7 +452,7 @@ contract IntegrationConfig is IntegrationDeployer, G2Operations, Constants {
         for (uint256 i = 0; i < quorums.length; i++) {
             uint8 quorum = uint8(quorums[i]);
             uint32 maxOperatorCount =
-                registryCoordinator.getOperatorSetParams(quorum).maxOperatorCount;
+                slashingRegistryCoordinator.getOperatorSetParams(quorum).maxOperatorCount;
 
             // Continue deregistering until we're under the cap
             // This uses while in case we tested a config change that lowered the max count

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -40,6 +40,7 @@ import "src/libraries/BitmapUtils.sol";
 import "eigenlayer-contracts/src/test/mocks/EmptyContract.sol";
 // import "src/test/integration/mocks/ServiceManagerMock.t.sol";
 import "test/integration/User.t.sol";
+import "test/integration/OperatorSetUser.t.sol";
 
 abstract contract IntegrationDeployer is Test, IUserDeployer {
     using Strings for *;
@@ -56,15 +57,16 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
     IBeacon eigenPodBeacon;
     EigenPod pod;
     ETHPOSDepositMock ethPOSDeposit;
-    AllocationManager allocationManager;
+    AllocationManager public allocationManager;
     PermissionController permissionController;
 
     // Base strategy implementation in case we want to create more strategies later
     StrategyBase baseStrategyImplementation;
 
     // Middleware contracts to deploy
+    SlashingRegistryCoordinator public slashingRegistryCoordinator;
     RegistryCoordinator public registryCoordinator;
-    ServiceManagerMock serviceManager;
+    ServiceManagerMock public serviceManager;
     BLSApkRegistry blsApkRegistry;
     StakeRegistry stakeRegistry;
     IndexRegistry indexRegistry;
@@ -89,6 +91,12 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
     address public churnApprover = cheats.addr(churnApproverPrivateKey);
     address ejector = address(uint160(uint256(keccak256("ejector"))));
     address rewardsUpdater = address(uint160(uint256(keccak256("rewardsUpdater"))));
+
+    /// @dev Account identifier for the AVS. This is the unique identifier address for the AVS in the AllocationManager.
+    /// This address is by default a UAM PermissionController admin and can transfer admin permissions to other addresses.
+    /// For existing AVSs using ServiceManagers, this should be the same address as the ServiceManager and there exist
+    /// interfaces on the ServiceManager to interact with UAM.
+    address avsAccountIdentifier = address(uint160(uint256(keccak256("avsAccountIdentifier"))));
 
     // Constants/Defaults
     uint64 constant GENESIS_TIME_LOCAL = 1 hours * 12;
@@ -314,6 +322,11 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
                 new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
             )
         );
+        slashingRegistryCoordinator = SlashingRegistryCoordinator(
+            address(
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
+            )
+        );
 
         stakeRegistry = StakeRegistry(
             address(
@@ -347,25 +360,25 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
         cheats.stopPrank();
 
         StakeRegistry stakeRegistryImplementation = new StakeRegistry(
-            ISlashingRegistryCoordinator(registryCoordinator),
+            ISlashingRegistryCoordinator(slashingRegistryCoordinator),
             IDelegationManager(delegationManager),
             IAVSDirectory(avsDirectory),
             allocationManager
         );
         BLSApkRegistry blsApkRegistryImplementation =
-            new BLSApkRegistry(ISlashingRegistryCoordinator(registryCoordinator));
+            new BLSApkRegistry(ISlashingRegistryCoordinator(slashingRegistryCoordinator));
         IndexRegistry indexRegistryImplementation =
-            new IndexRegistry(ISlashingRegistryCoordinator(registryCoordinator));
+            new IndexRegistry(ISlashingRegistryCoordinator(slashingRegistryCoordinator));
         ServiceManagerMock serviceManagerImplementation = new ServiceManagerMock(
             IAVSDirectory(avsDirectory),
             rewardsCoordinator,
-            ISlashingRegistryCoordinator(registryCoordinator),
+            ISlashingRegistryCoordinator(slashingRegistryCoordinator),
             stakeRegistry,
             permissionController,
             allocationManager
         );
         SocketRegistry socketRegistryImplementation =
-            new SocketRegistry(IRegistryCoordinator(registryCoordinator));
+            new SocketRegistry(ISlashingRegistryCoordinator(slashingRegistryCoordinator));
 
         proxyAdmin.upgrade(
             TransparentUpgradeableProxy(payable(address(stakeRegistry))),
@@ -423,6 +436,27 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
             )
         );
 
+        SlashingRegistryCoordinator slashingRegistryCoordinatorImplementation = new SlashingRegistryCoordinator(
+            stakeRegistry,
+            blsApkRegistry,
+            indexRegistry,
+            socketRegistry,
+            allocationManager,
+            pauserRegistry
+        );
+        proxyAdmin.upgradeAndCall(
+            TransparentUpgradeableProxy(payable(address(slashingRegistryCoordinator))),
+            address(slashingRegistryCoordinatorImplementation),
+            abi.encodeWithSelector(
+                SlashingRegistryCoordinator.initialize.selector,
+                registryCoordinatorOwner,
+                churnApprover,
+                ejector,
+                0, /*initialPausedStatus*/
+                avsAccountIdentifier /* accountIdentifier */
+            )
+        );
+
         operatorStateRetriever = new OperatorStateRetriever();
 
         // Setup UAM Permissions
@@ -458,10 +492,48 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
             selector: IAllocationManager.removeStrategiesFromOperatorSet.selector
         });
         cheats.stopPrank();
-
         _setOperatorSetsEnabled(false);
         _setM2QuorumsDisabled(false);
         _setM2QuorumBitmap(0);
+
+        /// Setup UAM Permissions for SlashingRegistryCoordinator
+        cheats.startPrank(avsAccountIdentifier);
+        permissionController.setAppointee({
+            account: avsAccountIdentifier,
+            appointee: address(avsAccountIdentifier),
+            target: address(allocationManager),
+            selector: IAllocationManager.setAVSRegistrar.selector
+        });
+        permissionController.setAppointee({
+            account: avsAccountIdentifier,
+            appointee: address(slashingRegistryCoordinator),
+            target: address(allocationManager),
+            selector: IAllocationManager.createOperatorSets.selector
+        });
+        permissionController.setAppointee({
+            account: avsAccountIdentifier,
+            appointee: address(slashingRegistryCoordinator),
+            target: address(allocationManager),
+            selector: IAllocationManager.deregisterFromOperatorSets.selector
+        });
+        permissionController.setAppointee({
+            account: avsAccountIdentifier,
+            appointee: address(stakeRegistry),
+            target: address(allocationManager),
+            selector: IAllocationManager.addStrategiesToOperatorSet.selector
+        });
+        permissionController.setAppointee({
+            account: avsAccountIdentifier,
+            appointee: address(stakeRegistry),
+            target: address(allocationManager),
+            selector: IAllocationManager.removeStrategiesFromOperatorSet.selector
+        });
+        // set AVS Registrar to slashingRegistryCoordinator
+        allocationManager.setAVSRegistrar(
+            avsAccountIdentifier, IAVSRegistrar(address(slashingRegistryCoordinator))
+        );
+
+        cheats.stopPrank();
     }
 
     /// @notice Overwrite RegistryCoordinator.operatorSetsEnabled to the specified value.

--- a/test/integration/OperatorSetUser.t.sol
+++ b/test/integration/OperatorSetUser.t.sol
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import "test/integration/User.t.sol";
+import "forge-std/console.sol";
+
+contract OperatorSetUser is User {
+    using BN254 for *;
+    using Strings for *;
+    using BitmapStrings for *;
+    using BitmapUtils for *;
+
+    SlashingRegistryCoordinator slashingRegistryCoordinator;
+    AllocationManager allocationManager;
+    address avs;
+
+    constructor(
+        string memory name,
+        uint256 _privKey,
+        IBLSApkRegistryTypes.PubkeyRegistrationParams memory _pubkeyParams
+    ) User(name, _privKey, _pubkeyParams) {
+        IUserDeployer deployer = IUserDeployer(msg.sender);
+
+        slashingRegistryCoordinator = deployer.slashingRegistryCoordinator();
+        allocationManager = AllocationManager(deployer.allocationManager());
+
+        avs = slashingRegistryCoordinator.accountIdentifier();
+
+        // Generate BN254 keypair and registration signature
+        privKey = _privKey;
+        pubkeyParams = _pubkeyParams;
+
+        BN254.G1Point memory registrationMessageHash =
+            slashingRegistryCoordinator.pubkeyRegistrationMessageHash(address(this));
+        pubkeyParams.pubkeyRegistrationSignature = registrationMessageHash.scalar_mul(privKey);
+
+        operatorId = pubkeyParams.pubkeyG1.hashG1Point();
+    }
+
+    function registerOperator(
+        bytes calldata quorums
+    ) public virtual override createSnapshot returns (bytes32) {
+        _log("registerOperator", quorums);
+
+        vm.warp(block.timestamp + 1);
+        // If operator has previously registered and is still slashable, roll blocks until they are
+        // no longer slashable
+        vm.roll(block.number + uint256(allocationManager.DEALLOCATION_DELAY()) + 1);
+
+        // encode bytes data field passed into SlashingRegistryCoordinator.registerOperator
+        // Register params for AllocationManager
+        bytes memory data = abi.encode(
+            ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, NAME, pubkeyParams
+        );
+        IAllocationManagerTypes.RegisterParams memory registerParams = IAllocationManagerTypes
+            .RegisterParams({avs: avs, operatorSetIds: _getOperatorSetIds(quorums), data: data});
+
+        allocationManager.registerForOperatorSets({operator: address(this), params: registerParams});
+
+        return pubkeyParams.pubkeyG1.hashG1Point();
+    }
+
+    function registerOperatorWithChurn(
+        bytes calldata churnQuorums,
+        User[] calldata churnTargets,
+        bytes calldata standardQuorums
+    ) public virtual override createSnapshot {
+        _logChurn("registerOperatorWithChurn", churnQuorums, churnTargets, standardQuorums);
+
+        vm.warp(block.timestamp + 1);
+        // If operator has previously registered and is still slashable, roll blocks until they are
+        // no longer slashable
+        vm.roll(block.number + uint256(allocationManager.DEALLOCATION_DELAY()) + 1);
+
+        // Sanity check input:
+        // - churnQuorums and churnTargets should have equal length
+        // - churnQuorums and standardQuorums should not have any bits in common
+        uint192 churnBitmap = uint192(churnQuorums.orderedBytesArrayToBitmap());
+        uint192 standardBitmap = uint192(standardQuorums.orderedBytesArrayToBitmap());
+        assertEq(
+            churnQuorums.length,
+            churnTargets.length,
+            "User.registerOperatorWithChurn: input length mismatch"
+        );
+        assertTrue(
+            churnBitmap.noBitsInCommon(standardBitmap),
+            "User.registerOperatorWithChurn: input quorums have common bits"
+        );
+        bytes memory allQuorums = churnBitmap.plus(standardBitmap).bitmapToBytesArray();
+
+        (
+            ISlashingRegistryCoordinatorTypes.OperatorKickParam[] memory kickParams,
+            ISignatureUtils.SignatureWithSaltAndExpiry memory churnApproverSignature
+        ) = _generateOperatorKickParams(allQuorums, churnQuorums, churnTargets, standardQuorums);
+
+        // Encode with RegistrationType.CHURN
+        bytes memory data = abi.encode(
+            ISlashingRegistryCoordinatorTypes.RegistrationType.CHURN,
+            NAME,
+            pubkeyParams,
+            kickParams,
+            churnApproverSignature
+        );
+
+        IAllocationManagerTypes.RegisterParams memory registerParams = IAllocationManagerTypes
+            .RegisterParams({avs: avs, operatorSetIds: _getOperatorSetIds(allQuorums), data: data});
+        allocationManager.registerForOperatorSets({operator: address(this), params: registerParams});
+    }
+
+    function deregisterOperator(
+        bytes calldata quorums
+    ) public virtual override createSnapshot {
+        _log("deregisterOperator", quorums);
+        uint32[] memory operatorSetIds = _getOperatorSetIds(quorums);
+        IAllocationManagerTypes.DeregisterParams memory deregisterParams = IAllocationManagerTypes
+            .DeregisterParams({avs: avs, operator: address(this), operatorSetIds: operatorSetIds});
+        allocationManager.deregisterFromOperatorSets({params: deregisterParams});
+    }
+
+    function _getOperatorSetIds(
+        bytes memory quorums
+    ) internal pure returns (uint32[] memory) {
+        uint32[] memory operatorSetIds = new uint32[](quorums.length);
+        for (uint256 i = 0; i < quorums.length; i++) {
+            operatorSetIds[i] = uint32(uint8(quorums[i]));
+        }
+        return operatorSetIds;
+    }
+
+    function _generateOperatorKickParams(
+        bytes memory allQuorums,
+        bytes calldata churnQuorums,
+        User[] calldata churnTargets,
+        bytes calldata standardQuorums
+    )
+        internal
+        virtual
+        override
+        returns (
+            ISlashingRegistryCoordinatorTypes.OperatorKickParam[] memory,
+            ISignatureUtils.SignatureWithSaltAndExpiry memory
+        )
+    {
+        ISlashingRegistryCoordinator.OperatorKickParam[] memory kickParams =
+            new ISlashingRegistryCoordinator.OperatorKickParam[](allQuorums.length);
+
+        // this constructs OperatorKickParam[] in ascending quorum order
+        // (yikes)
+        uint256 churnIdx;
+        uint256 stdIdx;
+        while (churnIdx + stdIdx < allQuorums.length) {
+            if (churnIdx == churnQuorums.length) {
+                kickParams[churnIdx + stdIdx] = ISlashingRegistryCoordinatorTypes.OperatorKickParam({
+                    quorumNumber: 0,
+                    operator: address(0)
+                });
+                stdIdx++;
+            } else if (
+                stdIdx == standardQuorums.length || churnQuorums[churnIdx] < standardQuorums[stdIdx]
+            ) {
+                kickParams[churnIdx + stdIdx] = ISlashingRegistryCoordinatorTypes.OperatorKickParam({
+                    quorumNumber: uint8(churnQuorums[churnIdx]),
+                    operator: address(churnTargets[churnIdx])
+                });
+                churnIdx++;
+            } else if (standardQuorums[stdIdx] < churnQuorums[churnIdx]) {
+                kickParams[churnIdx + stdIdx] = ISlashingRegistryCoordinatorTypes.OperatorKickParam({
+                    quorumNumber: 0,
+                    operator: address(0)
+                });
+                stdIdx++;
+            } else {
+                revert("User.registerOperatorWithChurn: malformed input");
+            }
+        }
+
+        // Generate churn approver signature
+        bytes32 _salt = keccak256(abi.encodePacked(++salt, address(this)));
+        uint256 expiry = type(uint256).max;
+        bytes32 digest = slashingRegistryCoordinator.calculateOperatorChurnApprovalDigestHash({
+            registeringOperator: address(this),
+            registeringOperatorId: operatorId,
+            operatorKickParams: kickParams,
+            salt: _salt,
+            expiry: expiry
+        });
+
+        // Sign digest
+        (uint8 v, bytes32 r, bytes32 s) = cheats.sign(churnApproverPrivateKey, digest);
+        bytes memory signature = new bytes(65);
+        assembly {
+            mstore(add(signature, 0x20), r)
+            mstore(add(signature, 0x40), s)
+        }
+        signature[signature.length - 1] = bytes1(v);
+        ISignatureUtils.SignatureWithSaltAndExpiry memory churnApproverSignature = ISignatureUtils
+            .SignatureWithSaltAndExpiry({signature: signature, salt: _salt, expiry: expiry});
+
+        return (kickParams, churnApproverSignature);
+    }
+}
+
+contract OperatorSetUser_AltMethods is OperatorSetUser {
+    using BitmapUtils for *;
+
+    modifier createSnapshot() virtual override {
+        cheats.roll(block.number + 1);
+        timeMachine.createSnapshot();
+        _;
+    }
+
+    constructor(
+        string memory name,
+        uint256 _privKey,
+        IBLSApkRegistryTypes.PubkeyRegistrationParams memory _pubkeyParams
+    ) OperatorSetUser(name, _privKey, _pubkeyParams) {}
+
+    /// @dev Rather than calling deregisterOperator, this pranks the ejector and calls
+    /// ejectOperator
+    function deregisterOperator(
+        bytes calldata quorums
+    ) public virtual override createSnapshot {
+        _log("deregisterOperator (eject)", quorums);
+
+        address ejector = slashingRegistryCoordinator.ejector();
+
+        cheats.prank(ejector);
+        slashingRegistryCoordinator.ejectOperator(address(this), quorums);
+    }
+
+    /// @dev Uses updateOperatorsForQuorum to update stakes of all operators in all quorums
+    function updateStakes() public virtual override createSnapshot {
+        _log("updateStakes (updateOperatorsForQuorum)");
+
+        bytes memory allQuorums =
+            ((1 << slashingRegistryCoordinator.quorumCount()) - 1).bitmapToBytesArray();
+        address[][] memory operatorsPerQuorum = new address[][](allQuorums.length);
+
+        for (uint256 i = 0; i < allQuorums.length; i++) {
+            uint8 quorum = uint8(allQuorums[i]);
+            bytes32[] memory operatorIds =
+                indexRegistry.getOperatorListAtBlockNumber(quorum, uint32(block.number));
+
+            operatorsPerQuorum[i] = new address[](operatorIds.length);
+
+            for (uint256 j = 0; j < operatorIds.length; j++) {
+                operatorsPerQuorum[i][j] = blsApkRegistry.getOperatorFromPubkeyHash(operatorIds[j]);
+            }
+
+            operatorsPerQuorum[i] = Sort.sortAddresses(operatorsPerQuorum[i]);
+        }
+
+        slashingRegistryCoordinator.updateOperatorsForQuorum(operatorsPerQuorum, allQuorums);
+    }
+}

--- a/test/integration/OperatorSetUser.t.sol
+++ b/test/integration/OperatorSetUser.t.sol
@@ -117,6 +117,30 @@ contract OperatorSetUser is User {
         allocationManager.deregisterFromOperatorSets({params: deregisterParams});
     }
 
+    /// @dev Uses updateOperators to update this user's stake
+    function updateStakes() public virtual override createSnapshot {
+        _log("updateStakes (updateOperators)");
+
+        // get all quorums this operator is registered for
+        uint192 currentBitmap = slashingRegistryCoordinator.getCurrentQuorumBitmap(operatorId);
+        bytes memory quorumNumbers = currentBitmap.bitmapToBytesArray();
+
+        // get all operators in those quorums
+        address[][] memory operatorsPerQuorum = new address[][](quorumNumbers.length);
+        for (uint256 i = 0; i < quorumNumbers.length; i++) {
+            bytes32[] memory operatorIds = indexRegistry.getOperatorListAtBlockNumber(
+                uint8(quorumNumbers[i]), uint32(block.number)
+            );
+            operatorsPerQuorum[i] = new address[](operatorIds.length);
+            for (uint256 j = 0; j < operatorIds.length; j++) {
+                operatorsPerQuorum[i][j] = blsApkRegistry.pubkeyHashToOperator(operatorIds[j]);
+            }
+
+            operatorsPerQuorum[i] = Sort.sortAddresses(operatorsPerQuorum[i]);
+        }
+        slashingRegistryCoordinator.updateOperatorsForQuorum(operatorsPerQuorum, quorumNumbers);
+    }
+
     function _getOperatorSetIds(
         bytes memory quorums
     ) internal pure returns (uint32[] memory) {

--- a/test/integration/User.t.sol
+++ b/test/integration/User.t.sol
@@ -14,6 +14,7 @@ import "eigenlayer-contracts/src/contracts/core/DelegationManager.sol";
 import "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
 import "eigenlayer-contracts/src/contracts/core/StrategyManager.sol";
 import "eigenlayer-contracts/src/contracts/core/AVSDirectory.sol";
+import "eigenlayer-contracts/src/contracts/core/AllocationManager.sol";
 
 // Middleware
 import "src/interfaces/IRegistryCoordinator.sol";
@@ -28,10 +29,14 @@ import "src/libraries/BitmapUtils.sol";
 import "test/integration/TimeMachine.t.sol";
 import "test/integration/utils/Sort.t.sol";
 import "test/integration/utils/BitmapStrings.t.sol";
+import "test/mocks/ServiceManagerMock.sol";
 
 interface IUserDeployer {
+    function slashingRegistryCoordinator() external view returns (SlashingRegistryCoordinator);
     function registryCoordinator() external view returns (RegistryCoordinator);
     function avsDirectory() external view returns (AVSDirectory);
+    function allocationManager() external view returns (AllocationManager);
+    function serviceManager() external view returns (ServiceManagerMock);
     function timeMachine() external view returns (TimeMachine);
     function churnApproverPrivateKey() external view returns (uint256);
     function churnApprover() external view returns (address);
@@ -82,7 +87,7 @@ contract User is Test {
 
         registryCoordinator = deployer.registryCoordinator();
         avsDirectory = deployer.avsDirectory();
-        serviceManager = ServiceManagerBase(address(registryCoordinator.serviceManager()));
+        serviceManager = ServiceManagerBase(address(deployer.serviceManager()));
 
         blsApkRegistry = BLSApkRegistry(address(registryCoordinator.blsApkRegistry()));
         stakeRegistry = StakeRegistry(address(registryCoordinator.stakeRegistry()));
@@ -124,6 +129,7 @@ contract User is Test {
         _log("registerOperator", quorums);
 
         vm.warp(block.timestamp + 1);
+
         registryCoordinator.registerOperator({
             quorumNumbers: quorums,
             socket: NAME,
@@ -161,61 +167,10 @@ contract User is Test {
 
         bytes memory allQuorums = churnBitmap.plus(standardBitmap).bitmapToBytesArray();
 
-        ISlashingRegistryCoordinator.OperatorKickParam[] memory kickParams =
-            new ISlashingRegistryCoordinator.OperatorKickParam[](allQuorums.length);
-
-        // this constructs OperatorKickParam[] in ascending quorum order
-        // (yikes)
-        uint256 churnIdx;
-        uint256 stdIdx;
-        while (churnIdx + stdIdx < allQuorums.length) {
-            if (churnIdx == churnQuorums.length) {
-                kickParams[churnIdx + stdIdx] = ISlashingRegistryCoordinatorTypes.OperatorKickParam({
-                    quorumNumber: 0,
-                    operator: address(0)
-                });
-                stdIdx++;
-            } else if (
-                stdIdx == standardQuorums.length || churnQuorums[churnIdx] < standardQuorums[stdIdx]
-            ) {
-                kickParams[churnIdx + stdIdx] = ISlashingRegistryCoordinatorTypes.OperatorKickParam({
-                    quorumNumber: uint8(churnQuorums[churnIdx]),
-                    operator: address(churnTargets[churnIdx])
-                });
-                churnIdx++;
-            } else if (standardQuorums[stdIdx] < churnQuorums[churnIdx]) {
-                kickParams[churnIdx + stdIdx] = ISlashingRegistryCoordinatorTypes.OperatorKickParam({
-                    quorumNumber: 0,
-                    operator: address(0)
-                });
-                stdIdx++;
-            } else {
-                revert("User.registerOperatorWithChurn: malformed input");
-            }
-        }
-
-        // Generate churn approver signature
-        bytes32 _salt = keccak256(abi.encodePacked(++salt, address(this)));
-        uint256 expiry = type(uint256).max;
-        bytes32 digest = registryCoordinator.calculateOperatorChurnApprovalDigestHash({
-            registeringOperator: address(this),
-            registeringOperatorId: operatorId,
-            operatorKickParams: kickParams,
-            salt: _salt,
-            expiry: expiry
-        });
-
-        // Sign digest
-        (uint8 v, bytes32 r, bytes32 s) = cheats.sign(churnApproverPrivateKey, digest);
-        bytes memory signature = new bytes(65);
-        assembly {
-            mstore(add(signature, 0x20), r)
-            mstore(add(signature, 0x40), s)
-        }
-        signature[signature.length - 1] = bytes1(v);
-
-        ISignatureUtils.SignatureWithSaltAndExpiry memory churnApproverSignature = ISignatureUtils
-            .SignatureWithSaltAndExpiry({signature: signature, salt: _salt, expiry: expiry});
+        (
+            ISlashingRegistryCoordinatorTypes.OperatorKickParam[] memory kickParams,
+            ISignatureUtils.SignatureWithSaltAndExpiry memory churnApproverSignature
+        ) = _generateOperatorKickParams(allQuorums, churnQuorums, churnTargets, standardQuorums);
 
         vm.warp(block.timestamp + 1);
         registryCoordinator.registerOperatorWithChurn({
@@ -388,6 +343,77 @@ contract User is Test {
         targetString = string.concat(targetString, "]");
 
         emit log_named_string("- churnTargets", targetString);
+    }
+
+    function _generateOperatorKickParams(
+        bytes memory allQuorums,
+        bytes calldata churnQuorums,
+        User[] calldata churnTargets,
+        bytes calldata standardQuorums
+    )
+        internal
+        virtual
+        returns (
+            ISlashingRegistryCoordinatorTypes.OperatorKickParam[] memory,
+            ISignatureUtils.SignatureWithSaltAndExpiry memory
+        )
+    {
+        ISlashingRegistryCoordinator.OperatorKickParam[] memory kickParams =
+            new ISlashingRegistryCoordinator.OperatorKickParam[](allQuorums.length);
+
+        // this constructs OperatorKickParam[] in ascending quorum order
+        // (yikes)
+        uint256 churnIdx;
+        uint256 stdIdx;
+        while (churnIdx + stdIdx < allQuorums.length) {
+            if (churnIdx == churnQuorums.length) {
+                kickParams[churnIdx + stdIdx] = ISlashingRegistryCoordinatorTypes.OperatorKickParam({
+                    quorumNumber: 0,
+                    operator: address(0)
+                });
+                stdIdx++;
+            } else if (
+                stdIdx == standardQuorums.length || churnQuorums[churnIdx] < standardQuorums[stdIdx]
+            ) {
+                kickParams[churnIdx + stdIdx] = ISlashingRegistryCoordinatorTypes.OperatorKickParam({
+                    quorumNumber: uint8(churnQuorums[churnIdx]),
+                    operator: address(churnTargets[churnIdx])
+                });
+                churnIdx++;
+            } else if (standardQuorums[stdIdx] < churnQuorums[churnIdx]) {
+                kickParams[churnIdx + stdIdx] = ISlashingRegistryCoordinatorTypes.OperatorKickParam({
+                    quorumNumber: 0,
+                    operator: address(0)
+                });
+                stdIdx++;
+            } else {
+                revert("User.registerOperatorWithChurn: malformed input");
+            }
+        }
+
+        // Generate churn approver signature
+        bytes32 _salt = keccak256(abi.encodePacked(++salt, address(this)));
+        uint256 expiry = type(uint256).max;
+        bytes32 digest = registryCoordinator.calculateOperatorChurnApprovalDigestHash({
+            registeringOperator: address(this),
+            registeringOperatorId: operatorId,
+            operatorKickParams: kickParams,
+            salt: _salt,
+            expiry: expiry
+        });
+
+        // Sign digest
+        (uint8 v, bytes32 r, bytes32 s) = cheats.sign(churnApproverPrivateKey, digest);
+        bytes memory signature = new bytes(65);
+        assembly {
+            mstore(add(signature, 0x20), r)
+            mstore(add(signature, 0x40), s)
+        }
+        signature[signature.length - 1] = bytes1(v);
+        ISignatureUtils.SignatureWithSaltAndExpiry memory churnApproverSignature = ISignatureUtils
+            .SignatureWithSaltAndExpiry({signature: signature, salt: _salt, expiry: expiry});
+
+        return (kickParams, churnApproverSignature);
     }
 }
 

--- a/test/integration/tests/Full_Register_Deregister.t.sol
+++ b/test/integration/tests/Full_Register_Deregister.t.sol
@@ -21,7 +21,8 @@ contract Integration_Full_Register_Deregister is IntegrationChecks {
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: NO_MINIMUM | HAS_MINIMUM,
-                fillTypes: FULL
+                fillTypes: FULL,
+                quorumType: DELEGATED_STAKE
             })
         });
 
@@ -71,7 +72,8 @@ contract Integration_Full_Register_Deregister is IntegrationChecks {
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: NO_MINIMUM | HAS_MINIMUM,
-                fillTypes: FULL
+                fillTypes: FULL,
+                quorumType: DELEGATED_STAKE
             })
         });
 
@@ -136,7 +138,8 @@ contract Integration_Full_Register_Deregister is IntegrationChecks {
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: NO_MINIMUM | HAS_MINIMUM,
-                fillTypes: FULL
+                fillTypes: FULL,
+                quorumType: DELEGATED_STAKE
             })
         });
 

--- a/test/integration/tests/NonFull_Register_CoreBalanceChange_Update.t.sol
+++ b/test/integration/tests/NonFull_Register_CoreBalanceChange_Update.t.sol
@@ -20,7 +20,8 @@ contract Integration_NonFull_Register_CoreBalanceChange_Update is IntegrationChe
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: HAS_MINIMUM,
-                fillTypes: EMPTY | SOME_FILL
+                fillTypes: EMPTY | SOME_FILL,
+                quorumType: DELEGATED_STAKE
             })
         });
 
@@ -64,7 +65,8 @@ contract Integration_NonFull_Register_CoreBalanceChange_Update is IntegrationChe
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: HAS_MINIMUM,
-                fillTypes: EMPTY | SOME_FILL
+                fillTypes: EMPTY | SOME_FILL,
+                quorumType: DELEGATED_STAKE
             })
         });
 
@@ -103,7 +105,8 @@ contract Integration_NonFull_Register_CoreBalanceChange_Update is IntegrationChe
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: HAS_MINIMUM,
-                fillTypes: EMPTY | SOME_FILL
+                fillTypes: EMPTY | SOME_FILL,
+                quorumType: DELEGATED_STAKE
             })
         });
 
@@ -138,7 +141,8 @@ contract Integration_NonFull_Register_CoreBalanceChange_Update is IntegrationChe
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: HAS_MINIMUM,
-                fillTypes: EMPTY | SOME_FILL
+                fillTypes: EMPTY | SOME_FILL,
+                quorumType: DELEGATED_STAKE
             })
         });
 
@@ -174,7 +178,8 @@ contract Integration_NonFull_Register_CoreBalanceChange_Update is IntegrationChe
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: HAS_MINIMUM,
-                fillTypes: EMPTY | SOME_FILL
+                fillTypes: EMPTY | SOME_FILL,
+                quorumType: DELEGATED_STAKE
             })
         });
 

--- a/test/integration/tests/NonFull_Register_Deregister.t.sol
+++ b/test/integration/tests/NonFull_Register_Deregister.t.sol
@@ -20,7 +20,8 @@ contract Integration_NonFull_Register_Deregister is IntegrationChecks {
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: NO_MINIMUM | HAS_MINIMUM,
-                fillTypes: EMPTY | SOME_FILL
+                fillTypes: EMPTY | SOME_FILL,
+                quorumType: DELEGATED_STAKE
             })
         });
 
@@ -52,7 +53,8 @@ contract Integration_NonFull_Register_Deregister is IntegrationChecks {
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: NO_MINIMUM | HAS_MINIMUM,
-                fillTypes: EMPTY | SOME_FILL
+                fillTypes: EMPTY | SOME_FILL,
+                quorumType: DELEGATED_STAKE
             })
         });
 
@@ -93,7 +95,8 @@ contract Integration_NonFull_Register_Deregister is IntegrationChecks {
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: NO_MINIMUM | HAS_MINIMUM,
-                fillTypes: EMPTY | SOME_FILL
+                fillTypes: EMPTY | SOME_FILL,
+                quorumType: DELEGATED_STAKE
             })
         });
 

--- a/test/mocks/AllocationManagerMock.sol
+++ b/test/mocks/AllocationManagerMock.sol
@@ -151,25 +151,4 @@ contract AllocationManagerIntermediate is IAllocationManager {
     ) external view virtual returns (bool) {}
 }
 
-contract AllocationManagerMock is AllocationManagerIntermediate {
-    bool defaultIsMemberOfOperatorSet;
-
-    constructor() {
-        // Return true by default to so that the SlashingRegistryCoordinator won't force deregister
-        // an operator for every quorum when a `updateOperators`,`updateOperatorsForQuorum` call is made
-        defaultIsMemberOfOperatorSet = true;
-    }
-
-    function isMemberOfOperatorSet(
-        address operator,
-        OperatorSet memory operatorSet
-    ) external view virtual override returns (bool) {
-        return defaultIsMemberOfOperatorSet;
-    }
-
-    function setDefaultIsMemberOfOperatorSet(
-        bool isMemberOfOperatorSet
-    ) external {
-        defaultIsMemberOfOperatorSet = isMemberOfOperatorSet;
-    }
-}
+contract AllocationManagerMock is AllocationManagerIntermediate {}

--- a/test/mocks/AllocationManagerMock.sol
+++ b/test/mocks/AllocationManagerMock.sol
@@ -151,4 +151,25 @@ contract AllocationManagerIntermediate is IAllocationManager {
     ) external view virtual returns (bool) {}
 }
 
-contract AllocationManagerMock is AllocationManagerIntermediate {}
+contract AllocationManagerMock is AllocationManagerIntermediate {
+    bool defaultIsMemberOfOperatorSet;
+
+    constructor() {
+        // Return true by default to so that the SlashingRegistryCoordinator won't force deregister
+        // an operator for every quorum when a `updateOperators`,`updateOperatorsForQuorum` call is made
+        defaultIsMemberOfOperatorSet = true;
+    }
+
+    function isMemberOfOperatorSet(
+        address operator,
+        OperatorSet memory operatorSet
+    ) external view virtual override returns (bool) {
+        return defaultIsMemberOfOperatorSet;
+    }
+
+    function setDefaultIsMemberOfOperatorSet(
+        bool isMemberOfOperatorSet
+    ) external {
+        defaultIsMemberOfOperatorSet = isMemberOfOperatorSet;
+    }
+}

--- a/test/unit/InstantSlasher.t.sol
+++ b/test/unit/InstantSlasher.t.sol
@@ -195,7 +195,8 @@ contract InstantSlasherTest is Test {
             AllocationManager.slashOperator.selector
         );
 
-        slashingRegistryCoordinator = SlashingRegistryCoordinator(middlewareDeployments.slashingRegistryCoordinator);
+        slashingRegistryCoordinator =
+            SlashingRegistryCoordinator(middlewareDeployments.slashingRegistryCoordinator);
         instantSlasher = InstantSlasher(middlewareDeployments.instantSlasher);
 
         PermissionController(coreDeployment.permissionController).setAppointee(

--- a/test/unit/InstantSlasher.t.sol
+++ b/test/unit/InstantSlasher.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, console2 as console} from "forge-std/Test.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {InstantSlasher} from "../../src/slashers/InstantSlasher.sol";
 import {
@@ -165,6 +165,7 @@ contract InstantSlasherTest is Test {
         middlewareConfig.stakeRegistry.strategyParams = 0;
         middlewareConfig.stakeRegistry.delegationManager = coreDeployment.delegationManager;
         middlewareConfig.stakeRegistry.avsDirectory = coreDeployment.avsDirectory;
+        middlewareConfig.instantSlasher.slasher = slasher;
         {
             IStakeRegistryTypes.StrategyParams[] memory stratParams =
                 new IStakeRegistryTypes.StrategyParams[](1);
@@ -194,11 +195,21 @@ contract InstantSlasherTest is Test {
             AllocationManager.slashOperator.selector
         );
 
+        slashingRegistryCoordinator = SlashingRegistryCoordinator(middlewareDeployments.slashingRegistryCoordinator);
+        instantSlasher = InstantSlasher(middlewareDeployments.instantSlasher);
+
         PermissionController(coreDeployment.permissionController).setAppointee(
             address(serviceManager),
             address(slashingRegistryCoordinator),
             coreDeployment.allocationManager,
             AllocationManager.createOperatorSets.selector
+        );
+
+        PermissionController(coreDeployment.permissionController).setAppointee(
+            address(serviceManager),
+            address(instantSlasher),
+            coreDeployment.allocationManager,
+            AllocationManager.slashOperator.selector
         );
 
         vm.stopPrank();

--- a/test/unit/InstantSlasher.t.sol
+++ b/test/unit/InstantSlasher.t.sol
@@ -186,14 +186,6 @@ contract InstantSlasherTest is Test {
         );
         vm.stopPrank();
 
-        instantSlasher = InstantSlasher(middlewareDeployments.instantSlasher);
-        slashingRegistryCoordinator =
-            SlashingRegistryCoordinator(middlewareDeployments.slashingRegistryCoordinator);
-        stakeRegistry = StakeRegistry(middlewareDeployments.stakeRegistry);
-        blsApkRegistry = BLSApkRegistry(middlewareDeployments.blsApkRegistry);
-        indexRegistry = IndexRegistry(middlewareDeployments.indexRegistry);
-        socketRegistry = SocketRegistry(middlewareDeployments.socketRegistry);
-
         vm.startPrank(serviceManager);
         PermissionController(coreDeployment.permissionController).setAppointee(
             address(serviceManager),

--- a/test/unit/VetoableSlasher.t.sol
+++ b/test/unit/VetoableSlasher.t.sol
@@ -202,6 +202,8 @@ contract VetoableSlasherTest is Test {
         vetoableSlasherImplementation = new VetoableSlasher(
             IAllocationManager(coreDeployment.allocationManager),
             ISlashingRegistryCoordinator(slashingRegistryCoordinator),
+            slasher,
+            vetoCommittee,
             vetoWindowBlocks
         );
 
@@ -217,8 +219,6 @@ contract VetoableSlasherTest is Test {
             address(vetoableSlasherImplementation)
         );
         vm.stopPrank();
-
-        vetoableSlasher.initialize(vetoCommittee, slasher);
 
         vm.startPrank(serviceManager);
         PermissionController(coreDeployment.permissionController).setAppointee(

--- a/test/unit/VetoableSlasher.t.sol
+++ b/test/unit/VetoableSlasher.t.sol
@@ -81,7 +81,7 @@ contract VetoableSlasherTest is Test {
     address public churnApprover = address(uint160(uint256(keccak256("churnApprover"))));
     address public ejector = address(uint160(uint256(keccak256("ejector"))));
 
-    uint256 constant VETO_PERIOD = 3 days;
+    uint32 constant vetoWindowBlocks = 3 days / 12 seconds;
     uint32 constant DEALLOCATION_DELAY = 7 days;
     uint32 constant ALLOCATION_CONFIGURATION_DELAY = 1 days;
 
@@ -201,7 +201,8 @@ contract VetoableSlasherTest is Test {
 
         vetoableSlasherImplementation = new VetoableSlasher(
             IAllocationManager(coreDeployment.allocationManager),
-            ISlashingRegistryCoordinator(slashingRegistryCoordinator)
+            ISlashingRegistryCoordinator(slashingRegistryCoordinator),
+            vetoWindowBlocks
         );
 
         vm.startPrank(proxyAdminOwner);
@@ -274,7 +275,7 @@ contract VetoableSlasherTest is Test {
 
     function test_initialization() public {
         assertEq(vetoableSlasher.vetoCommittee(), vetoCommittee);
-        assertEq(vetoableSlasher.VETO_PERIOD(), VETO_PERIOD);
+        assertEq(vetoableSlasher.vetoWindowBlocks(), vetoWindowBlocks);
     }
 
     function _createMockSlashingParams()
@@ -340,7 +341,7 @@ contract VetoableSlasherTest is Test {
         vm.prank(slasher);
         vetoableSlasher.queueSlashingRequest(params);
 
-        vm.warp(block.timestamp + VETO_PERIOD + 1);
+        vm.roll(block.number + vetoWindowBlocks + 1);
 
         vm.prank(vetoCommittee);
         vm.expectRevert(IVetoableSlasherErrors.VetoPeriodPassed.selector);
@@ -479,7 +480,7 @@ contract VetoableSlasherTest is Test {
         vetoableSlasher.queueSlashingRequest(params);
 
         // Wait for veto period to pass
-        vm.warp(block.timestamp + VETO_PERIOD + 1);
+        vm.roll(block.number + vetoWindowBlocks + 1);
 
         vm.prank(slasher);
         vetoableSlasher.fulfillSlashingRequest(0);

--- a/test/utils/MiddlewareDeployLib.sol
+++ b/test/utils/MiddlewareDeployLib.sol
@@ -193,8 +193,6 @@ library MiddlewareDeployLib {
                 slasherConfig.slasher
             )
         );
-        UpgradeableProxyLib.upgrade(
-            deployments.instantSlasher, instantSlasherImpl
-        );
+        UpgradeableProxyLib.upgrade(deployments.instantSlasher, instantSlasherImpl);
     }
 }

--- a/test/utils/MiddlewareDeployLib.sol
+++ b/test/utils/MiddlewareDeployLib.sol
@@ -193,10 +193,8 @@ library MiddlewareDeployLib {
                 slasherConfig.slasher
             )
         );
-        bytes memory upgradeCall =
-            abi.encodeCall(InstantSlasher.initialize, (slasherConfig.slasher));
-        UpgradeableProxyLib.upgradeAndCall(
-            deployments.instantSlasher, instantSlasherImpl, upgradeCall
+        UpgradeableProxyLib.upgrade(
+            deployments.instantSlasher, instantSlasherImpl
         );
     }
 }


### PR DESCRIPTION
Edge case fixed:
The AllocationManager has a try/catch in the `deregisterFromOperatorSets` implementation. This was put in place to allow operators to force deregister from an AVS. However this can lead to a weird state where an operator is registered in AVS contracts but deregistered from EigenLayer. Checks for this are added for forceDeregistration by the AVS to avoid reverts. In addition, AVSSync (`updateOperatorsForQuorum`, `updateOperator`) will now also include these operators to be force deregistered.

Refactored integration tests to only use the `SlashingRegistryCoordinator` and defines a `OperatorSetUser` contract.
The `SlashingRegistryCoordinator` and the Registry contracts do not depend on the ServiceManager base contract.
Interactions with the core protocol are integrated with UAM and setting the `avsAccountIdentifier` as the unique account identifier address for the AVS. For existing AVSs, this will be the address of your ServiceManager contract.

TODOs, could be implemented in followup PR
1. integration tests with the `RegistryCoordinator` and legacy quorums will require some fork integration testing refactor and testing the legacy interfaces. This is still a TODO that should be added.
2. Integration tests with slashing and allocations
    - Should test the following, allocate, register to AVS after meeting slashable stake threshold, slash operator, update stakes, expect operator to have been force deregistered
    - allocate, register to AVS meeting slashable stake threshold, create vetoeable slashing request, veto slash, expect operator magnitude and shares to be unchanged
