### PR TITLE
feat: avs identifier callback and handle ejected operators

### DIFF
--- a/src/EjectionManager.sol
+++ b/src/EjectionManager.sol
@@ -9,8 +9,6 @@ import {
     IStakeRegistry
 } from "./EjectionManagerStorage.sol";
 
-// TODO: double check order of inheritance since we separated storage from logic...
-
 /**
  * @title Used for automated ejection of operators from the SlashingRegistryCoordinator under a ratelimit
  * @author Layr Labs, Inc.

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -165,9 +165,10 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
         uint192 quorumsToRemove =
             uint192(BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers, quorumCount));
         if (operatorInfo.status == OperatorStatus.REGISTERED && !quorumsToRemove.isEmpty()) {
+            // Allocate memory once outside the loop
+            bytes memory singleQuorumNumber = new bytes(1);
             // For each quorum number, check if it's an M2 quorum
             for (uint256 i = 0; i < quorumNumbers.length; i++) {
-                bytes memory singleQuorumNumber = new bytes(1);
                 singleQuorumNumber[0] = quorumNumbers[i];
 
                 if (_isM2Quorum(uint8(quorumNumbers[i]))) {

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -160,7 +160,7 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
         override(ISlashingRegistryCoordinator, SlashingRegistryCoordinator)
         onlyEjector
     {
-        _kickOperators({operator: operator, quorumNumbers: quorumNumbers, isEjection: true});
+        _kickOperator({operator: operator, quorumNumbers: quorumNumbers, isEjection: true});
     }
 
     /**
@@ -221,7 +221,7 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
 
                 bytes memory singleQuorumNumber = new bytes(1);
                 singleQuorumNumber[0] = quorumNumbers[i];
-                _kickOperators({
+                _kickOperator({
                     operator: operatorKickParams[i].operator,
                     quorumNumbers: singleQuorumNumber,
                     isEjection: false
@@ -230,8 +230,8 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
         }
     }
 
-    /// @dev override the _kickOperators function to handle M2 quorum ejection
-    function _kickOperators(
+    /// @dev override the _kickOperator function to handle M2 quorum ejection
+    function _kickOperator(
         address operator,
         bytes memory quorumNumbers,
         bool isEjection
@@ -333,7 +333,7 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
 
         for (uint256 i = 0; i < operators.length; ++i) {
             if (doesNotMeetStakeThreshold[i]) {
-                _kickOperators({
+                _kickOperator({
                     operator: operators[i],
                     quorumNumbers: singleQuorumNumber,
                     isEjection: false

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -228,7 +228,7 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
             // so check for operatorSet inclusion in the AllocationManager
             if (!isM2Quorum) {
                 registeredInCore = allocationManager.isMemberOfOperatorSet(
-                    operators[i], OperatorSet({avs: accountIdentifier, id: uint32(quorumNumber)})
+                    operators[i], OperatorSet({avs: avs, id: uint32(quorumNumber)})
                 );
             }
 

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -159,13 +159,8 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
     /// @dev override the _kickOperator function to handle M2 quorum ejection
     function _kickOperator(
         address operator,
-        bytes memory quorumNumbers,
-        bool isEjection
+        bytes memory quorumNumbers
     ) internal virtual override {
-        if (isEjection) {
-            lastEjectionTimestamp[operator] = block.timestamp;
-        }
-
         OperatorInfo storage operatorInfo = _operatorInfo[operator];
         uint192 quorumsToRemove =
             uint192(BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers, quorumCount));
@@ -259,11 +254,7 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
 
         for (uint256 i = 0; i < operators.length; ++i) {
             if (doesNotMeetStakeThreshold[i]) {
-                _kickOperator({
-                    operator: operators[i],
-                    quorumNumbers: singleQuorumNumber,
-                    isEjection: false
-                });
+                _kickOperator(operators[i], singleQuorumNumber);
             }
         }
     }

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -156,7 +156,7 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
      *
      */
 
-    /// @dev override the _kickOperator function to handle M2 quorum ejection
+    /// @dev override the _kickOperator function to handle M2 quorum forced deregistration
     function _kickOperator(
         address operator,
         bytes memory quorumNumbers

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -156,67 +156,6 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
      *
      */
 
-    /**
-     * @notice Internal function to handle operator registration with churn
-     * @param operator The operator to register
-     * @param operatorId The operator's ID
-     * @param quorumNumbers The quorum numbers to register for
-     * @param socket The operator's socket
-     * @param operatorKickParams The parameters needed to kick operators from quorums that have reached their caps
-     * @param churnApproverSignature The churnApprover's signature approving the registration
-     */
-    function _registerOperatorWithChurn(
-        address operator,
-        bytes32 operatorId,
-        bytes memory quorumNumbers,
-        string memory socket,
-        OperatorKickParam[] memory operatorKickParams,
-        SignatureWithSaltAndExpiry memory churnApproverSignature
-    ) internal virtual override {
-        // verify churnApprover's signature
-        _verifyChurnApproverSignature(
-            operator, operatorId, operatorKickParams, churnApproverSignature
-        );
-
-        // quorum bitmap and registration status
-        RegisterResults memory results = _registerOperator({
-            operator: operator,
-            operatorId: operatorId,
-            quorumNumbers: quorumNumbers,
-            socket: socket,
-            checkMaxOperatorCount: false
-        });
-
-        // Check that each quorum's operator count is below the configured maximum. If the max
-        // is exceeded, use `operatorKickParams` to deregister an existing operator to make space
-        for (uint256 i = 0; i < quorumNumbers.length; i++) {
-            OperatorSetParam memory operatorSetParams = _quorumParams[uint8(quorumNumbers[i])];
-
-            /**
-             * If the new operator count for any quorum exceeds the maximum, validate
-             * that churn can be performed, then deregister the specified operator
-             */
-            if (results.numOperatorsPerQuorum[i] > operatorSetParams.maxOperatorCount) {
-                _validateChurn({
-                    quorumNumber: uint8(quorumNumbers[i]),
-                    totalQuorumStake: results.totalStakes[i],
-                    newOperator: operator,
-                    newOperatorStake: results.operatorStakes[i],
-                    kickParams: operatorKickParams[i],
-                    setParams: operatorSetParams
-                });
-
-                bytes memory singleQuorumNumber = new bytes(1);
-                singleQuorumNumber[0] = quorumNumbers[i];
-                _kickOperator({
-                    operator: operatorKickParams[i].operator,
-                    quorumNumbers: singleQuorumNumber,
-                    isEjection: false
-                });
-            }
-        }
-    }
-
     /// @dev override the _kickOperator function to handle M2 quorum ejection
     function _kickOperator(
         address operator,

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -134,11 +134,7 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
             OnlyM2QuorumsAllowed()
         );
 
-        _deregisterOperator({
-            operator: msg.sender,
-            quorumNumbers: quorumNumbers,
-            shouldForceDeregister: false
-        });
+        _deregisterOperator({operator: msg.sender, quorumNumbers: quorumNumbers});
     }
 
     /// @inheritdoc IRegistryCoordinator
@@ -173,11 +169,7 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
 
                 if (_isM2Quorum(uint8(quorumNumbers[i]))) {
                     // For M2 quorums, use _deregisterOperator
-                    _deregisterOperator({
-                        operator: operator,
-                        quorumNumbers: singleQuorumNumber,
-                        shouldForceDeregister: true
-                    });
+                    _deregisterOperator({operator: operator, quorumNumbers: singleQuorumNumber});
                 } else {
                     // For non-M2 quorums, use _forceDeregisterOperator
                     _forceDeregisterOperator(operator, singleQuorumNumber);

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -150,19 +150,6 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
         emit M2QuorumRegistrationDisabled();
     }
 
-    /// @inheritdoc ISlashingRegistryCoordinator
-    function ejectOperator(
-        address operator,
-        bytes memory quorumNumbers
-    )
-        public
-        virtual
-        override(ISlashingRegistryCoordinator, SlashingRegistryCoordinator)
-        onlyEjector
-    {
-        _kickOperator({operator: operator, quorumNumbers: quorumNumbers, isEjection: true});
-    }
-
     /**
      *
      *                            INTERNAL FUNCTIONS

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -150,11 +150,119 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
         emit M2QuorumRegistrationDisabled();
     }
 
+    /// @inheritdoc ISlashingRegistryCoordinator
+    function ejectOperator(
+        address operator,
+        bytes memory quorumNumbers
+    )
+        public
+        virtual
+        override(ISlashingRegistryCoordinator, SlashingRegistryCoordinator)
+        onlyEjector
+    {
+        _kickOperators({operator: operator, quorumNumbers: quorumNumbers, isEjection: true});
+    }
+
     /**
      *
      *                            INTERNAL FUNCTIONS
      *
      */
+
+    /**
+     * @notice Internal function to handle operator registration with churn
+     * @param operator The operator to register
+     * @param operatorId The operator's ID
+     * @param quorumNumbers The quorum numbers to register for
+     * @param socket The operator's socket
+     * @param operatorKickParams The parameters needed to kick operators from quorums that have reached their caps
+     * @param churnApproverSignature The churnApprover's signature approving the registration
+     */
+    function _registerOperatorWithChurn(
+        address operator,
+        bytes32 operatorId,
+        bytes memory quorumNumbers,
+        string memory socket,
+        OperatorKickParam[] memory operatorKickParams,
+        SignatureWithSaltAndExpiry memory churnApproverSignature
+    ) internal virtual override {
+        // verify churnApprover's signature
+        _verifyChurnApproverSignature(
+            operator, operatorId, operatorKickParams, churnApproverSignature
+        );
+
+        // quorum bitmap and registration status
+        RegisterResults memory results = _registerOperator({
+            operator: operator,
+            operatorId: operatorId,
+            quorumNumbers: quorumNumbers,
+            socket: socket,
+            checkMaxOperatorCount: false
+        });
+
+        // Check that each quorum's operator count is below the configured maximum. If the max
+        // is exceeded, use `operatorKickParams` to deregister an existing operator to make space
+        for (uint256 i = 0; i < quorumNumbers.length; i++) {
+            OperatorSetParam memory operatorSetParams = _quorumParams[uint8(quorumNumbers[i])];
+
+            /**
+             * If the new operator count for any quorum exceeds the maximum, validate
+             * that churn can be performed, then deregister the specified operator
+             */
+            if (results.numOperatorsPerQuorum[i] > operatorSetParams.maxOperatorCount) {
+                _validateChurn({
+                    quorumNumber: uint8(quorumNumbers[i]),
+                    totalQuorumStake: results.totalStakes[i],
+                    newOperator: operator,
+                    newOperatorStake: results.operatorStakes[i],
+                    kickParams: operatorKickParams[i],
+                    setParams: operatorSetParams
+                });
+
+                bytes memory singleQuorumNumber = new bytes(1);
+                singleQuorumNumber[0] = quorumNumbers[i];
+                _kickOperators({
+                    operator: operatorKickParams[i].operator,
+                    quorumNumbers: singleQuorumNumber,
+                    isEjection: false
+                });
+            }
+        }
+    }
+
+    /// @dev override the _kickOperators function to handle M2 quorum ejection
+    function _kickOperators(
+        address operator,
+        bytes memory quorumNumbers,
+        bool isEjection
+    ) internal virtual override {
+        if (isEjection) {
+            lastEjectionTimestamp[operator] = block.timestamp;
+        }
+
+        OperatorInfo storage operatorInfo = _operatorInfo[operator];
+        uint192 quorumsToRemove =
+            uint192(BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers, quorumCount));
+        if (operatorInfo.status == OperatorStatus.REGISTERED && !quorumsToRemove.isEmpty()) {
+            // For each quorum number, check if it's an M2 quorum
+            for (uint256 i = 0; i < quorumNumbers.length; i++) {
+                bytes memory singleQuorumNumber = new bytes(1);
+                singleQuorumNumber[0] = quorumNumbers[i];
+
+                if (_isM2Quorum(uint8(quorumNumbers[i]))) {
+                    // For M2 quorums, use _deregisterOperator
+                    _deregisterOperator({
+                        operator: operator,
+                        quorumNumbers: singleQuorumNumber,
+                        shouldForceDeregister: true
+                    });
+                } else {
+                    // For non-M2 quorums, use _forceDeregisterOperator
+                    _forceDeregisterOperator(operator, singleQuorumNumber);
+                }
+            }
+        }
+    }
 
     /// @dev override the _forceDeregisterOperator function to handle M2 quorum deregistration
     function _forceDeregisterOperator(
@@ -204,14 +312,16 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
     }
 
     /**
-     * @dev Helper function to update operator stakes and deregister loiterers
-     * Loiterers are AVS registered operators who have force deregistered from the OperatorSet/quorum
-     * in the core EigenLayer contract AllocationManager but not deregistered from the OperatorSet/quorum
-     * in this contract. Potentially due to out of gas errors in the deregistration callback. This function
-     * will handle that edge case by deregistering the operator from the AVS if they are no longer registered
-     * in the AllocationManager.
+     * @dev Helper function to update operator stakes and deregister operators with insufficient stake
+     * This function handles two cases:
+     * 1. Operators who no longer meet the minimum stake requirement for a quorum
+     * 2. Operators who have been force-deregistered from the AllocationManager but not from this contract
+     * (e.g. due to out of gas errors in the deregistration callback)
+     * @param operators The list of operators to check and update
+     * @param operatorIds The corresponding operator IDs
+     * @param quorumNumber The quorum number to check stakes for
      */
-    function _updateStakesAndDeregisterLoiterers(
+    function _updateOperatorsStakes(
         address[] memory operators,
         bytes32[] memory operatorIds,
         uint8 quorumNumber
@@ -222,30 +332,11 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
             stakeRegistry.updateOperatorsStake(operators, operatorIds, quorumNumber);
 
         for (uint256 i = 0; i < operators.length; ++i) {
-            bool isM2Quorum = _isM2Quorum(quorumNumber);
-            bool registeredInCore;
-            // If its an operatorSet quorum, its possible for registeredInCore to be true/false
-            // so check for operatorSet inclusion in the AllocationManager
-            if (!isM2Quorum) {
-                registeredInCore = allocationManager.isMemberOfOperatorSet(
-                    operators[i], OperatorSet({avs: avs, id: uint32(quorumNumber)})
-                );
-            }
-
-            // Determine if the operator should be deregistered
-            // If the operator does not have the minimum stake, they need to be force deregistered.
-            // Additionally, it is possible for an operator to have deregistered from an OperatorSet
-            // in the core EigenLayer contract AllocationManager but not have the deregistration
-            // callback succeed here in `deregisterOperator` due to out of gas errors. If that is the case,
-            // we need to deregister the operator from the OperatorSet in this contract
-            bool shouldDeregister =
-                doesNotMeetStakeThreshold[i] || (!registeredInCore && !isM2Quorum);
-
-            if (shouldDeregister) {
-                _deregisterOperator({
+            if (doesNotMeetStakeThreshold[i]) {
+                _kickOperators({
                     operator: operators[i],
                     quorumNumbers: singleQuorumNumber,
-                    shouldForceDeregister: registeredInCore
+                    isEjection: false
                 });
             }
         }

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -230,11 +230,7 @@ contract SlashingRegistryCoordinator is
     ) external override onlyAllocationManager onlyWhenNotPaused(PAUSED_DEREGISTER_OPERATOR) {
         require(supportsAVS(avs), InvalidAVS());
         bytes memory quorumNumbers = _getQuorumNumbers(operatorSetIds);
-        _deregisterOperator({
-            operator: operator,
-            quorumNumbers: quorumNumbers,
-            shouldForceDeregister: false
-        });
+        _deregisterOperator({operator: operator, quorumNumbers: quorumNumbers});
     }
 
     /// @inheritdoc ISlashingRegistryCoordinator
@@ -538,14 +534,9 @@ contract SlashingRegistryCoordinator is
      * the operator with the BLSApkRegistry, IndexRegistry, and StakeRegistry
      * @param operator the operator to deregister
      * @param quorumNumbers the quorum numbers to deregister from
-     * @param shouldForceDeregister whether the operator needs to be deregistered from the OperatorSets of
      * the core EigenLayer contract AllocationManager
      */
-    function _deregisterOperator(
-        address operator,
-        bytes memory quorumNumbers,
-        bool shouldForceDeregister
-    ) internal virtual {
+    function _deregisterOperator(address operator, bytes memory quorumNumbers) internal virtual {
         // Fetch the operator's info and ensure they are registered
         OperatorInfo storage operatorInfo = _operatorInfo[operator];
         bytes32 operatorId = operatorInfo.operatorId;
@@ -583,12 +574,6 @@ contract SlashingRegistryCoordinator is
         blsApkRegistry.deregisterOperator(operator, quorumNumbers);
         stakeRegistry.deregisterOperator(operatorId, quorumNumbers);
         indexRegistry.deregisterOperator(operatorId, quorumNumbers);
-
-        // If the operator is not deregistered from the EigenLayer core protocol, then we need to force deregister them
-        // from their respective OperatorSets in the AllocationManager
-        if (shouldForceDeregister) {
-            _forceDeregisterOperator(operator, quorumNumbers);
-        }
 
         // call hook to allow for any post-deregister logic
         _afterDeregisterOperator(operator, operatorId, quorumNumbers, newBitmap);

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -329,7 +329,7 @@ contract SlashingRegistryCoordinator is
         address operator,
         bytes memory quorumNumbers
     ) public virtual onlyEjector {
-        _kickOperators({operator: operator, quorumNumbers: quorumNumbers, isEjection: true});
+        _kickOperator({operator: operator, quorumNumbers: quorumNumbers, isEjection: true});
     }
 
     /**
@@ -390,7 +390,7 @@ contract SlashingRegistryCoordinator is
      * @param operator The operator to eject
      * @param quorumNumbers The quorum numbers to eject the operator from
      */
-    function _kickOperators(
+    function _kickOperator(
         address operator,
         bytes memory quorumNumbers,
         bool isEjection
@@ -533,7 +533,7 @@ contract SlashingRegistryCoordinator is
 
                 bytes memory singleQuorumNumber = new bytes(1);
                 singleQuorumNumber[0] = quorumNumbers[i];
-                _kickOperators({
+                _kickOperator({
                     operator: operatorKickParams[i].operator,
                     quorumNumbers: singleQuorumNumber,
                     isEjection: false
@@ -667,7 +667,7 @@ contract SlashingRegistryCoordinator is
         for (uint256 j = 0; j < operators.length; ++j) {
             // If the operator does not have the minimum stake, they need to be force deregistered.
             if (doesNotMeetStakeThreshold[j]) {
-                _kickOperators({
+                _kickOperator({
                     operator: operators[j],
                     quorumNumbers: singleQuorumNumber,
                     isEjection: false

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -1155,7 +1155,9 @@ contract SlashingRegistryCoordinator is
         return _hashTypedDataV4(keccak256(abi.encode(PUBKEY_REGISTRATION_TYPEHASH, operator)));
     }
 
-    function supportsAVS(address _avs) external view virtual returns (bool) {
+    function supportsAVS(
+        address _avs
+    ) external view virtual returns (bool) {
         return _avs == address(avs);
     }
 }

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.27;
 import {IPauserRegistry} from "eigenlayer-contracts/src/contracts/interfaces/IPauserRegistry.sol";
 import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
 import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
+import {IAVSRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IAVSRegistrar.sol";
 import {
     IAllocationManager,
     OperatorSet,
@@ -144,7 +145,7 @@ contract SlashingRegistryCoordinator is
         );
     }
 
-    /// @inheritdoc ISlashingRegistryCoordinator
+    /// @inheritdoc IAVSRegistrar
     function registerOperator(
         address operator,
         address avs,
@@ -221,7 +222,7 @@ contract SlashingRegistryCoordinator is
         }
     }
 
-    /// @inheritdoc ISlashingRegistryCoordinator
+    /// @inheritdoc IAVSRegistrar
     function deregisterOperator(
         address operator,
         address avs,

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -151,7 +151,7 @@ contract SlashingRegistryCoordinator is
         uint32[] memory operatorSetIds,
         bytes calldata data
     ) external override onlyAllocationManager onlyWhenNotPaused(PAUSED_REGISTER_OPERATOR) {
-        if (!supportsAVS(avs)) revert InvalidAVS();
+        require(supportsAVS(avs), InvalidAVS());
         bytes memory quorumNumbers = _getQuorumNumbers(operatorSetIds);
 
         (
@@ -227,7 +227,7 @@ contract SlashingRegistryCoordinator is
         address avs,
         uint32[] memory operatorSetIds
     ) external override onlyAllocationManager onlyWhenNotPaused(PAUSED_DEREGISTER_OPERATOR) {
-        if (!supportsAVS(avs)) revert InvalidAVS();
+        require(supportsAVS(avs), InvalidAVS());
         bytes memory quorumNumbers = _getQuorumNumbers(operatorSetIds);
         _deregisterOperator({
             operator: operator,

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -147,6 +147,7 @@ contract SlashingRegistryCoordinator is
     /// @inheritdoc ISlashingRegistryCoordinator
     function registerOperator(
         address operator,
+        address avs,
         uint32[] memory operatorSetIds,
         bytes calldata data
     ) external override onlyAllocationManager onlyWhenNotPaused(PAUSED_REGISTER_OPERATOR) {
@@ -222,6 +223,7 @@ contract SlashingRegistryCoordinator is
     /// @inheritdoc ISlashingRegistryCoordinator
     function deregisterOperator(
         address operator,
+        address avs,
         uint32[] memory operatorSetIds
     ) external override onlyAllocationManager onlyWhenNotPaused(PAUSED_DEREGISTER_OPERATOR) {
         bytes memory quorumNumbers = _getQuorumNumbers(operatorSetIds);
@@ -1146,5 +1148,9 @@ contract SlashingRegistryCoordinator is
         address operator
     ) public view returns (bytes32) {
         return _hashTypedDataV4(keccak256(abi.encode(PUBKEY_REGISTRATION_TYPEHASH, operator)));
+    }
+
+    function supportsAVS(address _avs) external view virtual returns (bool) {
+        return _avs == address(avs);
     }
 }

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -388,7 +388,7 @@ contract SlashingRegistryCoordinator is
 
     /**
      * @notice Internal function to handle operator ejection logic
-     * @param operator The operator to eject
+     * @param operator The operator to force deregister from the avs
      * @param quorumNumbers The quorum numbers to eject the operator from
      */
     function _kickOperator(address operator, bytes memory quorumNumbers) internal virtual {

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -151,6 +151,7 @@ contract SlashingRegistryCoordinator is
         uint32[] memory operatorSetIds,
         bytes calldata data
     ) external override onlyAllocationManager onlyWhenNotPaused(PAUSED_REGISTER_OPERATOR) {
+        if (!supportsAVS(avs)) revert InvalidAVS();
         bytes memory quorumNumbers = _getQuorumNumbers(operatorSetIds);
 
         (
@@ -226,6 +227,7 @@ contract SlashingRegistryCoordinator is
         address avs,
         uint32[] memory operatorSetIds
     ) external override onlyAllocationManager onlyWhenNotPaused(PAUSED_DEREGISTER_OPERATOR) {
+        if (!supportsAVS(avs)) revert InvalidAVS();
         bytes memory quorumNumbers = _getQuorumNumbers(operatorSetIds);
         _deregisterOperator({
             operator: operator,
@@ -1157,7 +1159,7 @@ contract SlashingRegistryCoordinator is
 
     function supportsAVS(
         address _avs
-    ) external view virtual returns (bool) {
+    ) public view virtual returns (bool) {
         return _avs == address(avs);
     }
 }

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -249,9 +249,7 @@ contract SlashingRegistryCoordinator is
             bytes memory quorumNumbers = currentBitmap.bitmapToBytesArray();
             for (uint256 j = 0; j < quorumNumbers.length; j++) {
                 // update the operator's stake for each quorum
-                _updateStakesAndDeregisterLoiterers(
-                    singleOperator, singleOperatorId, uint8(quorumNumbers[j])
-                );
+                _updateOperatorsStakes(singleOperator, singleOperatorId, uint8(quorumNumbers[j]));
             }
         }
     }
@@ -302,7 +300,7 @@ contract SlashingRegistryCoordinator is
                 prevOperatorAddress = operator;
             }
 
-            _updateStakesAndDeregisterLoiterers(currQuorumOperators, operatorIds, quorumNumber);
+            _updateOperatorsStakes(currQuorumOperators, operatorIds, quorumNumber);
 
             // Update timestamp that all operators in quorum have been updated all at once
             quorumUpdateBlockNumber[quorumNumber] = block.number;
@@ -325,24 +323,11 @@ contract SlashingRegistryCoordinator is
      */
 
     /// @inheritdoc ISlashingRegistryCoordinator
-    function ejectOperator(address operator, bytes memory quorumNumbers) external onlyEjector {
-        lastEjectionTimestamp[operator] = block.timestamp;
-
-        OperatorInfo storage operatorInfo = _operatorInfo[operator];
-        bytes32 operatorId = operatorInfo.operatorId;
-        uint192 quorumsToRemove =
-            uint192(BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers, quorumCount));
-        uint192 currentBitmap = _currentOperatorBitmap(operatorId);
-        if (
-            operatorInfo.status == OperatorStatus.REGISTERED && !quorumsToRemove.isEmpty()
-                && quorumsToRemove.isSubsetOf(currentBitmap)
-        ) {
-            _deregisterOperator({
-                operator: operator,
-                quorumNumbers: quorumNumbers,
-                shouldForceDeregister: true
-            });
-        }
+    function ejectOperator(
+        address operator,
+        bytes memory quorumNumbers
+    ) public virtual onlyEjector {
+        _kickOperators({operator: operator, quorumNumbers: quorumNumbers, isEjection: true});
     }
 
     /**
@@ -397,6 +382,33 @@ contract SlashingRegistryCoordinator is
      *                         INTERNAL FUNCTIONS
      *
      */
+
+    /**
+     * @notice Internal function to handle operator ejection logic
+     * @param operator The operator to eject
+     * @param quorumNumbers The quorum numbers to eject the operator from
+     */
+    function _kickOperators(
+        address operator,
+        bytes memory quorumNumbers,
+        bool isEjection
+    ) internal virtual {
+        if (isEjection) {
+            lastEjectionTimestamp[operator] = block.timestamp;
+        }
+
+        OperatorInfo storage operatorInfo = _operatorInfo[operator];
+        bytes32 operatorId = operatorInfo.operatorId;
+        uint192 quorumsToRemove =
+            uint192(BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers, quorumCount));
+        uint192 currentBitmap = _currentOperatorBitmap(operatorId);
+        if (
+            operatorInfo.status == OperatorStatus.REGISTERED && !quorumsToRemove.isEmpty()
+                && quorumsToRemove.isSubsetOf(currentBitmap)
+        ) {
+            _forceDeregisterOperator(operator, quorumNumbers);
+        }
+    }
 
     /**
      * @notice Register the operator for one or more quorums. This method updates the
@@ -519,10 +531,10 @@ contract SlashingRegistryCoordinator is
 
                 bytes memory singleQuorumNumber = new bytes(1);
                 singleQuorumNumber[0] = quorumNumbers[i];
-                _deregisterOperator({
+                _kickOperators({
                     operator: operatorKickParams[i].operator,
                     quorumNumbers: singleQuorumNumber,
-                    shouldForceDeregister: true
+                    isEjection: false
                 });
             }
         }
@@ -632,14 +644,16 @@ contract SlashingRegistryCoordinator is
     }
 
     /**
-     * @dev Helper function to update operator stakes and deregister loiterers
-     * Loiterers are AVS registered operators who have force deregistered from the OperatorSet/quorum
-     * in the core EigenLayer contract AllocationManager but not deregistered from the OperatorSet/quorum
-     * in this contract. Potentially due to out of gas errors in the deregistration callback. This function
-     * will handle that edge case by deregistering the operator from the AVS if they are no longer registered
-     * in the AllocationManager.
+     * @dev Helper function to update operator stakes and deregister operators with insufficient stake
+     * This function handles two cases:
+     * 1. Operators who no longer meet the minimum stake requirement for a quorum
+     * 2. Operators who have been force-deregistered from the AllocationManager but not from this contract
+     * (e.g. due to out of gas errors in the deregistration callback)
+     * @param operators The list of operators to check and update
+     * @param operatorIds The corresponding operator IDs
+     * @param quorumNumber The quorum number to check stakes for
      */
-    function _updateStakesAndDeregisterLoiterers(
+    function _updateOperatorsStakes(
         address[] memory operators,
         bytes32[] memory operatorIds,
         uint8 quorumNumber
@@ -649,21 +663,12 @@ contract SlashingRegistryCoordinator is
         bool[] memory doesNotMeetStakeThreshold =
             stakeRegistry.updateOperatorsStake(operators, operatorIds, quorumNumber);
         for (uint256 j = 0; j < operators.length; ++j) {
-            // whether the operator is registered in the core EigenLayer contract AllocationManager
-            bool registeredInCore = allocationManager.isMemberOfOperatorSet(
-                operators[j], OperatorSet({avs: avs, id: uint32(quorumNumber)})
-            );
-
             // If the operator does not have the minimum stake, they need to be force deregistered.
-            // Additionally, it is possible for an operator to have deregistered from an OperatorSet
-            // in the core EigenLayer contract AllocationManager but not have the deregistration
-            // callback succeed here in `deregisterOperator` due to out of gas errors. If that is the case,
-            // we need to deregister the operator from the OperatorSet in this contract
-            if (doesNotMeetStakeThreshold[j] || !registeredInCore) {
-                _deregisterOperator({
+            if (doesNotMeetStakeThreshold[j]) {
+                _kickOperators({
                     operator: operators[j],
                     quorumNumbers: singleQuorumNumber,
-                    shouldForceDeregister: registeredInCore
+                    isEjection: false
                 });
             }
         }

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -98,13 +98,13 @@ contract SlashingRegistryCoordinator is
         address _churnApprover,
         address _ejector,
         uint256 _initialPausedStatus,
-        address _accountIdentifier
+        address _avs
     ) external initializer {
         _transferOwnership(_initialOwner);
         _setChurnApprover(_churnApprover);
         _setPausedStatus(_initialPausedStatus);
         _setEjector(_ejector);
-        _setAccountIdentifier(_accountIdentifier);
+        _setAvs(_avs);
 
         // Add registry contracts to the registries array
         registries.push(address(stakeRegistry));
@@ -377,10 +377,10 @@ contract SlashingRegistryCoordinator is
     }
 
     /// @inheritdoc ISlashingRegistryCoordinator
-    function setAccountIdentifier(
-        address _accountIdentifier
+    function setAvs(
+        address _avs
     ) external onlyOwner {
-        _setAccountIdentifier(_accountIdentifier);
+        _setAvs(_avs);
     }
 
     /// @inheritdoc ISlashingRegistryCoordinator
@@ -607,7 +607,7 @@ contract SlashingRegistryCoordinator is
             uint32 operatorSetId = uint32(uint8(quorumNumbers[i]));
             if (
                 allocationManager.isMemberOfOperatorSet(
-                    operator, OperatorSet({avs: accountIdentifier, id: operatorSetId})
+                    operator, OperatorSet({avs: avs, id: operatorSetId})
                 )
             ) {
                 operatorSetIds[numDeregister] = operatorSetId;
@@ -623,7 +623,7 @@ contract SlashingRegistryCoordinator is
         allocationManager.deregisterFromOperatorSets(
             IAllocationManagerTypes.DeregisterParams({
                 operator: operator,
-                avs: accountIdentifier,
+                avs: avs,
                 operatorSetIds: _getOperatorSetIds(quorumNumbers)
             })
         );
@@ -649,7 +649,7 @@ contract SlashingRegistryCoordinator is
         for (uint256 j = 0; j < operators.length; ++j) {
             // whether the operator is registered in the core EigenLayer contract AllocationManager
             bool registeredInCore = allocationManager.isMemberOfOperatorSet(
-                operators[j], OperatorSet({avs: accountIdentifier, id: uint32(quorumNumber)})
+                operators[j], OperatorSet({avs: avs, id: uint32(quorumNumber)})
             );
 
             // If the operator does not have the minimum stake, they need to be force deregistered.
@@ -859,7 +859,7 @@ contract SlashingRegistryCoordinator is
             operatorSetId: quorumNumber,
             strategies: strategies
         });
-        allocationManager.createOperatorSets({avs: accountIdentifier, params: createSetParams});
+        allocationManager.createOperatorSets({avs: avs, params: createSetParams});
 
         // Initialize stake registry based on stake type
         if (stakeType == IStakeRegistryTypes.StakeType.TOTAL_DELEGATED) {
@@ -951,10 +951,10 @@ contract SlashingRegistryCoordinator is
         ejector = newEjector;
     }
 
-    function _setAccountIdentifier(
-        address _accountIdentifier
+    function _setAvs(
+        address _avs
     ) internal {
-        accountIdentifier = _accountIdentifier;
+        avs = _avs;
     }
 
     /// @dev Hook to allow for any pre-create quorum logic

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -391,10 +391,7 @@ contract SlashingRegistryCoordinator is
      * @param operator The operator to eject
      * @param quorumNumbers The quorum numbers to eject the operator from
      */
-    function _kickOperator(
-        address operator,
-        bytes memory quorumNumbers
-    ) internal virtual {
+    function _kickOperator(address operator, bytes memory quorumNumbers) internal virtual {
         OperatorInfo storage operatorInfo = _operatorInfo[operator];
         bytes32 operatorId = operatorInfo.operatorId;
         uint192 quorumsToRemove =

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -329,7 +329,8 @@ contract SlashingRegistryCoordinator is
         address operator,
         bytes memory quorumNumbers
     ) public virtual onlyEjector {
-        _kickOperator({operator: operator, quorumNumbers: quorumNumbers, isEjection: true});
+        lastEjectionTimestamp[operator] = block.timestamp;
+        _kickOperator(operator, quorumNumbers);
     }
 
     /**
@@ -392,13 +393,8 @@ contract SlashingRegistryCoordinator is
      */
     function _kickOperator(
         address operator,
-        bytes memory quorumNumbers,
-        bool isEjection
+        bytes memory quorumNumbers
     ) internal virtual {
-        if (isEjection) {
-            lastEjectionTimestamp[operator] = block.timestamp;
-        }
-
         OperatorInfo storage operatorInfo = _operatorInfo[operator];
         bytes32 operatorId = operatorInfo.operatorId;
         uint192 quorumsToRemove =
@@ -533,11 +529,7 @@ contract SlashingRegistryCoordinator is
 
                 bytes memory singleQuorumNumber = new bytes(1);
                 singleQuorumNumber[0] = quorumNumbers[i];
-                _kickOperator({
-                    operator: operatorKickParams[i].operator,
-                    quorumNumbers: singleQuorumNumber,
-                    isEjection: false
-                });
+                _kickOperator(operatorKickParams[i].operator, singleQuorumNumber);
             }
         }
     }
@@ -667,11 +659,7 @@ contract SlashingRegistryCoordinator is
         for (uint256 j = 0; j < operators.length; ++j) {
             // If the operator does not have the minimum stake, they need to be force deregistered.
             if (doesNotMeetStakeThreshold[j]) {
-                _kickOperator({
-                    operator: operators[j],
-                    quorumNumbers: singleQuorumNumber,
-                    isEjection: false
-                });
+                _kickOperator(operators[j], singleQuorumNumber);
             }
         }
     }

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -104,7 +104,7 @@ contract SlashingRegistryCoordinator is
         _setChurnApprover(_churnApprover);
         _setPausedStatus(_initialPausedStatus);
         _setEjector(_ejector);
-        _setAvs(_avs);
+        _setAVS(_avs);
 
         // Add registry contracts to the registries array
         registries.push(address(stakeRegistry));
@@ -367,10 +367,10 @@ contract SlashingRegistryCoordinator is
     }
 
     /// @inheritdoc ISlashingRegistryCoordinator
-    function setAvs(
+    function setAVS(
         address _avs
     ) external onlyOwner {
-        _setAvs(_avs);
+        _setAVS(_avs);
     }
 
     /// @inheritdoc ISlashingRegistryCoordinator
@@ -945,7 +945,7 @@ contract SlashingRegistryCoordinator is
         ejector = newEjector;
     }
 
-    function _setAvs(
+    function _setAVS(
         address _avs
     ) internal {
         avs = _avs;

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -592,25 +592,6 @@ contract SlashingRegistryCoordinator is
         address operator,
         bytes memory quorumNumbers
     ) internal virtual {
-        uint32[] memory operatorSetIds = new uint32[](quorumNumbers.length);
-        uint256 numDeregister = 0;
-        for (uint256 i = 0; i < quorumNumbers.length; ++i) {
-            uint32 operatorSetId = uint32(uint8(quorumNumbers[i]));
-            if (
-                allocationManager.isMemberOfOperatorSet(
-                    operator, OperatorSet({avs: avs, id: operatorSetId})
-                )
-            ) {
-                operatorSetIds[numDeregister] = operatorSetId;
-                numDeregister++;
-            }
-        }
-
-        // resize operatorSetIds array length to numDeregister
-        assembly {
-            mstore(operatorSetIds, numDeregister)
-        }
-
         allocationManager.deregisterFromOperatorSets(
             IAllocationManagerTypes.DeregisterParams({
                 operator: operator,

--- a/src/SlashingRegistryCoordinatorStorage.sol
+++ b/src/SlashingRegistryCoordinatorStorage.sol
@@ -85,10 +85,10 @@ abstract contract SlashingRegistryCoordinatorStorage is ISlashingRegistryCoordin
     /// @notice the delay in seconds before an operator can reregister after being ejected
     uint256 public ejectionCooldown;
 
-    /// @notice The account identifier for this AVS (used for UAM integration in EigenLayer)
+    /// @notice The avs address for this AVS (used for UAM integration in EigenLayer)
     /// @dev NOTE: Updating this value will break existing OperatorSets and UAM integration.
     /// This value should only be set once.
-    address public accountIdentifier;
+    address public avs;
 
     constructor(
         IStakeRegistry _stakeRegistry,

--- a/src/StakeRegistry.sol
+++ b/src/StakeRegistry.sol
@@ -240,7 +240,7 @@ contract StakeRegistry is StakeRegistryStorage {
 
         uint256 numStratsToAdd = _strategyParams.length;
 
-        address avs = registryCoordinator.accountIdentifier();
+        address avs = registryCoordinator.avs();
         if (allocationManager.isOperatorSet(OperatorSet(avs, quorumNumber))) {
             IStrategy[] memory strategiesToAdd = new IStrategy[](numStratsToAdd);
             for (uint256 i = 0; i < numStratsToAdd; i++) {
@@ -283,7 +283,7 @@ contract StakeRegistry is StakeRegistryStorage {
             _strategiesPerQuorum.pop();
         }
 
-        address avs = registryCoordinator.accountIdentifier();
+        address avs = registryCoordinator.avs();
         if (allocationManager.isOperatorSet(OperatorSet(avs, quorumNumber))) {
             allocationManager.removeStrategiesFromOperatorSet({
                 avs: avs,
@@ -515,7 +515,7 @@ contract StakeRegistry is StakeRegistryStorage {
         uint32 beforeBlock = uint32(block.number + slashableStakeLookAheadPerQuorum[quorumNumber]);
 
         uint256[][] memory slashableShares = allocationManager.getMinimumSlashableStake(
-            OperatorSet(registryCoordinator.accountIdentifier(), quorumNumber),
+            OperatorSet(registryCoordinator.avs(), quorumNumber),
             operators,
             strategiesPerQuorum[quorumNumber],
             beforeBlock

--- a/src/interfaces/ISlashingRegistryCoordinator.sol
+++ b/src/interfaces/ISlashingRegistryCoordinator.sol
@@ -51,6 +51,8 @@ interface ISlashingRegistryCoordinatorErrors {
     error NotSorted();
     /// @notice Thrown when maximum quorum count is reached.
     error MaxQuorumsReached();
+    /// @notice Thrown when the provided AVS address does not match the expected one.
+    error InvalidAVS();
 }
 
 interface ISlashingRegistryCoordinatorTypes {

--- a/src/interfaces/ISlashingRegistryCoordinator.sol
+++ b/src/interfaces/ISlashingRegistryCoordinator.sol
@@ -448,13 +448,13 @@ interface ISlashingRegistryCoordinator is
     ) external;
 
     /**
-     * @notice Updates the account identifier for this AVS (used for UAM integration in EigenLayer)
-     * @param _accountIdentifier The new account identifier address
+     * @notice Updates the avs address for this AVS (used for UAM integration in EigenLayer)
+     * @param _avs The new avs address
      * @dev Can only be called by the contract owner
      * @dev NOTE: Updating this value will break existing OperatorSets and UAM integration. This value should only be set once.
      */
-    function setAccountIdentifier(
-        address _accountIdentifier
+    function setAvs(
+        address _avs
     ) external;
 
     /// VIEW
@@ -603,9 +603,9 @@ interface ISlashingRegistryCoordinator is
     ) external view returns (BN254.G1Point memory);
 
     /**
-     * @notice Returns the account identifier for this AVS (used for UAM integration in EigenLayer)
+     * @notice Returns the avs address for this AVS (used for UAM integration in EigenLayer)
      * @dev NOTE: Updating this value will break existing OperatorSets and UAM integration. This value should only be set once.
-     * @return The account identifier address
+     * @return The avs address
      */
-    function accountIdentifier() external view returns (address);
+    function avs() external view returns (address);
 }

--- a/src/interfaces/ISlashingRegistryCoordinator.sol
+++ b/src/interfaces/ISlashingRegistryCoordinator.sol
@@ -306,50 +306,6 @@ interface ISlashingRegistryCoordinator is
     /// ACTIONS
 
     /**
-     * @notice Registers an operator through the allocation manager for operator set quorums.
-     * @param operator The operator address to register.
-     * @param avs The AVS contract address that the operator is registering for.
-     * @param operatorSetIds The operator set IDs to register for (corresponds to quorum numbers).
-     * @param data Additional registration data containing:
-     *        - RegistrationType: NORMAL or CHURN
-     *        - socket: The operator's socket string (typically an IP address)
-     *        - PubkeyRegistrationParams: The operator's BLS public key parameters
-     *        - OperatorKickParams[]: (Only for CHURN) Array of operators to kick from each quorum
-     *        - SignatureWithSaltAndExpiry: (Only for CHURN) Signature from churn approver
-     * @dev Can only be called by the allocation manager.
-     * @dev Will revert if:
-     *      - Operator sets are not enabled
-     *      - Registering for M2 quorums
-     *      - Invalid registration type
-     *      - Max operator count exceeded (for NORMAL registration)
-     *      - Invalid churn parameters (for CHURN registration)
-     */
-    function registerOperator(
-        address operator,
-        address avs,
-        uint32[] memory operatorSetIds,
-        bytes memory data
-    ) external;
-
-    /**
-     * @notice Deregisters an operator through the allocation manager from operator set quorums.
-     * @param operator The operator address to deregister.
-     * @param avs The AVS contract address that the operator is deregistering from.
-     * @param operatorSetIds The operator set IDs to deregister from (corresponds to quorum numbers).
-     * @dev Can only be called by the allocation manager.
-     * @dev Will revert if:
-     *      - Operator sets are not enabled
-     *      - Deregistering from M2 quorums
-     *      - Operator is not registered in the specified quorums
-     * @dev This function implements the Slashing deregistration pathway specified by the IAVSRegistrar interface.
-     */
-    function deregisterOperator(
-        address operator,
-        address avs,
-        uint32[] memory operatorSetIds
-    ) external;
-
-    /**
      * @notice Updates stake weights for specified operators. If any operator is found to be below
      * the minimum stake for their registered quorums, they are deregistered from those quorums.
      * @param operators The operators whose stakes should be updated.

--- a/src/interfaces/ISlashingRegistryCoordinator.sol
+++ b/src/interfaces/ISlashingRegistryCoordinator.sol
@@ -341,7 +341,11 @@ interface ISlashingRegistryCoordinator is
      *      - Operator is not registered in the specified quorums
      * @dev This function implements the Slashing deregistration pathway specified by the IAVSRegistrar interface.
      */
-    function deregisterOperator(address operator, address avs, uint32[] memory operatorSetIds) external;
+    function deregisterOperator(
+        address operator,
+        address avs,
+        uint32[] memory operatorSetIds
+    ) external;
 
     /**
      * @notice Updates stake weights for specified operators. If any operator is found to be below

--- a/src/interfaces/ISlashingRegistryCoordinator.sol
+++ b/src/interfaces/ISlashingRegistryCoordinator.sol
@@ -306,14 +306,25 @@ interface ISlashingRegistryCoordinator is
     /**
      * @notice Registers an operator through the allocation manager for operator set quorums.
      * @param operator The operator address to register.
+     * @param avs The AVS contract address that the operator is registering for.
      * @param operatorSetIds The operator set IDs to register for (corresponds to quorum numbers).
-     * @param data Additional registration data containing the operator's socket and BLS public key parameters.
+     * @param data Additional registration data containing:
+     *        - RegistrationType: NORMAL or CHURN
+     *        - socket: The operator's socket string (typically an IP address)
+     *        - PubkeyRegistrationParams: The operator's BLS public key parameters
+     *        - OperatorKickParams[]: (Only for CHURN) Array of operators to kick from each quorum
+     *        - SignatureWithSaltAndExpiry: (Only for CHURN) Signature from churn approver
      * @dev Can only be called by the allocation manager.
-     * @dev Will revert if operator sets are not enabled or if registering for M2 quorums.
-     * @dev This function implements the Slashing registration pathway specified by the IAVSRegistrar interface.
+     * @dev Will revert if:
+     *      - Operator sets are not enabled
+     *      - Registering for M2 quorums
+     *      - Invalid registration type
+     *      - Max operator count exceeded (for NORMAL registration)
+     *      - Invalid churn parameters (for CHURN registration)
      */
     function registerOperator(
         address operator,
+        address avs,
         uint32[] memory operatorSetIds,
         bytes memory data
     ) external;
@@ -321,12 +332,16 @@ interface ISlashingRegistryCoordinator is
     /**
      * @notice Deregisters an operator through the allocation manager from operator set quorums.
      * @param operator The operator address to deregister.
+     * @param avs The AVS contract address that the operator is deregistering from.
      * @param operatorSetIds The operator set IDs to deregister from (corresponds to quorum numbers).
      * @dev Can only be called by the allocation manager.
-     * @dev Will revert if operator sets are not enabled or if deregistering from M2 quorums.
+     * @dev Will revert if:
+     *      - Operator sets are not enabled
+     *      - Deregistering from M2 quorums
+     *      - Operator is not registered in the specified quorums
      * @dev This function implements the Slashing deregistration pathway specified by the IAVSRegistrar interface.
      */
-    function deregisterOperator(address operator, uint32[] memory operatorSetIds) external;
+    function deregisterOperator(address operator, address avs, uint32[] memory operatorSetIds) external;
 
     /**
      * @notice Updates stake weights for specified operators. If any operator is found to be below

--- a/src/interfaces/ISlashingRegistryCoordinator.sol
+++ b/src/interfaces/ISlashingRegistryCoordinator.sol
@@ -474,7 +474,7 @@ interface ISlashingRegistryCoordinator is
      * @dev Can only be called by the contract owner
      * @dev NOTE: Updating this value will break existing OperatorSets and UAM integration. This value should only be set once.
      */
-    function setAvs(
+    function setAVS(
         address _avs
     ) external;
 

--- a/src/libraries/BitmapUtils.sol
+++ b/src/libraries/BitmapUtils.sol
@@ -215,4 +215,12 @@ library BitmapUtils {
     function minus(uint256 a, uint256 b) internal pure returns (uint256) {
         return a & ~b;
     }
+
+    /**
+     * @notice Returns a new bitmap that contains only bits set in both `a` and `b`
+     * @dev Result is the intersection of `a` and `b`
+     */
+    function and(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a & b;
+    }
 }

--- a/src/slashers/base/SlasherBase.sol
+++ b/src/slashers/base/SlasherBase.sol
@@ -36,10 +36,7 @@ abstract contract SlasherBase is SlasherStorage {
         uint256 _requestId,
         IAllocationManager.SlashingParams memory _params
     ) internal virtual {
-        allocationManager.slashOperator({
-            avs: slashingRegistryCoordinator.accountIdentifier(),
-            params: _params
-        });
+        allocationManager.slashOperator({avs: slashingRegistryCoordinator.avs(), params: _params});
         emit OperatorSlashed(
             _requestId,
             _params.operator,

--- a/test/harnesses/RegistryCoordinatorHarness.t.sol
+++ b/test/harnesses/RegistryCoordinatorHarness.t.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.27;
 
 import "../../src/RegistryCoordinator.sol";
-
 import {ISocketRegistry} from "../../src/interfaces/ISocketRegistry.sol";
+import {IAVSRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IAVSRegistrar.sol";
+
 
 import "forge-std/Test.sol";
 
@@ -84,5 +85,9 @@ contract RegistryCoordinatorHarness is RegistryCoordinator, Test {
         uint256 bitmap
     ) external {
         _m2QuorumBitmap = bitmap;
+    }
+
+    function supportsAVS(address avs) external view override (IAVSRegistrar, SlashingRegistryCoordinator) returns (bool) {
+        return avs == address(serviceManager);
     }
 }

--- a/test/harnesses/RegistryCoordinatorHarness.t.sol
+++ b/test/harnesses/RegistryCoordinatorHarness.t.sol
@@ -88,7 +88,7 @@ contract RegistryCoordinatorHarness is RegistryCoordinator, Test {
 
     function supportsAVS(
         address avs
-    ) external view override(IAVSRegistrar, SlashingRegistryCoordinator) returns (bool) {
+    ) public view override(IAVSRegistrar, SlashingRegistryCoordinator) returns (bool) {
         return avs == address(serviceManager);
     }
 }

--- a/test/harnesses/RegistryCoordinatorHarness.t.sol
+++ b/test/harnesses/RegistryCoordinatorHarness.t.sol
@@ -60,7 +60,7 @@ contract RegistryCoordinatorHarness is RegistryCoordinator, Test {
 
     // @notice exposes the internal `_deregisterOperator` function, overriding all access controls
     function _deregisterOperatorExternal(address operator, bytes calldata quorumNumbers) external {
-        _deregisterOperator(operator, quorumNumbers, false);
+        _deregisterOperator(operator, quorumNumbers);
     }
 
     // @notice exposes the internal `_updateOperatorBitmap` function, overriding all access controls

--- a/test/harnesses/RegistryCoordinatorHarness.t.sol
+++ b/test/harnesses/RegistryCoordinatorHarness.t.sol
@@ -5,7 +5,6 @@ import "../../src/RegistryCoordinator.sol";
 import {ISocketRegistry} from "../../src/interfaces/ISocketRegistry.sol";
 import {IAVSRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IAVSRegistrar.sol";
 
-
 import "forge-std/Test.sol";
 
 // wrapper around the RegistryCoordinator contract that exposes the internal functions for unit testing.
@@ -87,7 +86,9 @@ contract RegistryCoordinatorHarness is RegistryCoordinator, Test {
         _m2QuorumBitmap = bitmap;
     }
 
-    function supportsAVS(address avs) external view override (IAVSRegistrar, SlashingRegistryCoordinator) returns (bool) {
+    function supportsAVS(
+        address avs
+    ) external view override(IAVSRegistrar, SlashingRegistryCoordinator) returns (bool) {
         return avs == address(serviceManager);
     }
 }

--- a/test/integration/IntegrationConfig.t.sol
+++ b/test/integration/IntegrationConfig.t.sol
@@ -227,6 +227,9 @@ contract IntegrationConfig is IntegrationDeployer, G2Operations, Constants {
                 }
             }
 
+            cheats.prank(address(serviceManager));
+            allocationManager.updateAVSMetadataURI(address(serviceManager), "test-avs-metadata");
+
             cheats.prank(registryCoordinatorOwner);
             slashingRegistryCoordinator.createTotalDelegatedStakeQuorum({
                 operatorSetParams: operatorSet,

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -444,6 +444,9 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
             allocationManager,
             pauserRegistry
         );
+        cheats.prank(avsAccountIdentifier);
+        allocationManager.updateAVSMetadataURI(address(avsAccountIdentifier), "ipfs://mock-metadata-uri");
+
         proxyAdmin.upgradeAndCall(
             TransparentUpgradeableProxy(payable(address(slashingRegistryCoordinator))),
             address(slashingRegistryCoordinatorImplementation),
@@ -467,25 +470,32 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
             target: address(allocationManager),
             selector: IAllocationManager.setAVSRegistrar.selector
         });
-        // 2. create operator sets
+
+        // 2. set AVS metadata
+        serviceManager.setAppointee({
+            appointee: serviceManager.owner(),
+            target: address(allocationManager),
+            selector: IAllocationManager.updateAVSMetadataURI.selector
+        });
+        // 3. create operator sets
         serviceManager.setAppointee({
             appointee: address(registryCoordinator),
             target: address(allocationManager),
             selector: IAllocationManager.createOperatorSets.selector
         });
-        // 3. deregister operator from operator sets
+        // 4. deregister operator from operator sets
         serviceManager.setAppointee({
             appointee: address(registryCoordinator),
             target: address(allocationManager),
             selector: IAllocationManager.deregisterFromOperatorSets.selector
         });
-        // 4. add strategies to operator sets
+        // 5. add strategies to operator sets
         serviceManager.setAppointee({
             appointee: address(registryCoordinator),
             target: address(stakeRegistry),
             selector: IAllocationManager.addStrategiesToOperatorSet.selector
         });
-        // 5. remove strategies from operator sets
+        // 6. remove strategies from operator sets
         serviceManager.setAppointee({
             appointee: address(registryCoordinator),
             target: address(stakeRegistry),

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -445,7 +445,9 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
             pauserRegistry
         );
         cheats.prank(avsAccountIdentifier);
-        allocationManager.updateAVSMetadataURI(address(avsAccountIdentifier), "ipfs://mock-metadata-uri");
+        allocationManager.updateAVSMetadataURI(
+            address(avsAccountIdentifier), "ipfs://mock-metadata-uri"
+        );
 
         proxyAdmin.upgradeAndCall(
             TransparentUpgradeableProxy(payable(address(slashingRegistryCoordinator))),

--- a/test/integration/OperatorSetUser.t.sol
+++ b/test/integration/OperatorSetUser.t.sol
@@ -24,7 +24,7 @@ contract OperatorSetUser is User {
         slashingRegistryCoordinator = deployer.slashingRegistryCoordinator();
         allocationManager = AllocationManager(deployer.allocationManager());
 
-        avs = slashingRegistryCoordinator.accountIdentifier();
+        avs = slashingRegistryCoordinator.avs();
 
         // Generate BN254 keypair and registration signature
         privKey = _privKey;

--- a/test/mocks/AVSRegistrarMock.sol
+++ b/test/mocks/AVSRegistrarMock.sol
@@ -6,12 +6,20 @@ import {IAVSRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IAVSR
 contract AVSRegistrarMock is IAVSRegistrar {
     function registerOperator(
         address operator,
+        address avs,
         uint32[] calldata operatorSetIds,
         bytes calldata data
     ) external override {}
 
     function deregisterOperator(
         address operator,
+        address avs,
         uint32[] calldata operatorSetIds
     ) external override {}
+
+    function supportsAVS(
+        address
+    ) external pure override returns (bool) {
+        return true;
+    }
 }

--- a/test/mocks/DelegationMock.sol
+++ b/test/mocks/DelegationMock.sol
@@ -232,7 +232,7 @@ contract DelegationIntermediate is IDelegationManager {
         IStrategy strategy,
         uint64 prevMaxMagnitude,
         uint64 newMaxMagnitude
-    ) external override {}
+    ) external {}
 
     function getQueuedWithdrawal(
         bytes32 withdrawalRoot

--- a/test/mocks/RewardsCoordinatorMock.sol
+++ b/test/mocks/RewardsCoordinatorMock.sol
@@ -32,18 +32,18 @@ contract RewardsCoordinatorMock is IRewardsCoordinator {
     function createOperatorDirectedOperatorSetRewardsSubmission(
         OperatorSet calldata operatorSet,
         OperatorDirectedRewardsSubmission[] calldata operatorDirectedRewardsSubmissions
-    ) external override {}
+    ) external {}
 
     function getOperatorSetSplit(
         address operator,
         OperatorSet calldata operatorSet
-    ) external view override returns (uint16) {}
+    ) external view returns (uint16) {}
 
     function setOperatorSetSplit(
         address operator,
         OperatorSet calldata operatorSet,
         uint16 split
-    ) external override {}
+    ) external {}
 
     function createOperatorDirectedAVSRewardsSubmission(
         address avs,

--- a/test/unit/AVSRegistrar.t.sol
+++ b/test/unit/AVSRegistrar.t.sol
@@ -21,6 +21,8 @@ contract AVSRegistrarTest is MockAVSDeployer {
 
     function setUp() public virtual {
         _deployMockEigenLayerAndAVS();
+        vm.prank(address(serviceManager));
+        allocationManager.updateAVSMetadataURI(address(serviceManager), "test-avs-metadata");
         avsRegistrarMock = new AVSRegistrarMock();
     }
 

--- a/test/unit/InstantSlasher.t.sol
+++ b/test/unit/InstantSlasher.t.sol
@@ -213,6 +213,13 @@ contract InstantSlasherTest is Test {
             AllocationManager.slashOperator.selector
         );
 
+        PermissionController(coreDeployment.permissionController).setAppointee(
+            address(serviceManager),
+            proxyAdminOwner,
+            coreDeployment.allocationManager,
+            AllocationManager.updateAVSMetadataURI.selector
+        );
+
         vm.stopPrank();
 
         uint8 quorumNumber = 0;
@@ -235,6 +242,7 @@ contract InstantSlasherTest is Test {
         });
 
         vm.startPrank(proxyAdminOwner);
+        IAllocationManager(coreDeployment.allocationManager).updateAVSMetadataURI(serviceManager, "fake-avs-metadata");
         slashingRegistryCoordinator.createSlashableStakeQuorum(
             operatorSetParams, 1 ether, strategyParams, 0
         );

--- a/test/unit/InstantSlasher.t.sol
+++ b/test/unit/InstantSlasher.t.sol
@@ -242,7 +242,9 @@ contract InstantSlasherTest is Test {
         });
 
         vm.startPrank(proxyAdminOwner);
-        IAllocationManager(coreDeployment.allocationManager).updateAVSMetadataURI(serviceManager, "fake-avs-metadata");
+        IAllocationManager(coreDeployment.allocationManager).updateAVSMetadataURI(
+            serviceManager, "fake-avs-metadata"
+        );
         slashingRegistryCoordinator.createSlashableStakeQuorum(
             operatorSetParams, 1 ether, strategyParams, 0
         );

--- a/test/unit/RegistryCoordinatorUnit.t.sol
+++ b/test/unit/RegistryCoordinatorUnit.t.sol
@@ -2337,7 +2337,10 @@ contract RegistryCoordinatorUnitTests_BeforeMigration is RegistryCoordinatorUnit
         cheats.expectRevert();
         /// TODO:
         registryCoordinator.registerOperator(
-            defaultOperator, address(0), new uint32[](0), abi.encode(defaultSocket, pubkeyRegistrationParams)
+            defaultOperator,
+            address(0),
+            new uint32[](0),
+            abi.encode(defaultSocket, pubkeyRegistrationParams)
         );
     }
 
@@ -2580,7 +2583,9 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
 
         cheats.prank(address(registryCoordinator.allocationManager()));
         /// TODO:
-        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
+        registryCoordinator.registerOperator(
+            defaultOperator, address(serviceManager), operatorSetIds, data
+        );
     }
 
     function test_registerHook_WithChurn() public {
@@ -2637,7 +2642,9 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
 
         // Prank as allocation manager and call register hook
         cheats.prank(address(registryCoordinator.allocationManager()));
-        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
+        registryCoordinator.registerOperator(
+            defaultOperator, address(serviceManager), operatorSetIds, data
+        );
     }
 
     function test_updateStakesForQuorum() public {
@@ -2706,7 +2713,9 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
             abi.encode(ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, socket, params);
 
         cheats.startPrank(address(registryCoordinator.allocationManager()));
-        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
+        registryCoordinator.registerOperator(
+            defaultOperator, address(serviceManager), operatorSetIds, data
+        );
 
         cheats.stopPrank();
     }
@@ -2749,7 +2758,9 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
             abi.encode(ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, socket, params);
 
         vm.expectRevert();
-        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
+        registryCoordinator.registerOperator(
+            defaultOperator, address(serviceManager), operatorSetIds, data
+        );
     }
 
     function test_deregisterHook_Reverts_WhenNotALM() public {
@@ -2793,10 +2804,14 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
             abi.encode(ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, socket, params);
 
         cheats.prank(address(registryCoordinator.allocationManager()));
-        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
+        registryCoordinator.registerOperator(
+            defaultOperator, address(serviceManager), operatorSetIds, data
+        );
 
         cheats.expectRevert();
-        registryCoordinator.deregisterOperator(defaultOperator, address(serviceManager), operatorSetIds);
+        registryCoordinator.deregisterOperator(
+            defaultOperator, address(serviceManager), operatorSetIds
+        );
     }
 
     function test_DeregisterHook_Reverts_WhenM2Quorum() public {

--- a/test/unit/RegistryCoordinatorUnit.t.sol
+++ b/test/unit/RegistryCoordinatorUnit.t.sol
@@ -2335,8 +2335,9 @@ contract RegistryCoordinatorUnitTests_BeforeMigration is RegistryCoordinatorUnit
     function test_registerALMHook_Reverts() public {
         cheats.prank(address(registryCoordinator.allocationManager()));
         cheats.expectRevert();
+        /// TODO:
         registryCoordinator.registerOperator(
-            defaultOperator, new uint32[](0), abi.encode(defaultSocket, pubkeyRegistrationParams)
+            defaultOperator, address(0), new uint32[](0), abi.encode(defaultSocket, pubkeyRegistrationParams)
         );
     }
 
@@ -2345,7 +2346,8 @@ contract RegistryCoordinatorUnitTests_BeforeMigration is RegistryCoordinatorUnit
         operatorSetIds[0] = 0;
         cheats.prank(address(registryCoordinator.allocationManager()));
         cheats.expectRevert();
-        registryCoordinator.deregisterOperator(defaultOperator, operatorSetIds);
+        /// TODO:
+        registryCoordinator.deregisterOperator(defaultOperator, address(0), operatorSetIds);
     }
 
     function test_CreateTotalDelegatedStakeQuorum() public {
@@ -2577,7 +2579,8 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
             abi.encode(ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, socket, params);
 
         cheats.prank(address(registryCoordinator.allocationManager()));
-        registryCoordinator.registerOperator(defaultOperator, operatorSetIds, data);
+        /// TODO:
+        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
     }
 
     function test_registerHook_WithChurn() public {
@@ -2634,7 +2637,7 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
 
         // Prank as allocation manager and call register hook
         cheats.prank(address(registryCoordinator.allocationManager()));
-        registryCoordinator.registerOperator(defaultOperator, operatorSetIds, data);
+        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
     }
 
     function test_updateStakesForQuorum() public {
@@ -2703,9 +2706,7 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
             abi.encode(ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, socket, params);
 
         cheats.startPrank(address(registryCoordinator.allocationManager()));
-        registryCoordinator.registerOperator(defaultOperator, operatorSetIds, data);
-
-        // registryCoordinator.deregisterOperator(defaultOperator, operatorSetIds);
+        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
 
         cheats.stopPrank();
     }
@@ -2748,7 +2749,7 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
             abi.encode(ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, socket, params);
 
         vm.expectRevert();
-        registryCoordinator.registerOperator(defaultOperator, operatorSetIds, data);
+        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
     }
 
     function test_deregisterHook_Reverts_WhenNotALM() public {
@@ -2792,10 +2793,10 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
             abi.encode(ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, socket, params);
 
         cheats.prank(address(registryCoordinator.allocationManager()));
-        registryCoordinator.registerOperator(defaultOperator, operatorSetIds, data);
+        registryCoordinator.registerOperator(defaultOperator, address(serviceManager), operatorSetIds, data);
 
         cheats.expectRevert();
-        registryCoordinator.deregisterOperator(defaultOperator, operatorSetIds);
+        registryCoordinator.deregisterOperator(defaultOperator, address(serviceManager), operatorSetIds);
     }
 
     function test_DeregisterHook_Reverts_WhenM2Quorum() public {

--- a/test/unit/VetoableSlasher.t.sol
+++ b/test/unit/VetoableSlasher.t.sol
@@ -235,6 +235,13 @@ contract VetoableSlasherTest is Test {
             AllocationManager.createOperatorSets.selector
         );
 
+        PermissionController(coreDeployment.permissionController).setAppointee(
+            address(serviceManager),
+            proxyAdminOwner,
+            coreDeployment.allocationManager,
+            AllocationManager.updateAVSMetadataURI.selector
+        );
+
         vm.stopPrank();
 
         uint8 quorumNumber = 0;
@@ -257,6 +264,7 @@ contract VetoableSlasherTest is Test {
         });
 
         vm.startPrank(proxyAdminOwner);
+        IAllocationManager(coreDeployment.allocationManager).updateAVSMetadataURI(serviceManager, "fake-avs-metadata");
         slashingRegistryCoordinator.createSlashableStakeQuorum(
             operatorSetParams, 1 ether, strategyParams, 0
         );

--- a/test/unit/VetoableSlasher.t.sol
+++ b/test/unit/VetoableSlasher.t.sol
@@ -264,7 +264,9 @@ contract VetoableSlasherTest is Test {
         });
 
         vm.startPrank(proxyAdminOwner);
-        IAllocationManager(coreDeployment.allocationManager).updateAVSMetadataURI(serviceManager, "fake-avs-metadata");
+        IAllocationManager(coreDeployment.allocationManager).updateAVSMetadataURI(
+            serviceManager, "fake-avs-metadata"
+        );
         slashingRegistryCoordinator.createSlashableStakeQuorum(
             operatorSetParams, 1 ether, strategyParams, 0
         );


### PR DESCRIPTION
Prevents unauthorized cross-AVS registrations when multiple AVSs share an AVS Registrar. 

Changes:
- Add `avs` address to `SlashingRegistryCoordinator` interface
- `avs` value will be used as a consent check to verify registrar assignment before an AVS can set it
- Associated with the update in the [core](https://github.com/Layr-Labs/eigenlayer-contracts/pull/1092/files) contracts that will utilize the getter

ejectOperator in SlashingRegistryCoordinator now only uses _forceDeregisterOperator, allowing AllocationManager to handle callbacks for deregistration

This change improves the ejection flow by ensuring proper deregistration handling through the AllocationManager while maintaining special handling for M2 quorums on ejection
