### PR TITLE
fix: avs registrar interface

### DIFF
--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -147,9 +147,11 @@ contract SlashingRegistryCoordinator is
     /// @inheritdoc ISlashingRegistryCoordinator
     function registerOperator(
         address operator,
+        address avs,
         uint32[] memory operatorSetIds,
         bytes calldata data
     ) external override onlyAllocationManager onlyWhenNotPaused(PAUSED_REGISTER_OPERATOR) {
+        require(avs == accountIdentifier, InvalidAVS());
         bytes memory quorumNumbers = _getQuorumNumbers(operatorSetIds);
 
         (
@@ -222,8 +224,10 @@ contract SlashingRegistryCoordinator is
     /// @inheritdoc ISlashingRegistryCoordinator
     function deregisterOperator(
         address operator,
+        address avs,
         uint32[] memory operatorSetIds
     ) external override onlyAllocationManager onlyWhenNotPaused(PAUSED_DEREGISTER_OPERATOR) {
+        require(avs == accountIdentifier, InvalidAVS());
         bytes memory quorumNumbers = _getQuorumNumbers(operatorSetIds);
         _deregisterOperator(operator, quorumNumbers);
     }

--- a/src/interfaces/ISlashingRegistryCoordinator.sol
+++ b/src/interfaces/ISlashingRegistryCoordinator.sol
@@ -51,6 +51,8 @@ interface ISlashingRegistryCoordinatorErrors {
     error NotSorted();
     /// @notice Thrown when maximum quorum count is reached.
     error MaxQuorumsReached();
+    /// @notice Thrown when registering/deregistering for the wrong AVS
+    error InvalidAVS();
 }
 
 interface ISlashingRegistryCoordinatorTypes {
@@ -306,6 +308,7 @@ interface ISlashingRegistryCoordinator is
     /**
      * @notice Registers an operator through the allocation manager for operator set quorums.
      * @param operator The operator address to register.
+     * @param avs The address of the AVS to register for.
      * @param operatorSetIds The operator set IDs to register for (corresponds to quorum numbers).
      * @param data Additional registration data containing the operator's socket and BLS public key parameters.
      * @dev Can only be called by the allocation manager.
@@ -314,6 +317,7 @@ interface ISlashingRegistryCoordinator is
      */
     function registerOperator(
         address operator,
+        address avs,
         uint32[] memory operatorSetIds,
         bytes memory data
     ) external;
@@ -321,12 +325,13 @@ interface ISlashingRegistryCoordinator is
     /**
      * @notice Deregisters an operator through the allocation manager from operator set quorums.
      * @param operator The operator address to deregister.
+     * @param avs The address of the AVS to deregister from.
      * @param operatorSetIds The operator set IDs to deregister from (corresponds to quorum numbers).
      * @dev Can only be called by the allocation manager.
      * @dev Will revert if operator sets are not enabled or if deregistering from M2 quorums.
      * @dev This function implements the Slashing deregistration pathway specified by the IAVSRegistrar interface.
      */
-    function deregisterOperator(address operator, uint32[] memory operatorSetIds) external;
+    function deregisterOperator(address operator, address avs, uint32[] memory operatorSetIds) external;
 
     /**
      * @notice Updates stake weights for specified operators. If any operator is found to be below

--- a/src/interfaces/ISlashingRegistryCoordinator.sol
+++ b/src/interfaces/ISlashingRegistryCoordinator.sol
@@ -331,7 +331,11 @@ interface ISlashingRegistryCoordinator is
      * @dev Will revert if operator sets are not enabled or if deregistering from M2 quorums.
      * @dev This function implements the Slashing deregistration pathway specified by the IAVSRegistrar interface.
      */
-    function deregisterOperator(address operator, address avs, uint32[] memory operatorSetIds) external;
+    function deregisterOperator(
+        address operator,
+        address avs,
+        uint32[] memory operatorSetIds
+    ) external;
 
     /**
      * @notice Updates stake weights for specified operators. If any operator is found to be below

--- a/test/mocks/AVSRegistrarMock.sol
+++ b/test/mocks/AVSRegistrarMock.sol
@@ -9,13 +9,11 @@ contract AVSRegistrarMock is IAVSRegistrar {
         address avs,
         uint32[] calldata operatorSetIds,
         bytes calldata data
-    ) external override {
-    }
+    ) external override {}
 
     function deregisterOperator(
         address operator,
         address avs,
         uint32[] calldata operatorSetIds
-    ) external override {
-    }
+    ) external override {}
 }

--- a/test/mocks/AVSRegistrarMock.sol
+++ b/test/mocks/AVSRegistrarMock.sol
@@ -6,12 +6,16 @@ import {IAVSRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IAVSR
 contract AVSRegistrarMock is IAVSRegistrar {
     function registerOperator(
         address operator,
+        address avs,
         uint32[] calldata operatorSetIds,
         bytes calldata data
-    ) external override {}
+    ) external override {
+    }
 
     function deregisterOperator(
         address operator,
+        address avs,
         uint32[] calldata operatorSetIds
-    ) external override {}
+    ) external override {
+    }
 }

--- a/test/mocks/AllocationManagerMock.sol
+++ b/test/mocks/AllocationManagerMock.sol
@@ -149,14 +149,17 @@ contract AllocationManagerIntermediate is IAllocationManager {
         OperatorSet memory operatorSet,
         address[] memory operators,
         IStrategy[] memory strategies
-    ) public view returns (uint256[][] memory) {
-    }
+    ) public view returns (uint256[][] memory) {}
 
-    function getEncumberedMagnitude(address operator, IStrategy strategy) external view returns (uint64) {
-    }
+    function getEncumberedMagnitude(
+        address operator,
+        IStrategy strategy
+    ) external view returns (uint64) {}
 
-    function isOperatorSlashable(address operator, OperatorSet memory operatorSet) public view returns (bool) {
-    }
+    function isOperatorSlashable(
+        address operator,
+        OperatorSet memory operatorSet
+    ) public view returns (bool) {}
 
     function isMemberOfOperatorSet(
         address operator,

--- a/test/mocks/AllocationManagerMock.sol
+++ b/test/mocks/AllocationManagerMock.sol
@@ -145,6 +145,19 @@ contract AllocationManagerIntermediate is IAllocationManager {
         uint32 futureBlock
     ) external view virtual returns (uint256[][] memory slashableStake) {}
 
+    function getAllocatedStake(
+        OperatorSet memory operatorSet,
+        address[] memory operators,
+        IStrategy[] memory strategies
+    ) public view returns (uint256[][] memory) {
+    }
+
+    function getEncumberedMagnitude(address operator, IStrategy strategy) external view returns (uint64) {
+    }
+
+    function isOperatorSlashable(address operator, OperatorSet memory operatorSet) public view returns (bool) {
+    }
+
     function isMemberOfOperatorSet(
         address operator,
         OperatorSet memory operatorSet

--- a/test/mocks/EigenPodManagerMock.sol
+++ b/test/mocks/EigenPodManagerMock.sol
@@ -92,7 +92,6 @@ contract EigenPodManagerMock is Test, Pausable, IEigenPodManager {
     function addShares(
         address staker,
         IStrategy strategy,
-        IERC20 token,
         uint256 shares
     ) external returns (uint256, uint256) {}
 

--- a/test/mocks/RewardsCoordinatorMock.sol
+++ b/test/mocks/RewardsCoordinatorMock.sol
@@ -29,22 +29,6 @@ contract RewardsCoordinatorMock is IRewardsCoordinator {
         RewardsSubmission[] calldata rewardsSubmissions
     ) external override {}
 
-    function createOperatorDirectedOperatorSetRewardsSubmission(
-        OperatorSet calldata operatorSet,
-        OperatorDirectedRewardsSubmission[] calldata operatorDirectedRewardsSubmissions
-    ) external override {}
-
-    function getOperatorSetSplit(
-        address operator,
-        OperatorSet calldata operatorSet
-    ) external view override returns (uint16) {}
-
-    function setOperatorSetSplit(
-        address operator,
-        OperatorSet calldata operatorSet,
-        uint16 split
-    ) external override {}
-
     function createOperatorDirectedAVSRewardsSubmission(
         address avs,
         OperatorDirectedRewardsSubmission[] calldata operatorDirectedRewardsSubmissions

--- a/test/unit/RegistryCoordinatorUnit.t.sol
+++ b/test/unit/RegistryCoordinatorUnit.t.sol
@@ -2336,7 +2336,7 @@ contract RegistryCoordinatorUnitTests_BeforeMigration is RegistryCoordinatorUnit
         cheats.prank(address(registryCoordinator.allocationManager()));
         cheats.expectRevert();
         registryCoordinator.registerOperator(
-            defaultOperator, new uint32[](0), abi.encode(defaultSocket, pubkeyRegistrationParams)
+            defaultOperator, address(serviceManager), new uint32[](0), abi.encode(defaultSocket, pubkeyRegistrationParams)
         );
     }
 
@@ -2345,7 +2345,7 @@ contract RegistryCoordinatorUnitTests_BeforeMigration is RegistryCoordinatorUnit
         operatorSetIds[0] = 0;
         cheats.prank(address(registryCoordinator.allocationManager()));
         cheats.expectRevert();
-        registryCoordinator.deregisterOperator(defaultOperator, operatorSetIds);
+        registryCoordinator.deregisterOperator(defaultOperator, address(serviceManager), operatorSetIds);
     }
 
     function test_CreateTotalDelegatedStakeQuorum() public {
@@ -2577,7 +2577,7 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
             abi.encode(ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, socket, params);
 
         cheats.prank(address(registryCoordinator.allocationManager()));
-        registryCoordinator.registerOperator(defaultOperator, operatorSetIds, data);
+        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
     }
 
     function test_registerHook_WithChurn() public {
@@ -2634,7 +2634,7 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
 
         // Prank as allocation manager and call register hook
         cheats.prank(address(registryCoordinator.allocationManager()));
-        registryCoordinator.registerOperator(defaultOperator, operatorSetIds, data);
+        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
     }
 
     function test_updateStakesForQuorum() public {
@@ -2703,7 +2703,7 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
             abi.encode(ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, socket, params);
 
         cheats.startPrank(address(registryCoordinator.allocationManager()));
-        registryCoordinator.registerOperator(defaultOperator, operatorSetIds, data);
+        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
 
         // registryCoordinator.deregisterOperator(defaultOperator, operatorSetIds);
 
@@ -2748,7 +2748,7 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
             abi.encode(ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, socket, params);
 
         vm.expectRevert();
-        registryCoordinator.registerOperator(defaultOperator, operatorSetIds, data);
+        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
     }
 
     function test_deregisterHook_Reverts_WhenNotALM() public {
@@ -2792,10 +2792,68 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
             abi.encode(ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, socket, params);
 
         cheats.prank(address(registryCoordinator.allocationManager()));
-        registryCoordinator.registerOperator(defaultOperator, operatorSetIds, data);
+        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
 
         cheats.expectRevert();
-        registryCoordinator.deregisterOperator(defaultOperator, operatorSetIds);
+        registryCoordinator.deregisterOperator(defaultOperator, address(serviceManager), operatorSetIds);
+    }
+
+    function test_deregisterHook_Reverts_WhenInvalidAVS() public {
+        _deployMockEigenLayerAndAVS(0);
+        address invalidAVS = address(0x1);
+
+        // Create quorum params
+        ISlashingRegistryCoordinatorTypes.OperatorSetParam memory operatorSetParams =
+        ISlashingRegistryCoordinatorTypes.OperatorSetParam({
+            maxOperatorCount: 10,
+            kickBIPsOfOperatorStake: 1000,
+            kickBIPsOfTotalStake: 100
+        });
+
+        uint96 minimumStake = 100;
+        IStakeRegistryTypes.StrategyParams[] memory strategyParams =
+            new IStakeRegistryTypes.StrategyParams[](1);
+        strategyParams[0] =
+            IStakeRegistryTypes.StrategyParams({strategy: IStrategy(address(1)), multiplier: 10000});
+
+        // Create total delegated stake quorum
+        cheats.prank(registryCoordinatorOwner);
+        registryCoordinator.createTotalDelegatedStakeQuorum(operatorSetParams, 0, strategyParams);
+
+        // operator sets should be enabled after creating a new quorum
+        assertTrue(registryCoordinator.operatorSetsEnabled(), "operatorSetsEnabled should be true");
+
+        // Prank as allocation manager and call register hook
+        uint32[] memory operatorSetIds = new uint32[](1);
+        operatorSetIds[0] = 0;
+
+        string memory socket = "socket";
+        IBLSApkRegistryTypes.PubkeyRegistrationParams memory params;
+        // TODO:
+        // params = IBLSApkRegistryTypes.PubkeyRegistrationParams({
+        //     pubkeyG1: defaultPubKey,
+        //     pubkeyG2: defaultPubKeyG2,
+        //     pubkeySignature: defaultPubKeySignature
+        // });
+
+        bytes memory data =
+            abi.encode(ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, socket, params);
+
+        // Check revert case when register callback is for wrong AVS
+        cheats.prank(address(registryCoordinator.allocationManager()));
+        cheats.expectRevert(ISlashingRegistryCoordinatorErrors.InvalidAVS.selector);
+        registryCoordinator.registerOperator(defaultOperator, invalidAVS, operatorSetIds, data);
+
+        cheats.prank(address(registryCoordinator.allocationManager()));
+        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
+
+        // Check revert case when deregistering for wrong AVS
+        cheats.prank(address(registryCoordinator.allocationManager()));
+        cheats.expectRevert(ISlashingRegistryCoordinatorErrors.InvalidAVS.selector);
+        registryCoordinator.deregisterOperator(defaultOperator, invalidAVS, operatorSetIds);
+
+        cheats.prank(address(registryCoordinator.allocationManager()));
+        registryCoordinator.deregisterOperator(defaultOperator, address(serviceManager), operatorSetIds);
     }
 
     function test_DeregisterHook_Reverts_WhenM2Quorum() public {

--- a/test/unit/RegistryCoordinatorUnit.t.sol
+++ b/test/unit/RegistryCoordinatorUnit.t.sol
@@ -2336,7 +2336,10 @@ contract RegistryCoordinatorUnitTests_BeforeMigration is RegistryCoordinatorUnit
         cheats.prank(address(registryCoordinator.allocationManager()));
         cheats.expectRevert();
         registryCoordinator.registerOperator(
-            defaultOperator, address(serviceManager), new uint32[](0), abi.encode(defaultSocket, pubkeyRegistrationParams)
+            defaultOperator,
+            address(serviceManager),
+            new uint32[](0),
+            abi.encode(defaultSocket, pubkeyRegistrationParams)
         );
     }
 
@@ -2345,7 +2348,9 @@ contract RegistryCoordinatorUnitTests_BeforeMigration is RegistryCoordinatorUnit
         operatorSetIds[0] = 0;
         cheats.prank(address(registryCoordinator.allocationManager()));
         cheats.expectRevert();
-        registryCoordinator.deregisterOperator(defaultOperator, address(serviceManager), operatorSetIds);
+        registryCoordinator.deregisterOperator(
+            defaultOperator, address(serviceManager), operatorSetIds
+        );
     }
 
     function test_CreateTotalDelegatedStakeQuorum() public {
@@ -2577,7 +2582,9 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
             abi.encode(ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, socket, params);
 
         cheats.prank(address(registryCoordinator.allocationManager()));
-        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
+        registryCoordinator.registerOperator(
+            defaultOperator, address(serviceManager), operatorSetIds, data
+        );
     }
 
     function test_registerHook_WithChurn() public {
@@ -2634,7 +2641,9 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
 
         // Prank as allocation manager and call register hook
         cheats.prank(address(registryCoordinator.allocationManager()));
-        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
+        registryCoordinator.registerOperator(
+            defaultOperator, address(serviceManager), operatorSetIds, data
+        );
     }
 
     function test_updateStakesForQuorum() public {
@@ -2703,7 +2712,9 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
             abi.encode(ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, socket, params);
 
         cheats.startPrank(address(registryCoordinator.allocationManager()));
-        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
+        registryCoordinator.registerOperator(
+            defaultOperator, address(serviceManager), operatorSetIds, data
+        );
 
         // registryCoordinator.deregisterOperator(defaultOperator, operatorSetIds);
 
@@ -2748,7 +2759,9 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
             abi.encode(ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, socket, params);
 
         vm.expectRevert();
-        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
+        registryCoordinator.registerOperator(
+            defaultOperator, address(serviceManager), operatorSetIds, data
+        );
     }
 
     function test_deregisterHook_Reverts_WhenNotALM() public {
@@ -2792,10 +2805,14 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
             abi.encode(ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, socket, params);
 
         cheats.prank(address(registryCoordinator.allocationManager()));
-        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
+        registryCoordinator.registerOperator(
+            defaultOperator, address(serviceManager), operatorSetIds, data
+        );
 
         cheats.expectRevert();
-        registryCoordinator.deregisterOperator(defaultOperator, address(serviceManager), operatorSetIds);
+        registryCoordinator.deregisterOperator(
+            defaultOperator, address(serviceManager), operatorSetIds
+        );
     }
 
     function test_deregisterHook_Reverts_WhenInvalidAVS() public {
@@ -2845,7 +2862,9 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
         registryCoordinator.registerOperator(defaultOperator, invalidAVS, operatorSetIds, data);
 
         cheats.prank(address(registryCoordinator.allocationManager()));
-        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
+        registryCoordinator.registerOperator(
+            defaultOperator, address(serviceManager), operatorSetIds, data
+        );
 
         // Check revert case when deregistering for wrong AVS
         cheats.prank(address(registryCoordinator.allocationManager()));
@@ -2853,7 +2872,9 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
         registryCoordinator.deregisterOperator(defaultOperator, invalidAVS, operatorSetIds);
 
         cheats.prank(address(registryCoordinator.allocationManager()));
-        registryCoordinator.deregisterOperator(defaultOperator, address(serviceManager), operatorSetIds);
+        registryCoordinator.deregisterOperator(
+            defaultOperator, address(serviceManager), operatorSetIds
+        );
     }
 
     function test_DeregisterHook_Reverts_WhenM2Quorum() public {


### PR DESCRIPTION
Updated eigenlayer-contracts submodule commit based on breaking interface change here https://github.com/Layr-Labs/eigenlayer-contracts/pull/1085.

Added avs require checks in `registerOperator`, `deregisterOperator` and fixed other affected interfaces.