### PR TITLE
refactor: move forge test intense workflow into separate file

### DIFF
--- a/.github/workflows/forge-test-intense.yml
+++ b/.github/workflows/forge-test-intense.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
       - mainnet
       - testnet-holesky
       - dev
@@ -30,13 +29,13 @@ jobs:
           submodules: recursive
 
       # Install the Foundry toolchain.
-      - name: "Install Foundry"
+      - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: stable
 
       # Build the project and display contract sizes.
-      - name: "Forge Build"
+      - name: Forge Build
         run: |
           forge --version
           forge build --sizes

--- a/.github/workflows/forge-test-intense.yml
+++ b/.github/workflows/forge-test-intense.yml
@@ -1,0 +1,50 @@
+name: Forge Test (Intense)
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - mainnet
+      - testnet-holesky
+      - dev
+
+env:
+  FOUNDRY_PROFILE: ci
+  RPC_MAINNET: ${{ secrets.RPC_MAINNET }}
+  RPC_HOLESKY: ${{ secrets.RPC_HOLESKY }}
+  CHAIN_ID: ${{ secrets.CHAIN_ID }}
+  
+jobs:      
+  # -----------------------------------------------------------------------
+  # Forge Test (Intense)
+  # -----------------------------------------------------------------------
+
+  forge-test-intense:
+    name: Test (Intense)
+    runs-on: ubuntu-latest
+    steps:
+      # Check out repository with all submodules for complete codebase access.
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # Install the Foundry toolchain.
+      - name: "Install Foundry"
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      # Build the project and display contract sizes.
+      - name: "Forge Build"
+        run: |
+          forge --version
+          forge build --sizes
+        id: build
+
+      # Run Forge Test (Intense)
+      - name: Forge Test (Intense)
+        run: |
+          echo -e "\033[1;33mWarning: This workflow may take several hours to complete.\033[0m"
+          echo -e "\033[1;33mThis intense fuzzing workflow is optional but helps catch edge cases through extended testing.\033[0m"
+          FOUNDRY_PROFILE=intense forge test -vvv

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -4,9 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
       - mainnet
-      - testnet-goerli
+      - testnet-holesky
       - dev
   pull_request:
 
@@ -24,8 +23,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
     steps:
       # Check out repository with all submodules for complete codebase access.
       - uses: actions/checkout@v4
@@ -33,30 +30,30 @@ jobs:
           submodules: recursive
 
       # Install the Foundry toolchain.
-      - name: "Install Foundry"
+      - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: stable
 
       # Run Forge's formatting checker to ensure consistent code style.
-      - name: "Forge Fmt"
+      - name: Forge Fmt
         run: |
           forge fmt --check
         id: fmt
 
       # Build the project and display contract sizes.
-      - name: "Forge Build"
+      - name: Forge Build
         run: |
           forge --version
           forge build --sizes
         id: build
 
       # Run local tests (unit and integration).
-      - name: "Forge Test (Local)"
+      - name: Forge Test (Local)
         run: forge test -vvv
 
       # Run integration tests using a mainnet fork.
-      - name: "Forge Test Integration (Fork)"
+      - name: Forge Test Integration (Fork)
         run: FOUNDRY_PROFILE=forktest forge test --match-contract Integration -vvv
 
   # -----------------------------------------------------------------------
@@ -66,8 +63,6 @@ jobs:
   run-coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
     steps:
       # Check out repository with all submodules for complete codebase access.
       - uses: actions/checkout@v4
@@ -75,7 +70,7 @@ jobs:
           submodules: recursive
 
       # Install the Foundry toolchain.
-      - name: "Install Foundry"
+      - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: stable
@@ -87,7 +82,7 @@ jobs:
         id: lcov
 
       # Build the project and display contract sizes.
-      - name: "Forge Build"
+      - name: Forge Build
         run: |
           forge --version
           forge build --sizes
@@ -107,7 +102,7 @@ jobs:
           path: report/*
 
       # Check coverage threshold after uploading report
-      - name: Check Coverage Threshold
+      - name: Check Coverage Threshold for >=90%
         run: |
           LINES_PCT=$(lcov --summary lcov.info | grep "lines" | cut -d ':' -f 2 | cut -d '%' -f 1 | tr -d '[:space:]')
           FUNCTIONS_PCT=$(lcov --summary lcov.info | grep "functions" | cut -d ':' -f 2 | cut -d '%' -f 1 | tr -d '[:space:]')          
@@ -145,7 +140,7 @@ jobs:
           submodules: recursive
 
       # Install the Foundry toolchain.
-      - name: "Install Foundry"
+      - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: stable

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -60,41 +60,6 @@ jobs:
         run: FOUNDRY_PROFILE=forktest forge test --match-contract Integration -vvv
 
   # -----------------------------------------------------------------------
-  # Forge Test (Intense)
-  # -----------------------------------------------------------------------
-
-  continuous-fuzzing:
-    name: Test (Intense)
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-    steps:
-      # Check out repository with all submodules for complete codebase access.
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      # Install the Foundry toolchain.
-      - name: "Install Foundry"
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: stable
-
-      # Build the project and display contract sizes.
-      - name: "Forge Build"
-        run: |
-          forge --version
-          forge build --sizes
-        id: build
-
-      # Run Forge Test (Intense)
-      - name: Forge Test (Intense)
-        run: |
-          echo -e "\033[1;33mWarning: This workflow may take several hours to complete.\033[0m"
-          echo -e "\033[1;33mThis intense fuzzing workflow is optional but helps catch edge cases through extended testing.\033[0m"
-          FOUNDRY_PROFILE=intense forge test -vvv
-          
-  # -----------------------------------------------------------------------
   # Forge Coverage
   # -----------------------------------------------------------------------
 


### PR DESCRIPTION
**Motivation**

Currently, the `Forge Test (Intense)` workflow runs on every PR. However, the results of this workflow are not helpful for deciding whether to merge PRs, as the Intense workflow is designed for continuous fuzzing on an infrequent (e.g. once per day) basis. As such, this creates noise when reviewing PRs.

**Changes**
* Creates the `Forge Test (Intense)` workflow with its own triggers, moving the functionality out of `.github/workflows/foundry.yml`

**Impact**
* Removes checks from PRs that are not relevant for merging while still making sure they run either upon manual dispatch or when merging into critical branches