### PR TITLE
test: increase `StakeRegistry` test coverage

### DIFF
--- a/.github/workflows/forge-test-intense.yml
+++ b/.github/workflows/forge-test-intense.yml
@@ -1,0 +1,49 @@
+name: Forge Test (Intense)
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - mainnet
+      - testnet-holesky
+      - dev
+
+env:
+  FOUNDRY_PROFILE: ci
+  RPC_MAINNET: ${{ secrets.RPC_MAINNET }}
+  RPC_HOLESKY: ${{ secrets.RPC_HOLESKY }}
+  CHAIN_ID: ${{ secrets.CHAIN_ID }}
+  
+jobs:      
+  # -----------------------------------------------------------------------
+  # Forge Test (Intense)
+  # -----------------------------------------------------------------------
+
+  forge-test-intense:
+    name: Test (Intense)
+    runs-on: ubuntu-latest
+    steps:
+      # Check out repository with all submodules for complete codebase access.
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # Install the Foundry toolchain.
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      # Build the project and display contract sizes.
+      - name: Forge Build
+        run: |
+          forge --version
+          forge build --sizes
+        id: build
+
+      # Run Forge Test (Intense)
+      - name: Forge Test (Intense)
+        run: |
+          echo -e "\033[1;33mWarning: This workflow may take several hours to complete.\033[0m"
+          echo -e "\033[1;33mThis intense fuzzing workflow is optional but helps catch edge cases through extended testing.\033[0m"
+          FOUNDRY_PROFILE=intense forge test -vvv

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -4,9 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
       - mainnet
-      - testnet-goerli
+      - testnet-holesky
       - dev
   pull_request:
 
@@ -24,8 +23,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
     steps:
       # Check out repository with all submodules for complete codebase access.
       - uses: actions/checkout@v4
@@ -33,67 +30,32 @@ jobs:
           submodules: recursive
 
       # Install the Foundry toolchain.
-      - name: "Install Foundry"
+      - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: stable
 
       # Run Forge's formatting checker to ensure consistent code style.
-      - name: "Forge Fmt"
+      - name: Forge Fmt
         run: |
           forge fmt --check
         id: fmt
 
       # Build the project and display contract sizes.
-      - name: "Forge Build"
+      - name: Forge Build
         run: |
           forge --version
           forge build --sizes
         id: build
 
       # Run local tests (unit and integration).
-      - name: "Forge Test (Local)"
+      - name: Forge Test (Local)
         run: forge test -vvv
 
       # Run integration tests using a mainnet fork.
-      - name: "Forge Test Integration (Fork)"
+      - name: Forge Test Integration (Fork)
         run: FOUNDRY_PROFILE=forktest forge test --match-contract Integration -vvv
 
-  # -----------------------------------------------------------------------
-  # Forge Test (Intense)
-  # -----------------------------------------------------------------------
-
-  continuous-fuzzing:
-    name: Test (Intense)
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-    steps:
-      # Check out repository with all submodules for complete codebase access.
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      # Install the Foundry toolchain.
-      - name: "Install Foundry"
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: stable
-
-      # Build the project and display contract sizes.
-      - name: "Forge Build"
-        run: |
-          forge --version
-          forge build --sizes
-        id: build
-
-      # Run Forge Test (Intense)
-      - name: Forge Test (Intense)
-        run: |
-          echo -e "\033[1;33mWarning: This workflow may take several hours to complete.\033[0m"
-          echo -e "\033[1;33mThis intense fuzzing workflow is optional but helps catch edge cases through extended testing.\033[0m"
-          FOUNDRY_PROFILE=intense forge test -vvv
-          
   # -----------------------------------------------------------------------
   # Forge Coverage
   # -----------------------------------------------------------------------
@@ -101,8 +63,6 @@ jobs:
   run-coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
     steps:
       # Check out repository with all submodules for complete codebase access.
       - uses: actions/checkout@v4
@@ -110,7 +70,7 @@ jobs:
           submodules: recursive
 
       # Install the Foundry toolchain.
-      - name: "Install Foundry"
+      - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: stable
@@ -122,7 +82,7 @@ jobs:
         id: lcov
 
       # Build the project and display contract sizes.
-      - name: "Forge Build"
+      - name: Forge Build
         run: |
           forge --version
           forge build --sizes
@@ -142,7 +102,7 @@ jobs:
           path: report/*
 
       # Check coverage threshold after uploading report
-      - name: Check Coverage Threshold
+      - name: Check Coverage Threshold for >=90%
         run: |
           LINES_PCT=$(lcov --summary lcov.info | grep "lines" | cut -d ':' -f 2 | cut -d '%' -f 1 | tr -d '[:space:]')
           FUNCTIONS_PCT=$(lcov --summary lcov.info | grep "functions" | cut -d ':' -f 2 | cut -d '%' -f 1 | tr -d '[:space:]')          
@@ -180,7 +140,7 @@ jobs:
           submodules: recursive
 
       # Install the Foundry toolchain.
-      - name: "Install Foundry"
+      - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: stable

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -101,14 +101,6 @@ jobs:
   run-coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    # Only run coverage checks on dev, testnet-holesky, and mainnet branches, or PRs targeting these branches
-    if: |
-      github.ref == 'refs/heads/dev' ||
-      github.ref == 'refs/heads/testnet-holesky' ||
-      github.ref == 'refs/heads/mainnet' ||
-      github.base_ref == 'dev' ||
-      github.base_ref == 'testnet-holesky' ||
-      github.base_ref == 'mainnet'
     strategy:
       fail-fast: true
     steps:

--- a/foundry.toml
+++ b/foundry.toml
@@ -16,10 +16,12 @@
 
     # Defines paths for Solidity imports.
     remappings = [
-        "@openzeppelin/=lib/openzeppelin-contracts-v4.9.0/",
-        "@openzeppelin-upgrades/=lib/openzeppelin-contracts-upgradeable-v4.9.0/",
+        "forge-std/=lib/forge-std/src/",
         "ds-test/=lib/ds-test/src/",
-        "forge-std/=lib/forge-std/src/"
+        "@openzeppelin/=lib/openzeppelin-contracts/",
+        "@openzeppelin-upgrades/=lib/openzeppelin-contracts-upgradeable/",
+        "eigenlayer-contracts/=lib/eigenlayer-contracts/",
+
     ]
     # Specifies the exact version of Solidity to use, overriding auto-detection.
     solc_version = '0.8.27'

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,5 +1,0 @@
-@openzeppelin-upgrades/=lib/openzeppelin-contracts-upgradeable/
-@openzeppelin/=lib/openzeppelin-contracts/
-ds-test/=lib/ds-test/src/
-eigenlayer-contracts/=lib/eigenlayer-contracts/
-forge-std/=lib/forge-std/src/

--- a/src/BLSApkRegistry.sol
+++ b/src/BLSApkRegistry.sol
@@ -189,9 +189,7 @@ contract BLSApkRegistry is BLSApkRegistryStorage {
                 quorumApkUpdatesLength == 0
                     || blockNumber < apkHistory[quorumNumber][0].updateBlockNumber
             ) {
-                revert(
-                    "BLSApkRegistry.getApkIndicesAtBlockNumber: blockNumber is before the first update"
-                );
+                revert BlockNumberBeforeFirstUpdate();
             }
 
             // Loop backward through apkHistory until we find an entry that preceeds `blockNumber`

--- a/src/BLSSignatureChecker.sol
+++ b/src/BLSSignatureChecker.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
 import {BitmapUtils} from "./libraries/BitmapUtils.sol";
 import {BN254} from "./libraries/BN254.sol";
 
@@ -18,7 +20,10 @@ contract BLSSignatureChecker is BLSSignatureCheckerStorage {
     /// MODIFIERS
 
     modifier onlyCoordinatorOwner() {
-        require(msg.sender == registryCoordinator.owner(), OnlyRegistryCoordinatorOwner());
+        require(
+            msg.sender == Ownable(address(registryCoordinator)).owner(),
+            OnlyRegistryCoordinatorOwner()
+        );
         _;
     }
 

--- a/src/EjectionManager.sol
+++ b/src/EjectionManager.sol
@@ -5,21 +5,21 @@ import {OwnableUpgradeable} from "@openzeppelin-upgrades/contracts/access/Ownabl
 import {
     EjectionManagerStorage,
     IEjectionManager,
-    IRegistryCoordinator,
+    ISlashingRegistryCoordinator,
     IStakeRegistry
 } from "./EjectionManagerStorage.sol";
 
 // TODO: double check order of inheritance since we separated storage from logic...
 
 /**
- * @title Used for automated ejection of operators from the RegistryCoordinator under a ratelimit
+ * @title Used for automated ejection of operators from the SlashingRegistryCoordinator under a ratelimit
  * @author Layr Labs, Inc.
  */
 contract EjectionManager is OwnableUpgradeable, EjectionManagerStorage {
     constructor(
-        IRegistryCoordinator _registryCoordinator,
+        ISlashingRegistryCoordinator _slashingRegistryCoordinator,
         IStakeRegistry _stakeRegistry
-    ) EjectionManagerStorage(_registryCoordinator, _stakeRegistry) {
+    ) EjectionManagerStorage(_slashingRegistryCoordinator, _stakeRegistry) {
         _disableInitializers();
     }
 
@@ -67,8 +67,8 @@ contract EjectionManager is OwnableUpgradeable, EjectionManagerStorage {
                         stakeForEjection += operatorStake;
                         ++ejectedOperators;
 
-                        registryCoordinator.ejectOperator(
-                            registryCoordinator.getOperatorFromId(operatorIds[i][j]),
+                        slashingRegistryCoordinator.ejectOperator(
+                            slashingRegistryCoordinator.getOperatorFromId(operatorIds[i][j]),
                             abi.encodePacked(quorumNumber)
                         );
 
@@ -80,8 +80,8 @@ contract EjectionManager is OwnableUpgradeable, EjectionManagerStorage {
                     stakeForEjection += operatorStake;
                     ++ejectedOperators;
 
-                    registryCoordinator.ejectOperator(
-                        registryCoordinator.getOperatorFromId(operatorIds[i][j]),
+                    slashingRegistryCoordinator.ejectOperator(
+                        slashingRegistryCoordinator.getOperatorFromId(operatorIds[i][j]),
                         abi.encodePacked(quorumNumber)
                     );
 

--- a/src/EjectionManagerStorage.sol
+++ b/src/EjectionManagerStorage.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import {IRegistryCoordinator} from "./interfaces/IRegistryCoordinator.sol";
+import {ISlashingRegistryCoordinator} from "./interfaces/ISlashingRegistryCoordinator.sol";
 import {IStakeRegistry} from "./interfaces/IStakeRegistry.sol";
 import {IEjectionManager} from "./interfaces/IEjectionManager.sol";
 
@@ -12,7 +12,7 @@ abstract contract EjectionManagerStorage is IEjectionManager {
     uint8 internal constant MAX_QUORUM_COUNT = 192;
 
     /// @inheritdoc IEjectionManager
-    IRegistryCoordinator public immutable registryCoordinator;
+    ISlashingRegistryCoordinator public immutable slashingRegistryCoordinator;
     /// @inheritdoc IEjectionManager
     IStakeRegistry public immutable stakeRegistry;
 
@@ -23,8 +23,11 @@ abstract contract EjectionManagerStorage is IEjectionManager {
     /// @inheritdoc IEjectionManager
     mapping(uint8 => QuorumEjectionParams) public quorumEjectionParams;
 
-    constructor(IRegistryCoordinator _registryCoordinator, IStakeRegistry _stakeRegistry) {
-        registryCoordinator = _registryCoordinator;
+    constructor(
+        ISlashingRegistryCoordinator _slashingRegistryCoordinator,
+        IStakeRegistry _stakeRegistry
+    ) {
+        slashingRegistryCoordinator = _slashingRegistryCoordinator;
         stakeRegistry = _stakeRegistry;
     }
 

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -2,8 +2,10 @@
 pragma solidity ^0.8.27;
 
 import {IPauserRegistry} from "eigenlayer-contracts/src/contracts/interfaces/IPauserRegistry.sol";
-import {IAllocationManager} from
-    "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {
+    IAllocationManager,
+    OperatorSet
+} from "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 import {IBLSApkRegistry, IBLSApkRegistryTypes} from "./interfaces/IBLSApkRegistry.sol";
 import {IStakeRegistry} from "./interfaces/IStakeRegistry.sol";
 import {IIndexRegistry} from "./interfaces/IIndexRegistry.sol";
@@ -132,7 +134,11 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
             OnlyM2QuorumsAllowed()
         );
 
-        _deregisterOperator({operator: msg.sender, quorumNumbers: quorumNumbers});
+        _deregisterOperator({
+            operator: msg.sender,
+            quorumNumbers: quorumNumbers,
+            shouldForceDeregister: false
+        });
     }
 
     /// @inheritdoc IRegistryCoordinator
@@ -194,6 +200,54 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
         // them from the AVS via the EigenLayer core contracts
         if (operatorM2QuorumBitmap.isEmpty()) {
             serviceManager.deregisterOperatorFromAVS(operator);
+        }
+    }
+
+    /**
+     * @dev Helper function to update operator stakes and deregister loiterers
+     * Loiterers are AVS registered operators who have force deregistered from the OperatorSet/quorum
+     * in the core EigenLayer contract AllocationManager but not deregistered from the OperatorSet/quorum
+     * in this contract. Potentially due to out of gas errors in the deregistration callback. This function
+     * will handle that edge case by deregistering the operator from the AVS if they are no longer registered
+     * in the AllocationManager.
+     */
+    function _updateStakesAndDeregisterLoiterers(
+        address[] memory operators,
+        bytes32[] memory operatorIds,
+        uint8 quorumNumber
+    ) internal virtual override {
+        bytes memory singleQuorumNumber = new bytes(1);
+        singleQuorumNumber[0] = bytes1(quorumNumber);
+        bool[] memory doesNotMeetStakeThreshold =
+            stakeRegistry.updateOperatorsStake(operators, operatorIds, quorumNumber);
+
+        for (uint256 i = 0; i < operators.length; ++i) {
+            bool isM2Quorum = _isM2Quorum(quorumNumber);
+            bool registeredInCore;
+            // If its an operatorSet quorum, its possible for registeredInCore to be true/false
+            // so check for operatorSet inclusion in the AllocationManager
+            if (!isM2Quorum) {
+                registeredInCore = allocationManager.isMemberOfOperatorSet(
+                    operators[i], OperatorSet({avs: accountIdentifier, id: uint32(quorumNumber)})
+                );
+            }
+
+            // Determine if the operator should be deregistered
+            // If the operator does not have the minimum stake, they need to be force deregistered.
+            // Additionally, it is possible for an operator to have deregistered from an OperatorSet
+            // in the core EigenLayer contract AllocationManager but not have the deregistration
+            // callback succeed here in `deregisterOperator` due to out of gas errors. If that is the case,
+            // we need to deregister the operator from the OperatorSet in this contract
+            bool shouldDeregister =
+                doesNotMeetStakeThreshold[i] || (!registeredInCore && !isM2Quorum);
+
+            if (shouldDeregister) {
+                _deregisterOperator({
+                    operator: operators[i],
+                    quorumNumbers: singleQuorumNumber,
+                    shouldForceDeregister: registeredInCore
+                });
+            }
         }
     }
 

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -18,10 +18,11 @@ import {OwnableUpgradeable} from "@openzeppelin-upgrades/contracts/access/Ownabl
 import {RegistryCoordinatorStorage} from "./RegistryCoordinatorStorage.sol";
 
 /**
- * @title A `RegistryCoordinator` that has three registries:
+ * @title A `RegistryCoordinator` that has four registries:
  *      1) a `StakeRegistry` that keeps track of operators' stakes
  *      2) a `BLSApkRegistry` that keeps track of operators' BLS public keys and aggregate BLS public keys for each quorum
  *      3) an `IndexRegistry` that keeps track of an ordered list of operators for each quorum
+ *      4) a `SocketRegistry` that keeps track of operators' sockets (arbitrary strings)
  *
  * @author Layr Labs, Inc.
  */

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -208,6 +208,16 @@ contract RegistryCoordinator is IRegistryCoordinator, SlashingRegistryCoordinato
         return (1 << quorumCount) - 1;
     }
 
+    /**
+     * @notice Returns the message hash that an operator must sign to register their BLS public key.
+     * @param operator is the address of the operator registering their BLS public key
+     */
+    function calculatePubkeyRegistrationMessageHash(
+        address operator
+    ) public view returns (bytes32) {
+        return _hashTypedDataV4(keccak256(abi.encode(PUBKEY_REGISTRATION_TYPEHASH, operator)));
+    }
+
     /// @dev need to override function here since its defined in both these contracts
     function owner()
         public

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -15,6 +15,7 @@ import {BitmapUtils} from "./libraries/BitmapUtils.sol";
 import {SlashingRegistryCoordinator} from "./SlashingRegistryCoordinator.sol";
 import {ISlashingRegistryCoordinator} from "./interfaces/ISlashingRegistryCoordinator.sol";
 import {OwnableUpgradeable} from "@openzeppelin-upgrades/contracts/access/OwnableUpgradeable.sol";
+import {RegistryCoordinatorStorage} from "./RegistryCoordinatorStorage.sol";
 
 /**
  * @title A `RegistryCoordinator` that has three registries:
@@ -24,11 +25,8 @@ import {OwnableUpgradeable} from "@openzeppelin-upgrades/contracts/access/Ownabl
  *
  * @author Layr Labs, Inc.
  */
-contract RegistryCoordinator is IRegistryCoordinator, SlashingRegistryCoordinator {
+contract RegistryCoordinator is RegistryCoordinatorStorage {
     using BitmapUtils for *;
-
-    /// @notice the ServiceManager for this AVS, which forwards calls onto EigenLayer's core contracts
-    IServiceManager public immutable serviceManager;
 
     constructor(
         IServiceManager _serviceManager,
@@ -39,7 +37,8 @@ contract RegistryCoordinator is IRegistryCoordinator, SlashingRegistryCoordinato
         IAllocationManager _allocationManager,
         IPauserRegistry _pauserRegistry
     )
-        SlashingRegistryCoordinator(
+        RegistryCoordinatorStorage(
+            _serviceManager,
             _stakeRegistry,
             _blsApkRegistry,
             _indexRegistry,
@@ -47,9 +46,7 @@ contract RegistryCoordinator is IRegistryCoordinator, SlashingRegistryCoordinato
             _allocationManager,
             _pauserRegistry
         )
-    {
-        serviceManager = _serviceManager;
-    }
+    {}
 
     /**
      *
@@ -64,44 +61,28 @@ contract RegistryCoordinator is IRegistryCoordinator, SlashingRegistryCoordinato
         IBLSApkRegistryTypes.PubkeyRegistrationParams memory params,
         SignatureWithSaltAndExpiry memory operatorSignature
     ) external onlyWhenNotPaused(PAUSED_REGISTER_OPERATOR) {
-        require(!m2QuorumsDisabled, M2QuorumsAlreadyDisabled());
-        /**
-         * If the operator has NEVER registered a pubkey before, use `params` to register
-         * their pubkey in blsApkRegistry
-         *
-         * If the operator HAS registered a pubkey, `params` is ignored and the pubkey hash
-         * (operatorId) is fetched instead
-         */
-        bytes32 operatorId = _getOrCreateOperatorId(msg.sender, params);
+        require(!isM2QuorumRegistrationDisabled, M2QuorumRegistrationIsDisabled());
+        require(
+            quorumNumbers.orderedBytesArrayToBitmap().isSubsetOf(m2QuorumBitmap()),
+            OnlyM2QuorumsAllowed()
+        );
 
-        // Register the operator in each of the registry contracts and update the operator's
-        // quorum bitmap and registration status
-        uint32[] memory numOperatorsPerQuorum = _registerOperator({
+        // Check if the operator has registered before
+        bool operatorRegisteredBefore =
+            _operatorInfo[msg.sender].status == OperatorStatus.REGISTERED;
+
+        // register the operator with the registry coordinator
+        _registerOperator({
             operator: msg.sender,
-            operatorId: operatorId,
+            operatorId: _getOrCreateOperatorId(msg.sender, params),
             quorumNumbers: quorumNumbers,
-            socket: socket
-        }).numOperatorsPerQuorum;
+            socket: socket,
+            checkMaxOperatorCount: true
+        });
 
-        // For each quorum, validate that the new operator count does not exceed the maximum
-        // (If it does, an operator needs to be replaced -- see `registerOperatorWithChurn`)
-        for (uint256 i = 0; i < quorumNumbers.length; i++) {
-            uint8 quorumNumber = uint8(quorumNumbers[i]);
-
-            require(
-                numOperatorsPerQuorum[i] <= _quorumParams[quorumNumber].maxOperatorCount,
-                MaxQuorumsReached()
-            );
-        }
-
-        // If the operator wasn't registered for any quorums, update their status
-        // and register them with this AVS in EigenLayer core (DelegationManager)
-        if (_operatorInfo[msg.sender].status != OperatorStatus.REGISTERED) {
-            _operatorInfo[msg.sender] =
-                OperatorInfo({operatorId: operatorId, status: OperatorStatus.REGISTERED});
-
+        // If the operator has never registered before, register them with the AVSDirectory
+        if (!operatorRegisteredBefore) {
             serviceManager.registerOperatorToAVS(msg.sender, operatorSignature);
-            emit OperatorRegistered(msg.sender, operatorId);
         }
     }
 
@@ -114,34 +95,29 @@ contract RegistryCoordinator is IRegistryCoordinator, SlashingRegistryCoordinato
         SignatureWithSaltAndExpiry memory churnApproverSignature,
         SignatureWithSaltAndExpiry memory operatorSignature
     ) external onlyWhenNotPaused(PAUSED_REGISTER_OPERATOR) {
-        require(!m2QuorumsDisabled, M2QuorumsAlreadyDisabled());
+        require(!isM2QuorumRegistrationDisabled, M2QuorumRegistrationIsDisabled());
+        require(
+            quorumNumbers.orderedBytesArrayToBitmap().isSubsetOf(m2QuorumBitmap()),
+            OnlyM2QuorumsAllowed()
+        );
 
-        /**
-         * If the operator has NEVER registered a pubkey before, use `params` to register
-         * their pubkey in blsApkRegistry
-         *
-         * If the operator HAS registered a pubkey, `params` is ignored and the pubkey hash
-         * (operatorId) is fetched instead
-         */
-        bytes32 operatorId = _getOrCreateOperatorId(msg.sender, params);
+        // Check if the operator has registered before
+        bool operatorRegisteredBefore =
+            _operatorInfo[msg.sender].status == OperatorStatus.REGISTERED;
 
+        // register the operator with the registry coordinator with churn
         _registerOperatorWithChurn({
             operator: msg.sender,
-            operatorId: operatorId,
+            operatorId: _getOrCreateOperatorId(msg.sender, params),
             quorumNumbers: quorumNumbers,
             socket: socket,
             operatorKickParams: operatorKickParams,
             churnApproverSignature: churnApproverSignature
         });
 
-        // If the operator wasn't registered for any quorums, update their status
-        // and register them with this AVS in EigenLayer core (DelegationManager)
-        if (_operatorInfo[msg.sender].status != OperatorStatus.REGISTERED) {
-            _operatorInfo[msg.sender] =
-                OperatorInfo({operatorId: operatorId, status: OperatorStatus.REGISTERED});
-
+        // If the operator has never registered before, register them with the AVSDirectory
+        if (!operatorRegisteredBefore) {
             serviceManager.registerOperatorToAVS(msg.sender, operatorSignature);
-            emit OperatorRegistered(msg.sender, operatorId);
         }
     }
 
@@ -150,44 +126,69 @@ contract RegistryCoordinator is IRegistryCoordinator, SlashingRegistryCoordinato
         bytes memory quorumNumbers
     ) external override onlyWhenNotPaused(PAUSED_DEREGISTER_OPERATOR) {
         // Check that the quorum numbers are M2 quorums
-        for (uint256 i = 0; i < quorumNumbers.length; i++) {
-            require(
-                !operatorSetsEnabled || _isM2Quorum(uint8(quorumNumbers[i])), OperatorSetQuorum()
-            );
-        }
+        require(
+            quorumNumbers.orderedBytesArrayToBitmap().isSubsetOf(m2QuorumBitmap()),
+            OnlyM2QuorumsAllowed()
+        );
+
         _deregisterOperator({operator: msg.sender, quorumNumbers: quorumNumbers});
     }
 
     /// @inheritdoc IRegistryCoordinator
-    function enableOperatorSets() external onlyOwner {
-        require(!operatorSetsEnabled, OperatorSetsAlreadyEnabled());
+    function disableM2QuorumRegistration() external onlyOwner {
+        require(!isM2QuorumRegistrationDisabled, M2QuorumRegistrationIsDisabled());
 
-        // Set the bitmap for M2 quorums
-        M2quorumBitmap = _getQuorumBitmap(quorumCount);
+        isM2QuorumRegistrationDisabled = true;
 
-        // Enable operator sets mode
-        operatorSetsEnabled = true;
-
-        emit OperatorSetsEnabled();
+        emit M2QuorumRegistrationDisabled();
     }
 
-    /// @inheritdoc IRegistryCoordinator
-    function disableM2QuorumRegistration() external onlyOwner {
-        require(operatorSetsEnabled, OperatorSetsNotEnabled());
+    /**
+     *
+     *                            INTERNAL FUNCTIONS
+     *
+     */
 
-        m2QuorumsDisabled = true;
+    /// @dev override the _forceDeregisterOperator function to handle M2 quorum deregistration
+    function _forceDeregisterOperator(
+        address operator,
+        bytes memory quorumNumbers
+    ) internal virtual override {
+        // filter out M2 quorums from the quorum numbers
+        uint256 operatorSetBitmap =
+            quorumNumbers.orderedBytesArrayToBitmap().minus(m2QuorumBitmap());
+        if (!operatorSetBitmap.isEmpty()) {
+            // call the parent _forceDeregisterOperator function for operator sets quorums
+            super._forceDeregisterOperator(operator, operatorSetBitmap.bitmapToBytesArray());
+        }
+    }
 
-        emit M2QuorumsDisabled();
+    /// @dev Hook to prevent any new quorums from being created if operator sets are not enabled
+    function _beforeCreateQuorum(
+        uint8
+    ) internal virtual override {
+        // If operator sets are not enabled, set the m2 quorum bitmap to the current m2 quorum bitmap
+        // and enable operator sets
+        if (!operatorSetsEnabled) {
+            _m2QuorumBitmap = m2QuorumBitmap();
+            operatorSetsEnabled = true;
+        }
     }
 
     /// @dev Hook to allow for any post-deregister logic
     function _afterDeregisterOperator(
         address operator,
-        bytes32 operatorId,
-        bytes memory quorumNumbers,
+        bytes32,
+        bytes memory,
         uint192 newBitmap
     ) internal virtual override {
-        uint256 operatorM2QuorumBitmap = newBitmap.minus(M2quorumBitmap);
+        // Bitmap representing all quorums including M2 and OperatorSet quorums
+        uint256 totalQuorumBitmap = _getTotalQuorumBitmap();
+        // Bitmap representing only OperatorSet quorums. Equal to 0 if operatorSets not enabled
+        uint256 operatorSetQuorumBitmap = totalQuorumBitmap.minus(m2QuorumBitmap());
+        // Operators updated M2 quorum bitmap, clear all the bits of operatorSetQuorumBitmap which gives the
+        // operator's M2 quorum bitmap.
+        uint256 operatorM2QuorumBitmap = newBitmap.minus(operatorSetQuorumBitmap);
         // If the operator is no longer registered for any M2 quorums, update their status and deregister
         // them from the AVS via the EigenLayer core contracts
         if (operatorM2QuorumBitmap.isEmpty()) {
@@ -195,17 +196,46 @@ contract RegistryCoordinator is IRegistryCoordinator, SlashingRegistryCoordinato
         }
     }
 
-    /// @dev Returns a bitmap with all bits set up to `quorumCount`. Used for bit-masking quorum numbers
-    /// and differentiating between operator sets and M2 quorums
-    function _getQuorumBitmap(
-        uint256 quorumCount
-    ) internal pure returns (uint256) {
+    /// @notice Return bitmap representing all quorums(Legacy M2 and OperatorSet) quorums
+    function _getTotalQuorumBitmap() internal view returns (uint256) {
         // This creates a number where all bits up to quorumCount are set to 1
         // For example:
         // quorumCount = 3 -> 0111 (7 in decimal)
         // quorumCount = 5 -> 011111 (31 in decimal)
         // This is a safe operation since we limit MAX_QUORUM_COUNT to 192
         return (1 << quorumCount) - 1;
+    }
+
+    /// @notice Returns true if the quorum number is an M2 quorum
+    /// @dev We use bitwise and to check if the quorum number is an M2 quorum
+    function _isM2Quorum(
+        uint8 quorumNumber
+    ) internal view returns (bool) {
+        return m2QuorumBitmap().isSet(quorumNumber);
+    }
+
+    /**
+     *
+     *                            VIEW FUNCTIONS
+     *
+     */
+
+    /// @dev Returns a bitmap with all bits set up to `quorumCount`. Used for bit-masking quorum numbers
+    /// and differentiating between operator sets and M2 quorums
+    function m2QuorumBitmap() public view returns (uint256) {
+        // If operator sets are enabled, return the current m2 quorum bitmap
+        if (operatorSetsEnabled) {
+            return _m2QuorumBitmap;
+        }
+
+        return _getTotalQuorumBitmap();
+    }
+
+    /// @notice Returns true if the quorum number is an M2 quorum
+    function isM2Quorum(
+        uint8 quorumNumber
+    ) external view returns (bool) {
+        return _isM2Quorum(quorumNumber);
     }
 
     /**
@@ -216,15 +246,5 @@ contract RegistryCoordinator is IRegistryCoordinator, SlashingRegistryCoordinato
         address operator
     ) public view returns (bytes32) {
         return _hashTypedDataV4(keccak256(abi.encode(PUBKEY_REGISTRATION_TYPEHASH, operator)));
-    }
-
-    /// @dev need to override function here since its defined in both these contracts
-    function owner()
-        public
-        view
-        override(SlashingRegistryCoordinator, ISlashingRegistryCoordinator)
-        returns (address)
-    {
-        return OwnableUpgradeable.owner();
     }
 }

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -237,14 +237,4 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
     ) external view returns (bool) {
         return _isM2Quorum(quorumNumber);
     }
-
-    /**
-     * @notice Returns the message hash that an operator must sign to register their BLS public key.
-     * @param operator is the address of the operator registering their BLS public key
-     */
-    function calculatePubkeyRegistrationMessageHash(
-        address operator
-    ) public view returns (bytes32) {
-        return _hashTypedDataV4(keccak256(abi.encode(PUBKEY_REGISTRATION_TYPEHASH, operator)));
-    }
 }

--- a/src/RegistryCoordinatorStorage.sol
+++ b/src/RegistryCoordinatorStorage.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {IPauserRegistry} from "eigenlayer-contracts/src/contracts/interfaces/IPauserRegistry.sol";
+import {IAllocationManager} from
+    "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IBLSApkRegistry, IBLSApkRegistryTypes} from "./interfaces/IBLSApkRegistry.sol";
+import {IStakeRegistry} from "./interfaces/IStakeRegistry.sol";
+import {IIndexRegistry} from "./interfaces/IIndexRegistry.sol";
+import {IServiceManager} from "./interfaces/IServiceManager.sol";
+import {IRegistryCoordinator} from "./interfaces/IRegistryCoordinator.sol";
+import {ISocketRegistry} from "./interfaces/ISocketRegistry.sol";
+
+import {SlashingRegistryCoordinator} from "./SlashingRegistryCoordinator.sol";
+
+abstract contract RegistryCoordinatorStorage is
+    IRegistryCoordinator,
+    SlashingRegistryCoordinator
+{
+    /**
+     *
+     *                            CONSTANTS AND IMMUTABLES
+     *
+     */
+
+    /// @notice the ServiceManager for this AVS, which forwards calls onto EigenLayer's core contracts
+    IServiceManager public immutable serviceManager;
+
+    /**
+     *
+     *                                    STATE
+     *
+     */
+
+    /// @notice Whether this AVS allows operator sets for creation/registration
+    /// @dev If true, then operator sets may be created and operators may register to operator sets via the AllocationManager
+    bool public operatorSetsEnabled;
+
+    /// @notice Whether this AVS allows M2 quorums for registration
+    /// @dev If true, operators may **not** register to M2 quorums. Deregistration is still allowed.
+    bool public isM2QuorumRegistrationDisabled;
+
+    /// @notice The bitmap containing all M2 quorums. This is only used for existing AVS middlewares that have M2 quorums
+    /// and need to call `enableOperatorSets()` to enable operator sets mode.
+    uint256 internal _m2QuorumBitmap;
+
+    constructor(
+        IServiceManager _serviceManager,
+        IStakeRegistry _stakeRegistry,
+        IBLSApkRegistry _blsApkRegistry,
+        IIndexRegistry _indexRegistry,
+        ISocketRegistry _socketRegistry,
+        IAllocationManager _allocationManager,
+        IPauserRegistry _pauserRegistry
+    )
+        SlashingRegistryCoordinator(
+            _stakeRegistry,
+            _blsApkRegistry,
+            _indexRegistry,
+            _socketRegistry,
+            _allocationManager,
+            _pauserRegistry
+        )
+    {
+        serviceManager = _serviceManager;
+    }
+
+    uint256[48] private __GAP;
+}

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -1066,4 +1066,14 @@ contract SlashingRegistryCoordinator is
             _hashTypedDataV4(keccak256(abi.encode(PUBKEY_REGISTRATION_TYPEHASH, operator)))
         );
     }
+
+    /**
+     * @notice Returns the message hash that an operator must sign to register their BLS public key.
+     * @param operator is the address of the operator registering their BLS public key
+     */
+    function calculatePubkeyRegistrationMessageHash(
+        address operator
+    ) public view returns (bytes32) {
+        return _hashTypedDataV4(keccak256(abi.encode(PUBKEY_REGISTRATION_TYPEHASH, operator)));
+    }
 }

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -225,7 +225,11 @@ contract SlashingRegistryCoordinator is
         uint32[] memory operatorSetIds
     ) external override onlyAllocationManager onlyWhenNotPaused(PAUSED_DEREGISTER_OPERATOR) {
         bytes memory quorumNumbers = _getQuorumNumbers(operatorSetIds);
-        _deregisterOperator(operator, quorumNumbers);
+        _deregisterOperator({
+            operator: operator,
+            quorumNumbers: quorumNumbers,
+            shouldForceDeregister: false
+        });
     }
 
     /// @inheritdoc ISlashingRegistryCoordinator
@@ -243,16 +247,9 @@ contract SlashingRegistryCoordinator is
             bytes memory quorumNumbers = currentBitmap.bitmapToBytesArray();
             for (uint256 j = 0; j < quorumNumbers.length; j++) {
                 // update the operator's stake for each quorum
-                uint8 quorumNumber = uint8(quorumNumbers[j]);
-                bool[] memory shouldBeDeregistered = stakeRegistry.updateOperatorsStake(
-                    singleOperator, singleOperatorId, quorumNumber
+                _updateStakesAndDeregisterLoiterers(
+                    singleOperator, singleOperatorId, uint8(quorumNumbers[j])
                 );
-
-                if (shouldBeDeregistered[0]) {
-                    bytes memory singleQuorumNumber = new bytes(1);
-                    singleQuorumNumber[0] = quorumNumbers[j];
-                    _deregisterOperator(operators[i], singleQuorumNumber);
-                }
             }
         }
     }
@@ -303,13 +300,7 @@ contract SlashingRegistryCoordinator is
                 prevOperatorAddress = operator;
             }
 
-            bool[] memory shouldBeDeregistered =
-                stakeRegistry.updateOperatorsStake(currQuorumOperators, operatorIds, quorumNumber);
-            for (uint256 j = 0; j < currQuorumOperators.length; ++j) {
-                if (shouldBeDeregistered[j]) {
-                    _deregisterOperator(currQuorumOperators[j], quorumNumbers[i:i + 1]);
-                }
-            }
+            _updateStakesAndDeregisterLoiterers(currQuorumOperators, operatorIds, quorumNumber);
 
             // Update timestamp that all operators in quorum have been updated all at once
             quorumUpdateBlockNumber[quorumNumber] = block.number;
@@ -344,7 +335,11 @@ contract SlashingRegistryCoordinator is
             operatorInfo.status == OperatorStatus.REGISTERED && !quorumsToRemove.isEmpty()
                 && quorumsToRemove.isSubsetOf(currentBitmap)
         ) {
-            _deregisterOperator({operator: operator, quorumNumbers: quorumNumbers});
+            _deregisterOperator({
+                operator: operator,
+                quorumNumbers: quorumNumbers,
+                shouldForceDeregister: true
+            });
         }
     }
 
@@ -522,7 +517,11 @@ contract SlashingRegistryCoordinator is
 
                 bytes memory singleQuorumNumber = new bytes(1);
                 singleQuorumNumber[0] = quorumNumbers[i];
-                _deregisterOperator(operatorKickParams[i].operator, singleQuorumNumber);
+                _deregisterOperator({
+                    operator: operatorKickParams[i].operator,
+                    quorumNumbers: singleQuorumNumber,
+                    shouldForceDeregister: true
+                });
             }
         }
     }
@@ -531,8 +530,16 @@ contract SlashingRegistryCoordinator is
      * @dev Deregister the operator from one or more quorums
      * This method updates the operator's quorum bitmap and status, then deregisters
      * the operator with the BLSApkRegistry, IndexRegistry, and StakeRegistry
+     * @param operator the operator to deregister
+     * @param quorumNumbers the quorum numbers to deregister from
+     * @param shouldForceDeregister whether the operator needs to be deregistered from the OperatorSets of
+     * the core EigenLayer contract AllocationManager
      */
-    function _deregisterOperator(address operator, bytes memory quorumNumbers) internal virtual {
+    function _deregisterOperator(
+        address operator,
+        bytes memory quorumNumbers,
+        bool shouldForceDeregister
+    ) internal virtual {
         // Fetch the operator's info and ensure they are registered
         OperatorInfo storage operatorInfo = _operatorInfo[operator];
         bytes32 operatorId = operatorInfo.operatorId;
@@ -571,8 +578,9 @@ contract SlashingRegistryCoordinator is
         stakeRegistry.deregisterOperator(operatorId, quorumNumbers);
         indexRegistry.deregisterOperator(operatorId, quorumNumbers);
 
-        // If the caller is not the allocationManager, then this is a force deregistration not consented by the operator
-        if (msg.sender != address(allocationManager)) {
+        // If the operator is not deregistered from the EigenLayer core protocol, then we need to force deregister them
+        // from their respective OperatorSets in the AllocationManager
+        if (shouldForceDeregister) {
             _forceDeregisterOperator(operator, quorumNumbers);
         }
 
@@ -583,6 +591,9 @@ contract SlashingRegistryCoordinator is
     /**
      * @notice Helper function to handle operator set deregistration for OperatorSets quorums. This is used
      * when an operator is force-deregistered from a set of quorums.
+     * Due to deregistration being possible in the AllocationManager but not in the AVS as a result of the
+     * try/catch in `AllocationManager.deregisterFromOperatorSets`, we need to first check that the operator
+     * is not already deregistered from the OperatorSet in the AllocationManager.
      * @param operator The operator to deregister
      * @param quorumNumbers The quorum numbers the operator is force-deregistered from
      */
@@ -590,6 +601,25 @@ contract SlashingRegistryCoordinator is
         address operator,
         bytes memory quorumNumbers
     ) internal virtual {
+        uint32[] memory operatorSetIds = new uint32[](quorumNumbers.length);
+        uint256 numDeregister = 0;
+        for (uint256 i = 0; i < quorumNumbers.length; ++i) {
+            uint32 operatorSetId = uint32(uint8(quorumNumbers[i]));
+            if (
+                allocationManager.isMemberOfOperatorSet(
+                    operator, OperatorSet({avs: accountIdentifier, id: operatorSetId})
+                )
+            ) {
+                operatorSetIds[numDeregister] = operatorSetId;
+                numDeregister++;
+            }
+        }
+
+        // resize operatorSetIds array length to numDeregister
+        assembly {
+            mstore(operatorSetIds, numDeregister)
+        }
+
         allocationManager.deregisterFromOperatorSets(
             IAllocationManagerTypes.DeregisterParams({
                 operator: operator,
@@ -597,6 +627,44 @@ contract SlashingRegistryCoordinator is
                 operatorSetIds: _getOperatorSetIds(quorumNumbers)
             })
         );
+    }
+
+    /**
+     * @dev Helper function to update operator stakes and deregister loiterers
+     * Loiterers are AVS registered operators who have force deregistered from the OperatorSet/quorum
+     * in the core EigenLayer contract AllocationManager but not deregistered from the OperatorSet/quorum
+     * in this contract. Potentially due to out of gas errors in the deregistration callback. This function
+     * will handle that edge case by deregistering the operator from the AVS if they are no longer registered
+     * in the AllocationManager.
+     */
+    function _updateStakesAndDeregisterLoiterers(
+        address[] memory operators,
+        bytes32[] memory operatorIds,
+        uint8 quorumNumber
+    ) internal virtual {
+        bytes memory singleQuorumNumber = new bytes(1);
+        singleQuorumNumber[0] = bytes1(quorumNumber);
+        bool[] memory doesNotMeetStakeThreshold =
+            stakeRegistry.updateOperatorsStake(operators, operatorIds, quorumNumber);
+        for (uint256 j = 0; j < operators.length; ++j) {
+            // whether the operator is registered in the core EigenLayer contract AllocationManager
+            bool registeredInCore = allocationManager.isMemberOfOperatorSet(
+                operators[j], OperatorSet({avs: accountIdentifier, id: uint32(quorumNumber)})
+            );
+
+            // If the operator does not have the minimum stake, they need to be force deregistered.
+            // Additionally, it is possible for an operator to have deregistered from an OperatorSet
+            // in the core EigenLayer contract AllocationManager but not have the deregistration
+            // callback succeed here in `deregisterOperator` due to out of gas errors. If that is the case,
+            // we need to deregister the operator from the OperatorSet in this contract
+            if (doesNotMeetStakeThreshold[j] || !registeredInCore) {
+                _deregisterOperator({
+                    operator: operators[j],
+                    quorumNumbers: singleQuorumNumber,
+                    shouldForceDeregister: registeredInCore
+                });
+            }
+        }
     }
 
     /**

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -29,10 +29,11 @@ import {Pausable} from "eigenlayer-contracts/src/contracts/permissions/Pausable.
 import {SlashingRegistryCoordinatorStorage} from "./SlashingRegistryCoordinatorStorage.sol";
 
 /**
- * @title A `RegistryCoordinator` that has three registries:
+ * @title A `RegistryCoordinator` that has four registries:
  *      1) a `StakeRegistry` that keeps track of operators' stakes
  *      2) a `BLSApkRegistry` that keeps track of operators' BLS public keys and aggregate BLS public keys for each quorum
  *      3) an `IndexRegistry` that keeps track of an ordered list of operators for each quorum
+ *      4) a `SocketRegistry` that keeps track of operators' sockets (arbitrary strings)
  *
  * @author Layr Labs, Inc.
  */
@@ -104,10 +105,12 @@ contract SlashingRegistryCoordinator is
         _setPausedStatus(_initialPausedStatus);
         _setEjector(_ejector);
         _setAccountIdentifier(_accountIdentifier);
+
         // Add registry contracts to the registries array
         registries.push(address(stakeRegistry));
         registries.push(address(blsApkRegistry));
         registries.push(address(indexRegistry));
+        registries.push(address(socketRegistry));
     }
 
     /// @inheritdoc ISlashingRegistryCoordinator

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -116,17 +116,7 @@ contract SlashingRegistryCoordinator is
         m2QuorumsDisabled = true;
     }
 
-    /**
-     * @notice Creates a quorum and initializes it in each registry contract
-     * @param operatorSetParams configures the quorum's max operator count and churn parameters
-     * @param minimumStake sets the minimum stake required for an operator to register or remain
-     * registered
-     * @param strategyParams a list of strategies and multipliers used by the StakeRegistry to
-     * calculate an operator's stake weight for the quorum
-     *  @dev For m2 AVS this function has the same behavior as createQuorum before
-     *       For migrated AVS that enable operator sets this will create a quorum that measures total delegated stake for operator set
-     *
-     */
+    /// @inheritdoc ISlashingRegistryCoordinator
     function createTotalDelegatedStakeQuorum(
         OperatorSetParam memory operatorSetParams,
         uint96 minimumStake,
@@ -141,6 +131,7 @@ contract SlashingRegistryCoordinator is
         );
     }
 
+    /// @inheritdoc ISlashingRegistryCoordinator
     function createSlashableStakeQuorum(
         OperatorSetParam memory operatorSetParams,
         uint96 minimumStake,
@@ -157,6 +148,7 @@ contract SlashingRegistryCoordinator is
         );
     }
 
+    /// @inheritdoc ISlashingRegistryCoordinator
     function registerOperator(
         address operator,
         uint32[] memory operatorSetIds,
@@ -238,6 +230,7 @@ contract SlashingRegistryCoordinator is
         }
     }
 
+    /// @inheritdoc ISlashingRegistryCoordinator
     function deregisterOperator(
         address operator,
         uint32[] memory operatorSetIds
@@ -247,12 +240,7 @@ contract SlashingRegistryCoordinator is
         _deregisterOperator(operator, quorumNumbers);
     }
 
-    /**
-     * @notice Updates the StakeRegistry's view of one or more operators' stakes. If any operator
-     * is found to be below the minimum stake for the quorum, they are deregistered.
-     * @dev stakes are queried from the Eigenlayer core DelegationManager contract
-     * @param operators a list of operator addresses to update
-     */
+    /// @inheritdoc ISlashingRegistryCoordinator
     function updateOperators(
         address[] memory operators
     ) external onlyWhenNotPaused(PAUSED_UPDATE_OPERATOR) {
@@ -268,20 +256,7 @@ contract SlashingRegistryCoordinator is
         }
     }
 
-    /**
-     * @notice For each quorum in `quorumNumbers`, updates the StakeRegistry's view of ALL its registered operators' stakes.
-     * Each quorum's `quorumUpdateBlockNumber` is also updated, which tracks the most recent block number when ALL registered
-     * operators were updated.
-     * @dev stakes are queried from the Eigenlayer core DelegationManager contract
-     * @param operatorsPerQuorum for each quorum in `quorumNumbers`, this has a corresponding list of operators to update.
-     * @dev Each list of operator addresses MUST be sorted in ascending order
-     * @dev Each list of operator addresses MUST represent the entire list of registered operators for the corresponding quorum
-     * @param quorumNumbers is an ordered byte array containing the quorum numbers being updated
-     * @dev invariant: Each list of `operatorsPerQuorum` MUST be a sorted version of `IndexRegistry.getOperatorListAtBlockNumber`
-     * for the corresponding quorum.
-     * @dev note on race condition: if an operator registers/deregisters for any quorum in `quorumNumbers` after a txn to
-     * this method is broadcast (but before it is executed), the method will fail
-     */
+    /// @inheritdoc ISlashingRegistryCoordinator
     function updateOperatorsForQuorum(
         address[][] memory operatorsPerQuorum,
         bytes calldata quorumNumbers
@@ -336,10 +311,7 @@ contract SlashingRegistryCoordinator is
         }
     }
 
-    /**
-     * @notice Updates the socket of the msg.sender given they are a registered operator
-     * @param socket is the new socket of the operator
-     */
+    /// @inheritdoc ISlashingRegistryCoordinator
     function updateSocket(
         string memory socket
     ) external {
@@ -353,12 +325,7 @@ contract SlashingRegistryCoordinator is
      *
      */
 
-    /**
-     * @notice Forcibly deregisters an operator from one or more quorums
-     * @param operator the operator to eject
-     * @param quorumNumbers the quorum numbers to eject the operator from
-     * @dev possible race condition if prior to being ejected for a set of quorums the operator self deregisters from a subset
-     */
+    /// @inheritdoc ISlashingRegistryCoordinator
     function ejectOperator(address operator, bytes memory quorumNumbers) external onlyEjector {
         lastEjectionTimestamp[operator] = block.timestamp;
 
@@ -385,13 +352,7 @@ contract SlashingRegistryCoordinator is
      *
      */
 
-    /**
-     * @notice Updates an existing quorum's configuration with a new max operator count
-     * and operator churn parameters
-     * @param quorumNumber the quorum number to update
-     * @param operatorSetParams the new config
-     * @dev only callable by the owner
-     */
+    /// @inheritdoc ISlashingRegistryCoordinator
     function setOperatorSetParams(
         uint8 quorumNumber,
         OperatorSetParam memory operatorSetParams
@@ -411,34 +372,21 @@ contract SlashingRegistryCoordinator is
         _setChurnApprover(_churnApprover);
     }
 
-    /**
-     * @notice Sets the ejector, which can force-deregister operators from quorums
-     * @param _ejector the new ejector
-     * @dev only callable by the owner
-     */
+    /// @inheritdoc ISlashingRegistryCoordinator
     function setEjector(
         address _ejector
     ) external onlyOwner {
         _setEjector(_ejector);
     }
 
-    /**
-     * @notice Sets the account identifier for this AVS (used for UAM integration in EigenLayer)
-     * @param _accountIdentifier the new account identifier
-     * @dev only callable by the owner
-     */
+    /// @inheritdoc ISlashingRegistryCoordinator
     function setAccountIdentifier(
         address _accountIdentifier
     ) external onlyOwner {
         _setAccountIdentifier(_accountIdentifier);
     }
 
-    /**
-     * @notice Sets the ejection cooldown, which is the time an operator must wait in
-     * seconds afer ejection before registering for any quorum
-     * @param _ejectionCooldown the new ejection cooldown in seconds
-     * @dev only callable by the owner
-     */
+    /// @inheritdoc ISlashingRegistryCoordinator
     function setEjectionCooldown(
         uint256 _ejectionCooldown
     ) external onlyOwner {

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -108,12 +108,6 @@ contract SlashingRegistryCoordinator is
         registries.push(address(stakeRegistry));
         registries.push(address(blsApkRegistry));
         registries.push(address(indexRegistry));
-
-        // Set the AVS to be OperatorSets compatible
-        operatorSetsEnabled = true;
-
-        // Set the AVS to not accept M2 quorums
-        m2QuorumsDisabled = true;
     }
 
     /// @inheritdoc ISlashingRegistryCoordinator
@@ -138,7 +132,6 @@ contract SlashingRegistryCoordinator is
         IStakeRegistryTypes.StrategyParams[] memory strategyParams,
         uint32 lookAheadPeriod
     ) external virtual onlyOwner {
-        require(operatorSetsEnabled, OperatorSetsNotEnabled());
         _createQuorum(
             operatorSetParams,
             minimumStake,
@@ -154,7 +147,6 @@ contract SlashingRegistryCoordinator is
         uint32[] memory operatorSetIds,
         bytes calldata data
     ) external override onlyAllocationManager onlyWhenNotPaused(PAUSED_REGISTER_OPERATOR) {
-        require(operatorSetsEnabled, OperatorSetsNotEnabled());
         bytes memory quorumNumbers = _getQuorumNumbers(operatorSetIds);
 
         (
@@ -179,7 +171,8 @@ contract SlashingRegistryCoordinator is
                 operator: operator,
                 operatorId: operatorId,
                 quorumNumbers: quorumNumbers,
-                socket: socket
+                socket: socket,
+                checkMaxOperatorCount: true
             }).numOperatorsPerQuorum;
 
             // For each quorum, validate that the new operator count does not exceed the maximum
@@ -221,13 +214,6 @@ contract SlashingRegistryCoordinator is
         } else {
             revert InvalidRegistrationType();
         }
-
-        // If the operator wasn't registered for any quorums, update their status
-        // and register them with this AVS in EigenLayer core (DelegationManager)
-        if (_operatorInfo[operator].status != OperatorStatus.REGISTERED) {
-            _operatorInfo[operator] = OperatorInfo(operatorId, OperatorStatus.REGISTERED);
-            emit OperatorRegistered(operator, operatorId);
-        }
     }
 
     /// @inheritdoc ISlashingRegistryCoordinator
@@ -235,7 +221,6 @@ contract SlashingRegistryCoordinator is
         address operator,
         uint32[] memory operatorSetIds
     ) external override onlyAllocationManager onlyWhenNotPaused(PAUSED_DEREGISTER_OPERATOR) {
-        require(operatorSetsEnabled, OperatorSetsNotEnabled());
         bytes memory quorumNumbers = _getQuorumNumbers(operatorSetIds);
         _deregisterOperator(operator, quorumNumbers);
     }
@@ -243,16 +228,29 @@ contract SlashingRegistryCoordinator is
     /// @inheritdoc ISlashingRegistryCoordinator
     function updateOperators(
         address[] memory operators
-    ) external onlyWhenNotPaused(PAUSED_UPDATE_OPERATOR) {
+    ) external override onlyWhenNotPaused(PAUSED_UPDATE_OPERATOR) {
         for (uint256 i = 0; i < operators.length; i++) {
-            address operator = operators[i];
-            OperatorInfo memory operatorInfo = _operatorInfo[operator];
-            bytes32 operatorId = operatorInfo.operatorId;
+            // create single-element arrays for the operator and operatorId
+            address[] memory singleOperator = new address[](1);
+            singleOperator[0] = operators[i];
+            bytes32[] memory singleOperatorId = new bytes32[](1);
+            singleOperatorId[0] = _operatorInfo[operators[i]].operatorId;
 
-            // Update the operator's stake for their active quorums
-            uint192 currentBitmap = _currentOperatorBitmap(operatorId);
-            bytes memory quorumsToUpdate = BitmapUtils.bitmapToBytesArray(currentBitmap);
-            _updateOperator(operator, operatorInfo, quorumsToUpdate);
+            uint192 currentBitmap = _currentOperatorBitmap(singleOperatorId[0]);
+            bytes memory quorumNumbers = currentBitmap.bitmapToBytesArray();
+            for (uint256 j = 0; j < quorumNumbers.length; j++) {
+                // update the operator's stake for each quorum
+                uint8 quorumNumber = uint8(quorumNumbers[j]);
+                bool[] memory shouldBeDeregistered = stakeRegistry.updateOperatorsStake(
+                    singleOperator, singleOperatorId, quorumNumber
+                );
+
+                if (shouldBeDeregistered[0]) {
+                    bytes memory singleQuorumNumber = new bytes(1);
+                    singleQuorumNumber[0] = quorumNumbers[j];
+                    _deregisterOperator(operators[i], singleQuorumNumber);
+                }
+            }
         }
     }
 
@@ -279,6 +277,7 @@ contract SlashingRegistryCoordinator is
                 QuorumOperatorCountMismatch()
             );
 
+            bytes32[] memory operatorIds = new bytes32[](currQuorumOperators.length);
             address prevOperatorAddress = address(0);
             // For each operator:
             // - check that they are registered for this quorum
@@ -287,11 +286,9 @@ contract SlashingRegistryCoordinator is
             for (uint256 j = 0; j < currQuorumOperators.length; ++j) {
                 address operator = currQuorumOperators[j];
 
-                OperatorInfo memory operatorInfo = _operatorInfo[operator];
-                bytes32 operatorId = operatorInfo.operatorId;
-
+                operatorIds[j] = _operatorInfo[operator].operatorId;
                 {
-                    uint192 currentBitmap = _currentOperatorBitmap(operatorId);
+                    uint192 currentBitmap = _currentOperatorBitmap(operatorIds[j]);
                     // Check that the operator is registered
                     require(
                         BitmapUtils.isSet(currentBitmap, quorumNumber), NotRegisteredForQuorum()
@@ -300,9 +297,15 @@ contract SlashingRegistryCoordinator is
                     require(operator > prevOperatorAddress, NotSorted());
                 }
 
-                // Update the operator
-                _updateOperator(operator, operatorInfo, quorumNumbers[i:i + 1]);
                 prevOperatorAddress = operator;
+            }
+
+            bool[] memory shouldBeDeregistered =
+                stakeRegistry.updateOperatorsStake(currQuorumOperators, operatorIds, quorumNumber);
+            for (uint256 j = 0; j < currQuorumOperators.length; ++j) {
+                if (shouldBeDeregistered[j]) {
+                    _deregisterOperator(currQuorumOperators[j], quorumNumbers[i:i + 1]);
+                }
             }
 
             // Update timestamp that all operators in quorum have been updated all at once
@@ -339,10 +342,6 @@ contract SlashingRegistryCoordinator is
                 && quorumsToRemove.isSubsetOf(currentBitmap)
         ) {
             _deregisterOperator({operator: operator, quorumNumbers: quorumNumbers});
-
-            if (operatorSetsEnabled) {
-                _forceDeregisterOperator(operator, quorumNumbers);
-            }
         }
     }
 
@@ -407,7 +406,8 @@ contract SlashingRegistryCoordinator is
         address operator,
         bytes32 operatorId,
         bytes memory quorumNumbers,
-        string memory socket
+        string memory socket,
+        bool checkMaxOperatorCount
     ) internal virtual returns (RegisterResults memory results) {
         /**
          * Get bitmap of quorums to register for and operator's current bitmap. Validate that:
@@ -439,13 +439,30 @@ contract SlashingRegistryCoordinator is
          */
         _updateOperatorBitmap({operatorId: operatorId, newBitmap: newBitmap});
 
-        emit OperatorSocketUpdate(operatorId, socket);
+        _setOperatorSocket(operatorId, socket);
+
+        // If the operator wasn't registered for any quorums, update their status
+        // and register them with this AVS in EigenLayer core (DelegationManager)
+        if (_operatorInfo[operator].status != OperatorStatus.REGISTERED) {
+            _operatorInfo[operator] = OperatorInfo(operatorId, OperatorStatus.REGISTERED);
+            emit OperatorRegistered(operator, operatorId);
+        }
 
         // Register the operator with the BLSApkRegistry, StakeRegistry, and IndexRegistry
         blsApkRegistry.registerOperator(operator, quorumNumbers);
         (results.operatorStakes, results.totalStakes) =
             stakeRegistry.registerOperator(operator, operatorId, quorumNumbers);
         results.numOperatorsPerQuorum = indexRegistry.registerOperator(operatorId, quorumNumbers);
+
+        if (checkMaxOperatorCount) {
+            for (uint256 i = 0; i < quorumNumbers.length; i++) {
+                OperatorSetParam memory operatorSetParams = _quorumParams[uint8(quorumNumbers[i])];
+                require(
+                    results.numOperatorsPerQuorum[i] <= operatorSetParams.maxOperatorCount,
+                    MaxQuorumsReached()
+                );
+            }
+        }
 
         // call hook to allow for any post-register logic
         _afterRegisterOperator(operator, operatorId, quorumNumbers, newBitmap);
@@ -473,8 +490,13 @@ contract SlashingRegistryCoordinator is
 
         // Register the operator in each of the registry contracts and update the operator's
         // quorum bitmap and registration status
-        RegisterResults memory results =
-            _registerOperator(operator, operatorId, quorumNumbers, socket);
+        RegisterResults memory results = _registerOperator({
+            operator: operator,
+            operatorId: operatorId,
+            quorumNumbers: quorumNumbers,
+            socket: socket,
+            checkMaxOperatorCount: false
+        });
 
         // Check that each quorum's operator count is below the configured maximum. If the max
         // is exceeded, use `operatorKickParams` to deregister an existing operator to make space
@@ -498,10 +520,6 @@ contract SlashingRegistryCoordinator is
                 bytes memory singleQuorumNumber = new bytes(1);
                 singleQuorumNumber[0] = quorumNumbers[i];
                 _deregisterOperator(operatorKickParams[i].operator, singleQuorumNumber);
-
-                if (operatorSetsEnabled) {
-                    _forceDeregisterOperator(operatorKickParams[i].operator, singleQuorumNumber);
-                }
             }
         }
     }
@@ -550,43 +568,32 @@ contract SlashingRegistryCoordinator is
         stakeRegistry.deregisterOperator(operatorId, quorumNumbers);
         indexRegistry.deregisterOperator(operatorId, quorumNumbers);
 
+        // If the caller is not the allocationManager, then this is a force deregistration not consented by the operator
+        if (msg.sender != address(allocationManager)) {
+            _forceDeregisterOperator(operator, quorumNumbers);
+        }
+
         // call hook to allow for any post-deregister logic
         _afterDeregisterOperator(operator, operatorId, quorumNumbers, newBitmap);
     }
 
     /**
      * @notice Helper function to handle operator set deregistration for OperatorSets quorums. This is used
-     * when an operator is force-deregistered from a set of quorums. For any of the quorums that are
-     * OperatorSets quorums, we need to deregister the operator in the AllocationManager.
+     * when an operator is force-deregistered from a set of quorums.
      * @param operator The operator to deregister
      * @param quorumNumbers The quorum numbers the operator is force-deregistered from
      */
-    function _forceDeregisterOperator(address operator, bytes memory quorumNumbers) internal {
-        uint32[] memory operatorSetIds = new uint32[](quorumNumbers.length);
-        uint256 numOperatorSetQuorums;
-
-        // Check each quorum's stake type
-        for (uint256 i = 0; i < quorumNumbers.length; i++) {
-            uint8 quorumNumber = uint8(quorumNumbers[i]);
-            if (_isM2Quorum(quorumNumber)) {
-                operatorSetIds[numOperatorSetQuorums++] = quorumNumber;
-            }
-        }
-
-        // If any OperatorSet quorums found, deregister from AVS in the AllocationManager
-        if (numOperatorSetQuorums > 0) {
-            // Resize array to exact size needed
-            assembly {
-                mstore(operatorSetIds, numOperatorSetQuorums)
-            }
-            allocationManager.deregisterFromOperatorSets(
-                IAllocationManagerTypes.DeregisterParams({
-                    operator: operator,
-                    avs: accountIdentifier,
-                    operatorSetIds: operatorSetIds
-                })
-            );
-        }
+    function _forceDeregisterOperator(
+        address operator,
+        bytes memory quorumNumbers
+    ) internal virtual {
+        allocationManager.deregisterFromOperatorSets(
+            IAllocationManagerTypes.DeregisterParams({
+                operator: operator,
+                avs: accountIdentifier,
+                operatorSetIds: _getOperatorSetIds(quorumNumbers)
+            })
+        );
     }
 
     /**
@@ -677,32 +684,6 @@ contract SlashingRegistryCoordinator is
     }
 
     /**
-     * @notice Updates the StakeRegistry's view of the operator's stake in one or more quorums.
-     * For any quorums where the StakeRegistry finds the operator is under the configured minimum
-     * stake, `quorumsToRemove` is returned and used to deregister the operator from those quorums
-     * @dev does nothing if operator is not registered for any quorums.
-     */
-    function _updateOperator(
-        address operator,
-        OperatorInfo memory operatorInfo,
-        bytes memory quorumsToUpdate
-    ) internal {
-        if (operatorInfo.status != OperatorStatus.REGISTERED) {
-            return;
-        }
-        bytes32 operatorId = operatorInfo.operatorId;
-        uint192 quorumsToRemove =
-            stakeRegistry.updateOperatorStake(operator, operatorId, quorumsToUpdate);
-
-        if (!quorumsToRemove.isEmpty()) {
-            _deregisterOperator({
-                operator: operator,
-                quorumNumbers: BitmapUtils.bitmapToBytesArray(quorumsToRemove)
-            });
-        }
-    }
-
-    /**
      * @notice Returns the stake threshold required for an incoming operator to replace an existing operator
      * The incoming operator must have more stake than the return value.
      */
@@ -778,36 +759,37 @@ contract SlashingRegistryCoordinator is
         IStakeRegistryTypes.StakeType stakeType,
         uint32 lookAheadPeriod
     ) internal {
-        // Increment the total quorum count. Fails if we're already at the max
-        uint8 prevQuorumCount = quorumCount;
-        require(prevQuorumCount < MAX_QUORUM_COUNT, MaxQuorumsReached());
-        quorumCount = prevQuorumCount + 1;
+        // The previous quorum count is the new quorum's number,
+        // this is because quorum numbers begin from index 0.
+        uint8 quorumNumber = quorumCount;
 
-        // The previous count is the new quorum's number
-        uint8 quorumNumber = prevQuorumCount;
+        // Hook to allow for any pre-create quorum logic
+        _beforeCreateQuorum(quorumNumber);
+
+        // Increment the total quorum count. Fails if we're already at the max
+        require(quorumNumber < MAX_QUORUM_COUNT, MaxQuorumsReached());
+        quorumCount += 1;
 
         // Initialize the quorum here and in each registry
         _setOperatorSetParams(quorumNumber, operatorSetParams);
 
-        /// Update the AllocationManager if operatorSetQuorum
-        if (operatorSetsEnabled && !_isM2Quorum(quorumNumber)) {
-            // Create array of CreateSetParams for the new quorum
-            IAllocationManagerTypes.CreateSetParams[] memory createSetParams =
-                new IAllocationManagerTypes.CreateSetParams[](1);
+        // Create array of CreateSetParams for the new quorum
+        IAllocationManagerTypes.CreateSetParams[] memory createSetParams =
+            new IAllocationManagerTypes.CreateSetParams[](1);
 
-            // Extract strategies from strategyParams
-            IStrategy[] memory strategies = new IStrategy[](strategyParams.length);
-            for (uint256 i = 0; i < strategyParams.length; i++) {
-                strategies[i] = strategyParams[i].strategy;
-            }
-
-            // Initialize CreateSetParams with quorumNumber as operatorSetId
-            createSetParams[0] = IAllocationManagerTypes.CreateSetParams({
-                operatorSetId: quorumNumber,
-                strategies: strategies
-            });
-            allocationManager.createOperatorSets({avs: accountIdentifier, params: createSetParams});
+        // Extract strategies from strategyParams
+        IStrategy[] memory strategies = new IStrategy[](strategyParams.length);
+        for (uint256 i = 0; i < strategyParams.length; i++) {
+            strategies[i] = strategyParams[i].strategy;
         }
+
+        // Initialize CreateSetParams with quorumNumber as operatorSetId
+        createSetParams[0] = IAllocationManagerTypes.CreateSetParams({
+            operatorSetId: quorumNumber,
+            strategies: strategies
+        });
+        allocationManager.createOperatorSets({avs: accountIdentifier, params: createSetParams});
+
         // Initialize stake registry based on stake type
         if (stakeType == IStakeRegistryTypes.StakeType.TOTAL_DELEGATED) {
             stakeRegistry.initializeDelegatedStakeQuorum(quorumNumber, minimumStake, strategyParams);
@@ -819,6 +801,9 @@ contract SlashingRegistryCoordinator is
 
         indexRegistry.initializeQuorum(quorumNumber);
         blsApkRegistry.initializeQuorum(quorumNumber);
+
+        // Hook to allow for any post-create quorum logic
+        _afterCreateQuorum(quorumNumber);
     }
 
     /**
@@ -863,12 +848,14 @@ contract SlashingRegistryCoordinator is
         return quorumNumbers;
     }
 
-    /// @notice Returns true if the quorum number is an M2 quorum
-    /// @dev We use bitwise and to check if the quorum number is an M2 quorum
-    function _isM2Quorum(
-        uint8 quorumNumber
-    ) internal view returns (bool) {
-        return M2quorumBitmap.isSet(quorumNumber);
+    function _getOperatorSetIds(
+        bytes memory quorumNumbers
+    ) internal pure returns (uint32[] memory) {
+        uint32[] memory operatorSetIds = new uint32[](quorumNumbers.length);
+        for (uint256 i = 0; i < quorumNumbers.length; i++) {
+            operatorSetIds[i] = uint32(uint8(quorumNumbers[i]));
+        }
+        return operatorSetIds;
     }
 
     function _setOperatorSetParams(
@@ -898,6 +885,16 @@ contract SlashingRegistryCoordinator is
     ) internal {
         accountIdentifier = _accountIdentifier;
     }
+
+    /// @dev Hook to allow for any pre-create quorum logic
+    function _beforeCreateQuorum(
+        uint8 quorumNumber
+    ) internal virtual {}
+
+    /// @dev Hook to allow for any post-create quorum logic
+    function _afterCreateQuorum(
+        uint8 quorumNumber
+    ) internal virtual {}
 
     /// @dev Hook to allow for any pre-register logic in `_registerOperator`
     function _beforeRegisterOperator(
@@ -970,13 +967,6 @@ contract SlashingRegistryCoordinator is
         address operator
     ) external view returns (ISlashingRegistryCoordinator.OperatorStatus) {
         return _operatorInfo[operator].status;
-    }
-
-    /// @notice Returns true if the quorum number is an M2 quorum
-    function isM2Quorum(
-        uint8 quorumNumber
-    ) external view returns (bool) {
-        return _isM2Quorum(quorumNumber);
     }
 
     /**
@@ -1075,16 +1065,5 @@ contract SlashingRegistryCoordinator is
         return BN254.hashToG1(
             _hashTypedDataV4(keccak256(abi.encode(PUBKEY_REGISTRATION_TYPEHASH, operator)))
         );
-    }
-
-    /// @dev need to override function here since its defined in both these contracts
-    function owner()
-        public
-        view
-        virtual
-        override(OwnableUpgradeable, ISlashingRegistryCoordinator)
-        returns (address)
-    {
-        return OwnableUpgradeable.owner();
     }
 }

--- a/src/SlashingRegistryCoordinatorStorage.sol
+++ b/src/SlashingRegistryCoordinatorStorage.sol
@@ -41,7 +41,7 @@ abstract contract SlashingRegistryCoordinatorStorage is ISlashingRegistryCoordin
     /// @notice The maximum number of quorums this contract supports
     uint8 internal constant MAX_QUORUM_COUNT = 192;
 
-    /// @notice
+    /// @notice the Socket Registry contract that will keep track of operators' sockets (arbitrary strings)
     ISocketRegistry public immutable socketRegistry;
     /// @notice the BLS Aggregate Pubkey Registry contract that will keep track of operators' aggregate BLS public keys per quorum
     IBLSApkRegistry public immutable blsApkRegistry;

--- a/src/SlashingRegistryCoordinatorStorage.sol
+++ b/src/SlashingRegistryCoordinatorStorage.sol
@@ -85,22 +85,10 @@ abstract contract SlashingRegistryCoordinatorStorage is ISlashingRegistryCoordin
     /// @notice the delay in seconds before an operator can reregister after being ejected
     uint256 public ejectionCooldown;
 
-    /// @notice Whether this AVS allows operator sets for registration
-    /// @dev If true, operators may register to operator sets via the AllocationManager
-    bool public operatorSetsEnabled;
-
-    /// @notice Whether this AVS allows M2 quorums for registration
-    /// @dev If true, operators may **not** register to M2 quorums. Deregistration is still allowed.
-    bool public m2QuorumsDisabled;
-
     /// @notice The account identifier for this AVS (used for UAM integration in EigenLayer)
     /// @dev NOTE: Updating this value will break existing OperatorSets and UAM integration.
     /// This value should only be set once.
     address public accountIdentifier;
-
-    /// @notice The bitmap containing all M2 quorums. This is only used for existing AVS middlewares that have M2 quorums
-    /// and need to call `enableOperatorSets()` to enable operator sets mode.
-    uint256 internal M2quorumBitmap;
 
     constructor(
         IStakeRegistry _stakeRegistry,
@@ -118,5 +106,5 @@ abstract contract SlashingRegistryCoordinatorStorage is ISlashingRegistryCoordin
 
     // storage gap for upgradeability
     // slither-disable-next-line shadowing-state
-    uint256[37] private __GAP;
+    uint256[38] private __GAP;
 }

--- a/src/SocketRegistry.sol
+++ b/src/SocketRegistry.sol
@@ -7,22 +7,13 @@ import {SocketRegistryStorage} from "./SocketRegistryStorage.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /**
- * @title A `Registry` that keeps track of operator sockets.
+ * @title A `Registry` that keeps track of operator sockets (arbitrary strings).
  * @author Layr Labs, Inc.
  */
-contract SocketRegistry is ISocketRegistry, SocketRegistryStorage {
-    /// @notice A modifier that only allows the RegistryCoordinator to call a function
+contract SocketRegistry is SocketRegistryStorage {
+    /// @notice A modifier that only allows the SlashingRegistryCoordinator to call a function
     modifier onlySlashingRegistryCoordinator() {
         require(msg.sender == slashingRegistryCoordinator, OnlySlashingRegistryCoordinator());
-        _;
-    }
-
-    /// @notice A modifier that only allows the owner of the SlashingRegistryCoordinator to call a function
-    modifier onlyCoordinatorOwner() {
-        require(
-            msg.sender == Ownable(slashingRegistryCoordinator).owner(),
-            OnlySlashingRegistryCoordinatorOwner()
-        );
         _;
     }
 
@@ -30,7 +21,7 @@ contract SocketRegistry is ISocketRegistry, SocketRegistryStorage {
         ISlashingRegistryCoordinator _slashingRegistryCoordinator
     ) SocketRegistryStorage(address(_slashingRegistryCoordinator)) {}
 
-    /// @notice sets the socket for an operator only callable by the RegistryCoordinator
+    /// @inheritdoc ISocketRegistry
     function setOperatorSocket(
         bytes32 _operatorId,
         string memory _socket
@@ -38,7 +29,7 @@ contract SocketRegistry is ISocketRegistry, SocketRegistryStorage {
         operatorIdToSocket[_operatorId] = _socket;
     }
 
-    /// @notice gets the stored socket for an operator
+    /// @inheritdoc ISocketRegistry
     function getOperatorSocket(
         bytes32 _operatorId
     ) external view returns (string memory) {

--- a/src/SocketRegistry.sol
+++ b/src/SocketRegistry.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.12;
 import {ISlashingRegistryCoordinator} from "./interfaces/ISlashingRegistryCoordinator.sol";
 import {ISocketRegistry} from "./interfaces/ISocketRegistry.sol";
 import {SocketRegistryStorage} from "./SocketRegistryStorage.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /**
  * @title A `Registry` that keeps track of operator sockets.
@@ -12,18 +13,15 @@ import {SocketRegistryStorage} from "./SocketRegistryStorage.sol";
 contract SocketRegistry is ISocketRegistry, SocketRegistryStorage {
     /// @notice A modifier that only allows the RegistryCoordinator to call a function
     modifier onlySlashingRegistryCoordinator() {
-        require(
-            msg.sender == address(slashingRegistryCoordinator),
-            "SocketRegistry.onlySlashingRegistryCoordinator: caller is not the SlashingRegistryCoordinator"
-        );
+        require(msg.sender == slashingRegistryCoordinator, OnlySlashingRegistryCoordinator());
         _;
     }
 
     /// @notice A modifier that only allows the owner of the SlashingRegistryCoordinator to call a function
     modifier onlyCoordinatorOwner() {
         require(
-            msg.sender == ISlashingRegistryCoordinator(slashingRegistryCoordinator).owner(),
-            "SocketRegistry.onlyCoordinatorOwner: caller is not the owner of the slashingRegistryCoordinator"
+            msg.sender == Ownable(slashingRegistryCoordinator).owner(),
+            OnlySlashingRegistryCoordinatorOwner()
         );
         _;
     }

--- a/src/SocketRegistry.sol
+++ b/src/SocketRegistry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.12;
 
-import {IRegistryCoordinator} from "./interfaces/IRegistryCoordinator.sol";
+import {ISlashingRegistryCoordinator} from "./interfaces/ISlashingRegistryCoordinator.sol";
 import {ISocketRegistry} from "./interfaces/ISocketRegistry.sol";
 import {SocketRegistryStorage} from "./SocketRegistryStorage.sol";
 
@@ -11,32 +11,32 @@ import {SocketRegistryStorage} from "./SocketRegistryStorage.sol";
  */
 contract SocketRegistry is ISocketRegistry, SocketRegistryStorage {
     /// @notice A modifier that only allows the RegistryCoordinator to call a function
-    modifier onlyRegistryCoordinator() {
+    modifier onlySlashingRegistryCoordinator() {
         require(
-            msg.sender == address(registryCoordinator),
-            "SocketRegistry.onlyRegistryCoordinator: caller is not the RegistryCoordinator"
+            msg.sender == address(slashingRegistryCoordinator),
+            "SocketRegistry.onlySlashingRegistryCoordinator: caller is not the SlashingRegistryCoordinator"
         );
         _;
     }
 
-    /// @notice A modifier that only allows the owner of the RegistryCoordinator to call a function
+    /// @notice A modifier that only allows the owner of the SlashingRegistryCoordinator to call a function
     modifier onlyCoordinatorOwner() {
         require(
-            msg.sender == IRegistryCoordinator(registryCoordinator).owner(),
-            "SocketRegistry.onlyCoordinatorOwner: caller is not the owner of the registryCoordinator"
+            msg.sender == ISlashingRegistryCoordinator(slashingRegistryCoordinator).owner(),
+            "SocketRegistry.onlyCoordinatorOwner: caller is not the owner of the slashingRegistryCoordinator"
         );
         _;
     }
 
     constructor(
-        IRegistryCoordinator _registryCoordinator
-    ) SocketRegistryStorage(address(_registryCoordinator)) {}
+        ISlashingRegistryCoordinator _slashingRegistryCoordinator
+    ) SocketRegistryStorage(address(_slashingRegistryCoordinator)) {}
 
     /// @notice sets the socket for an operator only callable by the RegistryCoordinator
     function setOperatorSocket(
         bytes32 _operatorId,
         string memory _socket
-    ) external onlyRegistryCoordinator {
+    ) external onlySlashingRegistryCoordinator {
         operatorIdToSocket[_operatorId] = _socket;
     }
 

--- a/src/SocketRegistryStorage.sol
+++ b/src/SocketRegistryStorage.sol
@@ -7,15 +7,15 @@ pragma solidity ^0.8.12;
  */
 contract SocketRegistryStorage {
     /// @notice The address of the RegistryCoordinator
-    address public immutable registryCoordinator;
+    address public immutable slashingRegistryCoordinator;
 
     /// @notice A mapping from operator IDs to their sockets
     mapping(bytes32 => string) public operatorIdToSocket;
 
     constructor(
-        address _registryCoordinator
+        address _slashingRegistryCoordinator
     ) {
-        registryCoordinator = _registryCoordinator;
+        slashingRegistryCoordinator = _slashingRegistryCoordinator;
     }
 
     uint256[48] private __GAP;

--- a/src/SocketRegistryStorage.sol
+++ b/src/SocketRegistryStorage.sol
@@ -1,13 +1,27 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.12;
 
+import {ISocketRegistry} from "./interfaces/ISocketRegistry.sol";
+
 /**
- * @title Storage contract for SocketRegistry
+ * @title Storage variables for the `SocketRegistry` contract.
  * @author Layr Labs, Inc.
  */
-contract SocketRegistryStorage {
-    /// @notice The address of the RegistryCoordinator
+abstract contract SocketRegistryStorage is ISocketRegistry {
+    /**
+     *
+     *                            CONSTANTS AND IMMUTABLES
+     *
+     */
+
+    /// @notice The address of the SlashingRegistryCoordinator
     address public immutable slashingRegistryCoordinator;
+
+    /**
+     *
+     *                                    STATE
+     *
+     */
 
     /// @notice A mapping from operator IDs to their sockets
     mapping(bytes32 => string) public operatorIdToSocket;
@@ -18,5 +32,5 @@ contract SocketRegistryStorage {
         slashingRegistryCoordinator = _slashingRegistryCoordinator;
     }
 
-    uint256[48] private __GAP;
+    uint256[49] private __GAP;
 }

--- a/src/StakeRegistry.sol
+++ b/src/StakeRegistry.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
 import {IDelegationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
 import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
@@ -123,12 +125,12 @@ contract StakeRegistry is StakeRegistryStorage {
     }
 
     /// @inheritdoc IStakeRegistry
-    function updateOperatorStake(
-        address operator,
-        bytes32 operatorId,
-        bytes calldata quorumNumbers
-    ) external onlySlashingRegistryCoordinator returns (uint192) {
-        uint192 quorumsToRemove;
+    function updateOperatorsStake(
+        address[] memory operators,
+        bytes32[] memory operatorIds,
+        uint8 quorumNumber
+    ) external onlySlashingRegistryCoordinator returns (bool[] memory) {
+        bool[] memory shouldBeDeregistered = new bool[](operators.length);
 
         /**
          * For each quorum, update the operator's stake and record the delta
@@ -138,34 +140,37 @@ contract StakeRegistry is StakeRegistryStorage {
          * in the quorum, the quorum number is added to `quorumsToRemove`, which
          * is returned to the registry coordinator.
          */
-        for (uint256 i = 0; i < quorumNumbers.length; i++) {
-            uint8 quorumNumber = uint8(quorumNumbers[i]);
-            _checkQuorumExists(quorumNumber);
+        _checkQuorumExists(quorumNumber);
 
-            // Fetch the operator's current stake, applying weighting parameters and checking
-            // against the minimum stake requirements for the quorum.
-            (uint96 stakeWeight, bool hasMinimumStake) =
-                _weightOfOperatorForQuorum(quorumNumber, operator);
-            // If the operator no longer meets the minimum stake, set their stake to zero and mark them for removal
-            /// also handle setting the operator's stake to 0 and remove them from the quorum
-            if (!hasMinimumStake) {
-                stakeWeight = 0;
-                quorumsToRemove = uint192(quorumsToRemove.setBit(quorumNumber));
+        // Fetch the operators' current stake, applying weighting parameters and checking
+        // against the minimum stake requirements for the quorum.
+        (uint96[] memory stakeWeights, bool[] memory hasMinimumStakes) =
+            _weightOfOperatorsForQuorum(quorumNumber, operators);
+
+        int256 totalStakeDelta = 0;
+        // If the operator no longer meets the minimum stake, set their stake to zero and mark them for removal
+        /// also handle setting the operator's stake to 0 and remove them from the quorum
+        for (uint256 i = 0; i < operators.length; i++) {
+            if (!hasMinimumStakes[i]) {
+                stakeWeights[i] = 0;
+                shouldBeDeregistered[i] = true;
             }
 
             // Update the operator's stake and retrieve the delta
             // If we're deregistering them, their weight is set to 0
             int256 stakeDelta = _recordOperatorStakeUpdate({
-                operatorId: operatorId,
+                operatorId: operatorIds[i],
                 quorumNumber: quorumNumber,
-                newStake: stakeWeight
+                newStake: stakeWeights[i]
             });
 
-            // Apply the delta to the quorum's total stake
-            _recordTotalStakeUpdate(quorumNumber, stakeDelta);
+            totalStakeDelta += stakeDelta;
         }
 
-        return quorumsToRemove;
+        // Apply the delta to the quorum's total stake
+        _recordTotalStakeUpdate(quorumNumber, totalStakeDelta);
+
+        return shouldBeDeregistered;
     }
 
     /// @inheritdoc IStakeRegistry
@@ -235,13 +240,14 @@ contract StakeRegistry is StakeRegistryStorage {
 
         uint256 numStratsToAdd = _strategyParams.length;
 
-        if (isOperatorSetQuorum(quorumNumber)) {
+        address avs = registryCoordinator.accountIdentifier();
+        if (allocationManager.isOperatorSet(OperatorSet(avs, quorumNumber))) {
             IStrategy[] memory strategiesToAdd = new IStrategy[](numStratsToAdd);
             for (uint256 i = 0; i < numStratsToAdd; i++) {
                 strategiesToAdd[i] = _strategyParams[i].strategy;
             }
             allocationManager.addStrategiesToOperatorSet({
-                avs: ISlashingRegistryCoordinator(registryCoordinator).accountIdentifier(),
+                avs: avs,
                 operatorSetId: quorumNumber,
                 strategies: strategiesToAdd
             });
@@ -277,9 +283,10 @@ contract StakeRegistry is StakeRegistryStorage {
             _strategiesPerQuorum.pop();
         }
 
-        if (isOperatorSetQuorum(quorumNumber)) {
+        address avs = registryCoordinator.accountIdentifier();
+        if (allocationManager.isOperatorSet(OperatorSet(avs, quorumNumber))) {
             allocationManager.removeStrategiesFromOperatorSet({
-                avs: ISlashingRegistryCoordinator(registryCoordinator).accountIdentifier(),
+                avs: avs,
                 operatorSetId: quorumNumber,
                 strategies: _strategiesToRemove
             });
@@ -500,73 +507,82 @@ contract StakeRegistry is StakeRegistryStorage {
         );
     }
 
-    /// Returns total Slashable stake for an operator per strategy that can have the weights applied based on strategy multipliers
+    /// Returns total Slashable stake for a list of operators per strategy that can have the weights applied based on strategy multipliers
     function _getSlashableStakePerStrategy(
         uint8 quorumNumber,
-        address operator
-    ) internal view returns (uint256[] memory) {
-        address[] memory operators = new address[](1);
-        operators[0] = operator;
-        uint32 beforeTimestamp =
-            uint32(block.number + slashableStakeLookAheadPerQuorum[quorumNumber]);
+        address[] memory operators
+    ) internal view returns (uint256[][] memory) {
+        uint32 beforeBlock = uint32(block.number + slashableStakeLookAheadPerQuorum[quorumNumber]);
 
         uint256[][] memory slashableShares = allocationManager.getMinimumSlashableStake(
-            OperatorSet(
-                ISlashingRegistryCoordinator(registryCoordinator).accountIdentifier(), quorumNumber
-            ),
+            OperatorSet(registryCoordinator.accountIdentifier(), quorumNumber),
             operators,
             strategiesPerQuorum[quorumNumber],
-            beforeTimestamp
+            beforeBlock
         );
 
-        return slashableShares[0];
+        return slashableShares;
     }
 
     /**
-     * @notice This function computes the total weight of the @param operator in the quorum @param quorumNumber.
+     * @notice This function computes the total weight of the @param operators in the quorum @param quorumNumber.
      * @dev this method DOES NOT check that the quorum exists
-     * @return `uint96` The weighted sum of the operator's shares across each strategy considered by the quorum
-     * @return `bool` True if the operator meets the quorum's minimum stake
+     * @return `uint96[] memory` The weighted sum of the operators' shares across each strategy considered by the quorum
+     * @return `bool[] memory` True if the respective operator meets the quorum's minimum stake
      */
+    function _weightOfOperatorsForQuorum(
+        uint8 quorumNumber,
+        address[] memory operators
+    ) internal view virtual returns (uint96[] memory, bool[] memory) {
+        uint96[] memory weights = new uint96[](operators.length);
+        bool[] memory hasMinimumStakes = new bool[](operators.length);
+
+        uint256 stratsLength = strategyParamsLength(quorumNumber);
+        StrategyParams[] memory stratsAndMultipliers = strategyParams[quorumNumber];
+        uint256[][] memory strategyShares;
+
+        if (stakeTypePerQuorum[quorumNumber] == IStakeRegistryTypes.StakeType.TOTAL_SLASHABLE) {
+            // get slashable stake for the operators from AllocationManager
+            strategyShares = _getSlashableStakePerStrategy(quorumNumber, operators);
+        } else {
+            // get delegated stake for the operators from DelegationManager
+            strategyShares =
+                delegation.getOperatorsShares(operators, strategiesPerQuorum[quorumNumber]);
+        }
+
+        // Calculate weight of each operator and whether they contain minimum stake for the quorum
+        for (uint256 opIndex = 0; opIndex < operators.length; opIndex++) {
+            // 1. For the given operator, loop through the strategies and calculate the operator's
+            // weight for the quorum
+            for (uint256 stratIndex = 0; stratIndex < stratsLength; stratIndex++) {
+                // get multiplier for strategy
+                StrategyParams memory strategyAndMultiplier = stratsAndMultipliers[stratIndex];
+
+                // calculate added weight for strategy and multiplier
+                if (strategyShares[opIndex][stratIndex] > 0) {
+                    weights[opIndex] += uint96(
+                        strategyShares[opIndex][stratIndex] * strategyAndMultiplier.multiplier
+                            / WEIGHTING_DIVISOR
+                    );
+                }
+            }
+
+            // 2. Check whether operator is above minimum stake threshold
+            hasMinimumStakes[opIndex] = weights[opIndex] >= minimumStakeForQuorum[quorumNumber];
+        }
+
+        return (weights, hasMinimumStakes);
+    }
+
     function _weightOfOperatorForQuorum(
         uint8 quorumNumber,
         address operator
     ) internal view virtual returns (uint96, bool) {
-        uint96 weight;
-        uint256 stratsLength = strategyParamsLength(quorumNumber);
-        StrategyParams memory strategyAndMultiplier;
-        uint256[] memory strategyShares;
-
-        if (stakeTypePerQuorum[quorumNumber] == IStakeRegistryTypes.StakeType.TOTAL_SLASHABLE) {
-            strategyShares = _getSlashableStakePerStrategy(quorumNumber, operator);
-            for (uint256 i = 0; i < stratsLength; i++) {
-                strategyAndMultiplier = strategyParams[quorumNumber][i];
-                if (strategyShares[i] > 0) {
-                    weight += uint96(
-                        strategyShares[i] * strategyAndMultiplier.multiplier / WEIGHTING_DIVISOR
-                    );
-                }
-            }
-        } else {
-            /// M2 Concept of delegated stake
-            strategyShares =
-                delegation.getOperatorShares(operator, strategiesPerQuorum[quorumNumber]);
-            for (uint256 i = 0; i < stratsLength; i++) {
-                // accessing i^th StrategyParams struct for the quorumNumber
-                strategyAndMultiplier = strategyParams[quorumNumber][i];
-
-                // add the weight from the shares for this strategy to the total weight
-                if (strategyShares[i] > 0) {
-                    weight += uint96(
-                        strategyShares[i] * strategyAndMultiplier.multiplier / WEIGHTING_DIVISOR
-                    );
-                }
-            }
-        }
-
-        // Return the weight, and `true` if the operator meets the quorum's minimum stake
-        bool hasMinimumStake = weight >= minimumStakeForQuorum[quorumNumber];
-        return (weight, hasMinimumStake);
+        address[] memory operators = new address[](1);
+        operators[0] = operator;
+        (uint96[] memory weights, bool[] memory hasMinimumStakes) =
+            _weightOfOperatorsForQuorum(quorumNumber, operators);
+        return (weights[0], hasMinimumStakes[0]);
     }
 
     /// @notice Returns `true` if the quorum has been initialized
@@ -581,15 +597,6 @@ contract StakeRegistry is StakeRegistryStorage {
      *                         VIEW FUNCTIONS
      *
      */
-
-    /// @inheritdoc IStakeRegistry
-    function isOperatorSetQuorum(
-        uint8 quorumNumber
-    ) public view returns (bool) {
-        bool isM2 = ISlashingRegistryCoordinator(registryCoordinator).isM2Quorum(quorumNumber);
-        bool isOperatorSet = ISlashingRegistryCoordinator(registryCoordinator).operatorSetsEnabled();
-        return isOperatorSet && !isM2;
-    }
 
     /// @inheritdoc IStakeRegistry
     function weightOfOperatorForQuorum(
@@ -785,18 +792,22 @@ contract StakeRegistry is StakeRegistryStorage {
      * @param _lookAheadBlocks The number of blocks to look ahead when checking shares
      */
     function _setLookAheadPeriod(uint8 quorumNumber, uint32 _lookAheadBlocks) internal {
+        require(
+            stakeTypePerQuorum[quorumNumber] == IStakeRegistryTypes.StakeType.TOTAL_SLASHABLE,
+            QuorumNotSlashable()
+        );
         uint32 oldLookAheadDays = slashableStakeLookAheadPerQuorum[quorumNumber];
         slashableStakeLookAheadPerQuorum[quorumNumber] = _lookAheadBlocks;
         emit LookAheadPeriodChanged(oldLookAheadDays, _lookAheadBlocks);
     }
 
     function _checkSlashingRegistryCoordinator() internal view {
-        require(msg.sender == registryCoordinator, OnlySlashingRegistryCoordinator());
+        require(msg.sender == address(registryCoordinator), OnlySlashingRegistryCoordinator());
     }
 
     function _checkSlashingRegistryCoordinatorOwner() internal view {
         require(
-            msg.sender == ISlashingRegistryCoordinator(registryCoordinator).owner(),
+            msg.sender == Ownable(address(registryCoordinator)).owner(),
             OnlySlashingRegistryCoordinatorOwner()
         );
     }

--- a/src/StakeRegistryStorage.sol
+++ b/src/StakeRegistryStorage.sol
@@ -37,7 +37,7 @@ abstract contract StakeRegistryStorage is IStakeRegistry {
     IAllocationManager public immutable allocationManager;
 
     /// @notice the coordinator contract that this registry is associated with
-    address public immutable registryCoordinator;
+    ISlashingRegistryCoordinator public immutable registryCoordinator;
 
     /// @notice In order to register for a quorum i, an operator must have at least `minimumStakeForQuorum[i]`
     /// evaluated by this contract's 'VoteWeigher' logic.
@@ -70,7 +70,7 @@ abstract contract StakeRegistryStorage is IStakeRegistry {
         IAVSDirectory _avsDirectory,
         IAllocationManager _allocationManager
     ) {
-        registryCoordinator = address(_slashingRegistryCoordinator);
+        registryCoordinator = _slashingRegistryCoordinator;
         delegation = _delegationManager;
         avsDirectory = _avsDirectory;
         allocationManager = _allocationManager;

--- a/src/interfaces/IBLSApkRegistry.sol
+++ b/src/interfaces/IBLSApkRegistry.sol
@@ -24,6 +24,8 @@ interface IBLSApkRegistryErrors {
     error BlockNumberTooRecent();
     /// @notice Thrown when blocknumber and index provided is not the latest apk update.
     error BlockNumberNotLatest();
+    /// @notice Thrown when the block number is before the first update.
+    error BlockNumberBeforeFirstUpdate();
 }
 
 interface IBLSApkRegistryTypes {

--- a/src/interfaces/IEjectionManager.sol
+++ b/src/interfaces/IEjectionManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import {IRegistryCoordinator} from "./IRegistryCoordinator.sol";
+import {ISlashingRegistryCoordinator} from "./ISlashingRegistryCoordinator.sol";
 import {IStakeRegistry} from "./IStakeRegistry.sol";
 
 interface IEjectionManagerErrors {
@@ -66,11 +66,11 @@ interface IEjectionManager is IEjectionManagerErrors, IEjectionManagerEvents {
     /* STATE */
 
     /*
-     * @notice Returns the address of the registry coordinator contract.
-     * @return The address of the registry coordinator.
+     * @notice Returns the address of the slashing registry coordinator contract.
+     * @return The address of the slashing registry coordinator.
      * @dev This value is immutable and set during contract construction.
      */
-    function registryCoordinator() external view returns (IRegistryCoordinator);
+    function slashingRegistryCoordinator() external view returns (ISlashingRegistryCoordinator);
 
     /*
      * @notice Returns the address of the stake registry contract.

--- a/src/interfaces/IInstantSlasher.sol
+++ b/src/interfaces/IInstantSlasher.sol
@@ -9,12 +9,6 @@ import {ISlasher} from "./ISlasher.sol";
 /// @notice A slashing contract that immediately executes slashing requests without any delay or veto period
 /// @dev Extends base interfaces to provide access controlled slashing functionality
 interface IInstantSlasher is ISlasher {
-    /// @notice Initializes the contract with a slasher address
-    /// @param _slasher Address authorized to create and fulfill slashing requests
-    function initialize(
-        address _slasher
-    ) external;
-
     /// @notice Immediately executes a slashing request
     /// @param _slashingParams Parameters defining the slashing request including operator and amount
     /// @dev Can only be called by the authorized slasher

--- a/src/interfaces/IInstantSlasher.sol
+++ b/src/interfaces/IInstantSlasher.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {IAllocationManager} from
+    "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {ISlasher} from "./ISlasher.sol";
+
+/// @title IInstantSlasher
+/// @notice A slashing contract that immediately executes slashing requests without any delay or veto period
+/// @dev Extends base interfaces to provide access controlled slashing functionality
+interface IInstantSlasher is ISlasher {
+    /// @notice Initializes the contract with a slasher address
+    /// @param _slasher Address authorized to create and fulfill slashing requests
+    function initialize(
+        address _slasher
+    ) external;
+
+    /// @notice Immediately executes a slashing request
+    /// @param _slashingParams Parameters defining the slashing request including operator and amount
+    /// @dev Can only be called by the authorized slasher
+    function fulfillSlashingRequest(
+        IAllocationManager.SlashingParams memory _slashingParams
+    ) external;
+}

--- a/src/interfaces/IRegistryCoordinator.sol
+++ b/src/interfaces/IRegistryCoordinator.sol
@@ -17,7 +17,11 @@ interface IRegistryCoordinatorErrors is ISlashingRegistryCoordinatorErrors {
     /// @notice Thrown when a quorum is an operator set quorum.
     error OperatorSetQuorum();
     /// @notice Thrown when M2 quorums are already disabled.
-    error M2QuorumsAlreadyDisabled();
+    error M2QuorumRegistrationIsDisabled();
+    /// @notice Thrown when operator set operations are attempted while not enabled.
+    error OperatorSetsNotEnabled();
+    /// @notice Thrown when only M2 quorums are allowed.
+    error OnlyM2QuorumsAllowed();
 }
 
 interface IRegistryCoordinatorTypes is ISlashingRegistryCoordinatorTypes {}
@@ -33,10 +37,10 @@ interface IRegistryCoordinatorEvents is
     event OperatorSetsEnabled();
 
     /**
-     * @notice Emitted when M2 quorums are disabled.
+     * @notice Emitted when M2 quorum registration is disabled.
      * @dev Emitted in disableM2QuorumRegistration().
      */
-    event M2QuorumsDisabled();
+    event M2QuorumRegistrationDisabled();
 }
 
 interface IRegistryCoordinator is
@@ -107,11 +111,13 @@ interface IRegistryCoordinator is
     ) external;
 
     /**
-     * @notice Enables operator sets mode for the AVS. Once enabled, this cannot be disabled.
-     * @dev When enabled, all existing quorums are marked as M2 quorums and future quorums must be explicitly
-     * created as either M2 or operator set quorums.
+     * @notice Checks if a quorum is an M2 quorum.
+     * @param quorumNumber The quorum identifier.
+     * @return True if the quorum is M2, false otherwise.
      */
-    function enableOperatorSets() external;
+    function isM2Quorum(
+        uint8 quorumNumber
+    ) external view returns (bool);
 
     /**
      * @notice Disables M2 quorum registration for the AVS. Once disabled, this cannot be enabled.

--- a/src/interfaces/IServiceManager.sol
+++ b/src/interfaces/IServiceManager.sol
@@ -19,8 +19,6 @@ interface IServiceManagerErrors {
     error OnlyRewardsInitiator();
     /// @notice Thrown when a function is called by an address that is not the StakeRegistry.
     error OnlyStakeRegistry();
-    /// @notice Thrown when a function is called by an address that is not the Slasher.
-    error OnlySlasher();
     /// @notice Thrown when a slashing proposal delay has not been met yet.
     error DelayPeriodNotPassed();
 }

--- a/src/interfaces/ISlasher.sol
+++ b/src/interfaces/ISlasher.sol
@@ -1,85 +1,24 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
 import {IAllocationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 
 interface ISlasherErrors {
-    /// @notice Thrown when a caller without veto committee privileges attempts a restricted operation.
-    error OnlyVetoCommittee();
-    /// @notice Thrown when a caller without slasher privileges attempts a restricted operation.
+    /// @notice Thrown when a caller without slasher privileges attempts a restricted operation
     error OnlySlasher();
-    /// @notice Thrown when attempting to veto a slashing request after the veto period has expired.
-    error VetoPeriodPassed();
-    /// @notice Thrown when attempting to execute a slashing request before the veto period has ended.
-    error VetoPeriodNotPassed();
-    /// @notice Thrown when attempting to interact with a slashing request that has been cancelled.
-    error SlashingRequestIsCancelled();
-    /// @notice Thrown when attempting to modify a slashing request that does not exist.
-    error SlashingRequestNotRequested();
 }
 
 interface ISlasherTypes {
-    /**
-     * @notice Represents the current status of a slashing request.
-     * @dev The status of a slashing request can be one of the following:
-     *      - Null: Default state, no request exists.
-     *      - Requested: Slashing has been requested but not yet executed.
-     *      - Completed: Slashing has been successfully executed.
-     *      - Cancelled: Slashing request was cancelled by veto committee.
-     */
-    enum SlashingStatus {
-        Null,
-        Requested,
-        Completed,
-        Cancelled
-    }
-
-    /**
-     * @notice Contains all information related to a slashing request.
-     * @param params The slashing parameters from the allocation manager.
-     * @param requestTimestamp The timestamp when the slashing request was created.
-     * @param status The current status of the slashing request.
-     */
+    /// @notice Structure containing details about a slashing request
     struct SlashingRequest {
         IAllocationManager.SlashingParams params;
         uint256 requestTimestamp;
-        SlashingStatus status;
     }
 }
 
 interface ISlasherEvents is ISlasherTypes {
-    /**
-     * @notice Emitted when a new slashing request is created.
-     * @param requestId The unique identifier for the slashing request (indexed).
-     * @param operator The address of the operator to be slashed (indexed).
-     * @param operatorSetId The ID of the operator set involved (indexed).
-     * @param wadsToSlash The amounts to slash from each strategy.
-     * @param description A human-readable description of the slashing reason.
-     */
-    event SlashingRequested(
-        uint256 indexed requestId,
-        address indexed operator,
-        uint32 indexed operatorSetId,
-        uint256[] wadsToSlash,
-        string description
-    );
-
-    /**
-     * @notice Emitted when a slashing request is cancelled by the veto committee.
-     * @param requestId The unique identifier of the cancelled request (indexed).
-     */
-    event SlashingRequestCancelled(uint256 indexed requestId);
-
-    /**
-     * @notice Emitted when an operator is successfully slashed.
-     * @param slashingRequestId The ID of the executed slashing request (indexed).
-     * @param operator The address of the slashed operator (indexed).
-     * @param operatorSetId The ID of the operator set involved (indexed).
-     * @param wadsToSlash The amounts slashed from each strategy.
-     * @param description A human-readable description of why the operator was slashed.
-     */
+    /// @notice Emitted when an operator is successfully slashed
     event OperatorSlashed(
         uint256 indexed slashingRequestId,
         address indexed operator,
@@ -89,4 +28,9 @@ interface ISlasherEvents is ISlasherTypes {
     );
 }
 
-interface ISlasher is ISlasherErrors, ISlasherEvents {}
+/// @title ISlasher
+/// @notice Base interface containing shared functionality for all slasher implementations
+interface ISlasher is ISlasherErrors, ISlasherEvents {
+    /// @notice Returns the address authorized to create and fulfill slashing requests
+    function slasher() external view returns (address);
+}

--- a/src/interfaces/ISlasher.sol
+++ b/src/interfaces/ISlasher.sol
@@ -33,4 +33,7 @@ interface ISlasherEvents is ISlasherTypes {
 interface ISlasher is ISlasherErrors, ISlasherEvents {
     /// @notice Returns the address authorized to create and fulfill slashing requests
     function slasher() external view returns (address);
+
+    /// @notice Returns the next slashing request ID
+    function nextRequestId() external view returns (uint256);
 }

--- a/src/interfaces/ISlashingRegistryCoordinator.sol
+++ b/src/interfaces/ISlashingRegistryCoordinator.sol
@@ -10,6 +10,7 @@ import {IAllocationManager} from
 import {IBLSApkRegistry} from "./IBLSApkRegistry.sol";
 import {IStakeRegistry, IStakeRegistryTypes} from "./IStakeRegistry.sol";
 import {IIndexRegistry} from "./IIndexRegistry.sol";
+import {ISocketRegistry} from "./ISocketRegistry.sol";
 import {BN254} from "../libraries/BN254.sol";
 import {IAVSRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IAVSRegistrar.sol";
 
@@ -231,6 +232,12 @@ interface ISlashingRegistryCoordinator is
      * @dev This is only relevant for Slashing AVSs
      */
     function allocationManager() external view returns (IAllocationManager);
+
+    /**
+     * @notice Reference to the SocketRegistry contract.
+     * @return The SocketRegistry contract interface.
+     */
+    function socketRegistry() external view returns (ISocketRegistry);
 
     /// STORAGE
 

--- a/src/interfaces/ISlashingRegistryCoordinator.sol
+++ b/src/interfaces/ISlashingRegistryCoordinator.sol
@@ -50,8 +50,6 @@ interface ISlashingRegistryCoordinatorErrors {
     error NotSorted();
     /// @notice Thrown when maximum quorum count is reached.
     error MaxQuorumsReached();
-    /// @notice Thrown when operator set operations are attempted while not enabled.
-    error OperatorSetsNotEnabled();
 }
 
 interface ISlashingRegistryCoordinatorTypes {
@@ -296,21 +294,6 @@ interface ISlashingRegistryCoordinator is
      */
     function ejectionCooldown() external view returns (uint256);
 
-    /**
-     * @notice Checks if a quorum is an M2 quorum.
-     * @param quorumNumber The quorum identifier.
-     * @return True if the quorum is M2, false otherwise.
-     */
-    function isM2Quorum(
-        uint8 quorumNumber
-    ) external view returns (bool);
-
-    /**
-     * @notice Whether operator sets mode is enabled.
-     * @return True if operator sets mode is enabled, false otherwise.
-     */
-    function operatorSetsEnabled() external view returns (bool);
-
     /// ACTIONS
 
     /**
@@ -343,6 +326,7 @@ interface ISlashingRegistryCoordinator is
      * the minimum stake for their registered quorums, they are deregistered from those quorums.
      * @param operators The operators whose stakes should be updated.
      * @dev Stakes are queried from the Eigenlayer core DelegationManager contract.
+     * @dev WILL BE DEPRECATED IN FAVOR OF updateOperatorsForQuorum
      */
     function updateOperators(
         address[] memory operators
@@ -602,13 +586,6 @@ interface ISlashingRegistryCoordinator is
     function pubkeyRegistrationMessageHash(
         address operator
     ) external view returns (BN254.G1Point memory);
-
-    /**
-     * @notice Returns the address of the contract owner.
-     * @return The owner's address.
-     * @dev The owner can update contract configuration and create new quorums.
-     */
-    function owner() external view returns (address);
 
     /**
      * @notice Returns the account identifier for this AVS (used for UAM integration in EigenLayer)

--- a/src/interfaces/ISlashingRegistryCoordinator.sol
+++ b/src/interfaces/ISlashingRegistryCoordinator.sol
@@ -453,6 +453,14 @@ interface ISlashingRegistryCoordinator is
     /// VIEW
 
     /**
+     * @notice Returns the hash of the message that operators must sign with their BLS key to register
+     * @param operator The operator's Ethereum address
+     */
+    function calculatePubkeyRegistrationMessageHash(
+        address operator
+    ) external view returns (bytes32);
+
+    /**
      * @notice Returns the operator set parameters for a given quorum.
      * @param quorumNumber The identifier of the quorum to query.
      * @return The OperatorSetParam struct containing max operator count and churn thresholds.

--- a/src/interfaces/ISlashingRegistryCoordinator.sol
+++ b/src/interfaces/ISlashingRegistryCoordinator.sol
@@ -352,12 +352,15 @@ interface ISlashingRegistryCoordinator is
      * @notice For each quorum in `quorumNumbers`, updates the StakeRegistry's view of ALL its registered operators' stakes.
      * Each quorum's `quorumUpdateBlockNumber` is also updated, which tracks the most recent block number when ALL registered
      * operators were updated.
+     * @dev stakes are queried from the Eigenlayer core DelegationManager contract
      * @param operatorsPerQuorum for each quorum in `quorumNumbers`, this has a corresponding list of operators to update.
-     * @param quorumNumbers is an ordered byte array containing the quorum numbers being updated.
-     * @dev Each list of operator addresses MUST be sorted in ascending order.
-     * @dev Each list of operator addresses MUST represent the entire list of registered operators for the corresponding quorum.
-     * @dev Stakes are queried from the Eigenlayer core DelegationManager contract.
-     * @dev Will revert if an operator registers/deregisters for any quorum in `quorumNumbers` after transaction broadcast but before execution.
+     * @dev Each list of operator addresses MUST be sorted in ascending order
+     * @dev Each list of operator addresses MUST represent the entire list of registered operators for the corresponding quorum
+     * @param quorumNumbers is an ordered byte array containing the quorum numbers being updated
+     * @dev invariant: Each list of `operatorsPerQuorum` MUST be a sorted version of `IndexRegistry.getOperatorListAtBlockNumber`
+     * for the corresponding quorum.
+     * @dev note on race condition: if an operator registers/deregisters for any quorum in `quorumNumbers` after a txn to
+     * this method is broadcast (but before it is executed), the method will fail
      */
     function updateOperatorsForQuorum(
         address[][] memory operatorsPerQuorum,
@@ -451,6 +454,16 @@ interface ISlashingRegistryCoordinator is
      */
     function setEjectionCooldown(
         uint256 _ejectionCooldown
+    ) external;
+
+    /**
+     * @notice Updates the account identifier for this AVS (used for UAM integration in EigenLayer)
+     * @param _accountIdentifier The new account identifier address
+     * @dev Can only be called by the contract owner
+     * @dev NOTE: Updating this value will break existing OperatorSets and UAM integration. This value should only be set once.
+     */
+    function setAccountIdentifier(
+        address _accountIdentifier
     ) external;
 
     /// VIEW

--- a/src/interfaces/ISocketRegistry.sol
+++ b/src/interfaces/ISocketRegistry.sol
@@ -1,18 +1,25 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
 interface ISocketRegistryErrors {
-    /// @notice Thrown when the caller is not the owner of the SlashingRegistryCoordinator
-    error OnlySlashingRegistryCoordinatorOwner();
     /// @notice Thrown when the caller is not the SlashingRegistryCoordinator
     error OnlySlashingRegistryCoordinator();
 }
 
 interface ISocketRegistry is ISocketRegistryErrors {
-    /// @notice sets the socket for an operator only callable by the RegistryCoordinator
+    /**
+     * @notice Sets the socket for an operator.
+     * @param _operatorId The id of the operator to set the socket for.
+     * @param _socket The socket (any arbitrary string as deemed useful by an AVS) to set.
+     * @dev Only callable by the SlashingRegistryCoordinator.
+     */
     function setOperatorSocket(bytes32 _operatorId, string memory _socket) external;
 
-    /// @notice gets the stored socket for an operator
+    /**
+     * @notice Gets the stored socket for an operator.
+     * @param _operatorId The id of the operator to query.
+     * @return The stored socket associated with the operator.
+     */
     function getOperatorSocket(
         bytes32 _operatorId
     ) external view returns (string memory);

--- a/src/interfaces/ISocketRegistry.sol
+++ b/src/interfaces/ISocketRegistry.sol
@@ -1,7 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-interface ISocketRegistry {
+interface ISocketRegistryErrors {
+    /// @notice Thrown when the caller is not the owner of the SlashingRegistryCoordinator
+    error OnlySlashingRegistryCoordinatorOwner();
+    /// @notice Thrown when the caller is not the SlashingRegistryCoordinator
+    error OnlySlashingRegistryCoordinator();
+}
+
+interface ISocketRegistry is ISocketRegistryErrors {
     /// @notice sets the socket for an operator only callable by the RegistryCoordinator
     function setOperatorSocket(bytes32 _operatorId, string memory _socket) external;
 

--- a/src/interfaces/IStakeRegistry.sol
+++ b/src/interfaces/IStakeRegistry.sol
@@ -29,6 +29,8 @@ interface IStakeRegistryErrors {
     error InvalidBlockNumber();
     /// @notice Thrown when attempting to access stake history that doesn't exist for a quorum.
     error EmptyStakeHistory();
+    /// @notice Thrown when the quorum is not slashable and the caller attempts to set the look ahead period.
+    error QuorumNotSlashable();
 }
 
 interface IStakeRegistryTypes {
@@ -164,17 +166,17 @@ interface IStakeRegistry is IStakeRegistryErrors, IStakeRegistryEvents {
     function deregisterOperator(bytes32 operatorId, bytes memory quorumNumbers) external;
 
     /**
-     * @notice Called by the registry coordinator to update an operator's stake for one or more quorums.
-     * @param operator The address of the operator to update.
-     * @param operatorId The id of the operator to update.
-     * @param quorumNumbers The quorum numbers to update the stake for.
-     * @return A bitmap of quorums where the operator no longer meets the minimum stake and should be deregistered.
+     * @notice Called by the registry coordinator to update the stake of a list of operators for a specific quorum.
+     * @param operators The addresses of the operators to update.
+     * @param operatorIds The ids of the operators to update.
+     * @param quorumNumber The quorum number to update the stake for.
+     * @return A list of bools, true if the corresponding operator should be deregistered since they no longer meet the minimum stake requirement.
      */
-    function updateOperatorStake(
-        address operator,
-        bytes32 operatorId,
-        bytes calldata quorumNumbers
-    ) external returns (uint192);
+    function updateOperatorsStake(
+        address[] memory operators,
+        bytes32[] memory operatorIds,
+        uint8 quorumNumber
+    ) external returns (bool[] memory);
 
     /**
      * @notice Initialize a new quorum created by the registry coordinator by setting strategies, weights, and minimum stake.
@@ -248,15 +250,6 @@ interface IStakeRegistry is IStakeRegistryErrors, IStakeRegistryEvents {
     ) external;
 
     /// VIEW
-
-    /**
-     * @notice Returns whether a quorum is an operator set quorum.
-     * @param quorumNumber The quorum number to query.
-     * @return Whether the quorum is an operator set quorum.
-     */
-    function isOperatorSetQuorum(
-        uint8 quorumNumber
-    ) external view returns (bool);
 
     /**
      * @notice Returns the minimum stake requirement for a quorum `quorumNumber`.

--- a/src/interfaces/IVetoableSlasher.sol
+++ b/src/interfaces/IVetoableSlasher.sol
@@ -29,7 +29,7 @@ interface IVetoableSlasherTypes {
     /// @notice Structure containing details about a vetoable slashing request
     struct VetoableSlashingRequest {
         IAllocationManager.SlashingParams params;
-        uint256 requestTimestamp;
+        uint256 requestBlock;
         SlashingStatus status;
     }
 }
@@ -58,16 +58,10 @@ interface IVetoableSlasher is
     IVetoableSlasherEvents
 {
     /// @notice Duration of the veto period during which the veto committee can cancel slashing requests
-    /// @dev Set to 3 days (259,200 seconds)
-    function VETO_PERIOD() external view returns (uint256);
+    function vetoWindowBlocks() external view returns (uint32);
 
     /// @notice Address of the committee that has veto power over slashing requests
     function vetoCommittee() external view returns (address);
-
-    /// @notice Initializes the contract with a veto committee and slasher address
-    /// @param _vetoCommittee Address of the committee that can veto slashing requests
-    /// @param _slasher Address authorized to create and fulfill slashing requests
-    function initialize(address _vetoCommittee, address _slasher) external;
 
     /// @notice Queues a new slashing request
     /// @param params Parameters defining the slashing request including operator and amount

--- a/src/interfaces/IVetoableSlasher.sol
+++ b/src/interfaces/IVetoableSlasher.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {IAllocationManager} from
+    "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {ISlasher} from "./ISlasher.sol";
+
+interface IVetoableSlasherErrors {
+    /// @notice Thrown when a caller without veto committee privileges attempts a restricted operation
+    error OnlyVetoCommittee();
+    /// @notice Thrown when attempting to veto a slashing request after the veto period has expired
+    error VetoPeriodPassed();
+    /// @notice Thrown when attempting to execute a slashing request before the veto period has ended
+    error VetoPeriodNotPassed();
+    /// @notice Thrown when attempting to interact with a slashing request that has been cancelled
+    error SlashingRequestIsCancelled();
+    /// @notice Thrown when attempting to modify a slashing request that does not exist
+    error SlashingRequestNotRequested();
+}
+
+interface IVetoableSlasherTypes {
+    /// @notice Represents the status of a slashing request
+    enum SlashingStatus {
+        Requested,
+        Cancelled,
+        Completed
+    }
+
+    /// @notice Structure containing details about a vetoable slashing request
+    struct VetoableSlashingRequest {
+        IAllocationManager.SlashingParams params;
+        uint256 requestTimestamp;
+        SlashingStatus status;
+    }
+}
+
+interface IVetoableSlasherEvents {
+    /// @notice Emitted when a new slashing request is created
+    event SlashingRequested(
+        uint256 indexed requestId,
+        address indexed operator,
+        uint32 operatorSetId,
+        uint256[] wadsToSlash,
+        string description
+    );
+
+    /// @notice Emitted when a slashing request is cancelled by the veto committee
+    event SlashingRequestCancelled(uint256 indexed requestId);
+}
+
+/// @title IVetoableSlasher
+/// @notice A slashing contract that implements a veto mechanism allowing a designated committee to cancel slashing requests
+/// @dev Extends base interfaces and adds a veto period during which slashing requests can be cancelled
+interface IVetoableSlasher is
+    ISlasher,
+    IVetoableSlasherErrors,
+    IVetoableSlasherTypes,
+    IVetoableSlasherEvents
+{
+    /// @notice Duration of the veto period during which the veto committee can cancel slashing requests
+    /// @dev Set to 3 days (259,200 seconds)
+    function VETO_PERIOD() external view returns (uint256);
+
+    /// @notice Address of the committee that has veto power over slashing requests
+    function vetoCommittee() external view returns (address);
+
+    /// @notice Initializes the contract with a veto committee and slasher address
+    /// @param _vetoCommittee Address of the committee that can veto slashing requests
+    /// @param _slasher Address authorized to create and fulfill slashing requests
+    function initialize(address _vetoCommittee, address _slasher) external;
+
+    /// @notice Queues a new slashing request
+    /// @param params Parameters defining the slashing request including operator and amount
+    /// @dev Can only be called by the authorized slasher
+    function queueSlashingRequest(
+        IAllocationManager.SlashingParams calldata params
+    ) external;
+
+    /// @notice Cancels a pending slashing request
+    /// @param requestId The ID of the slashing request to cancel
+    /// @dev Can only be called by the veto committee during the veto period
+    function cancelSlashingRequest(
+        uint256 requestId
+    ) external;
+
+    /// @notice Executes a slashing request after the veto period has passed
+    /// @param requestId The ID of the slashing request to fulfill
+    /// @dev Can only be called by the authorized slasher after the veto period
+    function fulfillSlashingRequest(
+        uint256 requestId
+    ) external;
+}

--- a/src/slashers/InstantSlasher.sol
+++ b/src/slashers/InstantSlasher.sol
@@ -16,14 +16,7 @@ contract InstantSlasher is IInstantSlasher, SlasherBase {
         IAllocationManager _allocationManager,
         ISlashingRegistryCoordinator _slashingRegistryCoordinator,
         address _slasher
-    ) SlasherBase(_allocationManager, _slashingRegistryCoordinator) {}
-
-    /// @inheritdoc IInstantSlasher
-    function initialize(
-        address _slasher
-    ) external override initializer {
-        __SlasherBase_init(_slasher);
-    }
+    ) SlasherBase(_allocationManager, _slashingRegistryCoordinator, _slasher) {}
 
     /// @inheritdoc IInstantSlasher
     function fulfillSlashingRequest(

--- a/src/slashers/InstantSlasher.sol
+++ b/src/slashers/InstantSlasher.sol
@@ -4,25 +4,31 @@ pragma solidity ^0.8.27;
 import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
 import {IAllocationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
-import {ISlashingRegistryCoordinator} from "../interfaces/ISlashingRegistryCoordinator.sol";
 import {SlasherBase} from "./base/SlasherBase.sol";
+import {ISlashingRegistryCoordinator} from "../interfaces/ISlashingRegistryCoordinator.sol";
+import {IInstantSlasher} from "../interfaces/IInstantSlasher.sol";
 
-contract InstantSlasher is SlasherBase {
+/// @title InstantSlasher
+/// @notice A slashing contract that immediately executes slashing requests without any delay or veto period
+/// @dev Extends SlasherBase to provide access controlled slashing functionality
+contract InstantSlasher is IInstantSlasher, SlasherBase {
     constructor(
         IAllocationManager _allocationManager,
         ISlashingRegistryCoordinator _slashingRegistryCoordinator,
         address _slasher
     ) SlasherBase(_allocationManager, _slashingRegistryCoordinator) {}
 
+    /// @inheritdoc IInstantSlasher
     function initialize(
         address _slasher
-    ) external initializer {
+    ) external override initializer {
         __SlasherBase_init(_slasher);
     }
 
+    /// @inheritdoc IInstantSlasher
     function fulfillSlashingRequest(
-        IAllocationManager.SlashingParams memory _slashingParams
-    ) external virtual onlySlasher {
+        IAllocationManager.SlashingParams calldata _slashingParams
+    ) external virtual override(IInstantSlasher) onlySlasher {
         uint256 requestId = nextRequestId++;
         _fulfillSlashingRequest(requestId, _slashingParams);
     }

--- a/src/slashers/VetoableSlasher.sol
+++ b/src/slashers/VetoableSlasher.sol
@@ -13,10 +13,10 @@ import {IVetoableSlasher, IVetoableSlasherTypes} from "../interfaces/IVetoableSl
 /// @dev Extends SlasherBase and adds a veto period during which slashing requests can be cancelled
 contract VetoableSlasher is IVetoableSlasher, SlasherBase {
     /// @inheritdoc IVetoableSlasher
-    uint256 public constant override VETO_PERIOD = 3 days;
+    uint32 public immutable override vetoWindowBlocks;
 
     /// @inheritdoc IVetoableSlasher
-    address public override vetoCommittee;
+    address public immutable override vetoCommittee;
 
     /// @notice Mapping of request IDs to their corresponding slashing request details
     mapping(uint256 => IVetoableSlasherTypes.VetoableSlashingRequest) public slashingRequests;
@@ -29,15 +29,12 @@ contract VetoableSlasher is IVetoableSlasher, SlasherBase {
 
     constructor(
         IAllocationManager _allocationManager,
-        ISlashingRegistryCoordinator _slashingRegistryCoordinator
-    ) SlasherBase(_allocationManager, _slashingRegistryCoordinator) {}
-
-    /// @inheritdoc IVetoableSlasher
-    function initialize(
+        ISlashingRegistryCoordinator _slashingRegistryCoordinator,
+        address _slasher,
         address _vetoCommittee,
-        address _slasher
-    ) external virtual override initializer {
-        __SlasherBase_init(_slasher);
+        uint32 _vetoWindowBlocks
+    ) SlasherBase(_allocationManager, _slashingRegistryCoordinator, _slasher) {
+        vetoWindowBlocks = _vetoWindowBlocks;
         vetoCommittee = _vetoCommittee;
     }
 
@@ -52,15 +49,6 @@ contract VetoableSlasher is IVetoableSlasher, SlasherBase {
     function cancelSlashingRequest(
         uint256 requestId
     ) external virtual override onlyVetoCommittee {
-        require(
-            block.timestamp < slashingRequests[requestId].requestTimestamp + VETO_PERIOD,
-            VetoPeriodPassed()
-        );
-        require(
-            slashingRequests[requestId].status == IVetoableSlasherTypes.SlashingStatus.Requested,
-            SlashingRequestNotRequested()
-        );
-
         _cancelSlashingRequest(requestId);
     }
 
@@ -68,27 +56,18 @@ contract VetoableSlasher is IVetoableSlasher, SlasherBase {
     function fulfillSlashingRequest(
         uint256 requestId
     ) external virtual override onlySlasher {
-        IVetoableSlasherTypes.VetoableSlashingRequest storage request = slashingRequests[requestId];
-        require(block.timestamp >= request.requestTimestamp + VETO_PERIOD, VetoPeriodNotPassed());
-        require(
-            request.status == IVetoableSlasherTypes.SlashingStatus.Requested,
-            SlashingRequestIsCancelled()
-        );
-
-        request.status = IVetoableSlasherTypes.SlashingStatus.Completed;
-
-        _fulfillSlashingRequest(requestId, request.params);
+        _fulfillSlashingRequestAndMarkAsCompleted(requestId);
     }
 
     /// @notice Internal function to create and store a new slashing request
     /// @param params Parameters defining the slashing request
     function _queueSlashingRequest(
-        IAllocationManager.SlashingParams calldata params
+        IAllocationManager.SlashingParams memory params
     ) internal virtual {
         uint256 requestId = nextRequestId++;
         slashingRequests[requestId] = IVetoableSlasherTypes.VetoableSlashingRequest({
             params: params,
-            requestTimestamp: block.timestamp,
+            requestBlock: block.number,
             status: IVetoableSlasherTypes.SlashingStatus.Requested
         });
 
@@ -102,8 +81,34 @@ contract VetoableSlasher is IVetoableSlasher, SlasherBase {
     function _cancelSlashingRequest(
         uint256 requestId
     ) internal virtual {
+        require(
+            block.number < slashingRequests[requestId].requestBlock + vetoWindowBlocks,
+            VetoPeriodPassed()
+        );
+        require(
+            slashingRequests[requestId].status == IVetoableSlasherTypes.SlashingStatus.Requested,
+            SlashingRequestNotRequested()
+        );
+
         slashingRequests[requestId].status = IVetoableSlasherTypes.SlashingStatus.Cancelled;
         emit SlashingRequestCancelled(requestId);
+    }
+
+    /// @notice Internal function to fullfill a slashing request and mark it as completed
+    /// @param requestId The ID of the slashing request to fulfill
+    function _fulfillSlashingRequestAndMarkAsCompleted(
+        uint256 requestId
+    ) internal virtual {
+        IVetoableSlasherTypes.VetoableSlashingRequest storage request = slashingRequests[requestId];
+        require(block.number >= request.requestBlock + vetoWindowBlocks, VetoPeriodNotPassed());
+        require(
+            request.status == IVetoableSlasherTypes.SlashingStatus.Requested,
+            SlashingRequestIsCancelled()
+        );
+
+        request.status = IVetoableSlasherTypes.SlashingStatus.Completed;
+
+        _fulfillSlashingRequest(requestId, request.params);
     }
 
     /// @notice Internal function to verify if an account is the veto committee

--- a/src/slashers/VetoableSlasher.sol
+++ b/src/slashers/VetoableSlasher.sol
@@ -20,8 +20,7 @@ contract VetoableSlasher is SlasherBase {
 
     constructor(
         IAllocationManager _allocationManager,
-        ISlashingRegistryCoordinator _slashingRegistryCoordinator,
-        address _slasher
+        ISlashingRegistryCoordinator _slashingRegistryCoordinator
     ) SlasherBase(_allocationManager, _slashingRegistryCoordinator) {}
 
     function initialize(address _vetoCommittee, address _slasher) external virtual initializer {
@@ -30,7 +29,7 @@ contract VetoableSlasher is SlasherBase {
     }
 
     function queueSlashingRequest(
-        IAllocationManager.SlashingParams memory params
+        IAllocationManager.SlashingParams calldata params
     ) external virtual onlySlasher {
         _queueSlashingRequest(params);
     }
@@ -63,7 +62,7 @@ contract VetoableSlasher is SlasherBase {
     }
 
     function _queueSlashingRequest(
-        IAllocationManager.SlashingParams memory params
+        IAllocationManager.SlashingParams calldata params
     ) internal virtual {
         uint256 requestId = nextRequestId++;
         slashingRequests[requestId] = SlashingRequest({

--- a/src/slashers/VetoableSlasher.sol
+++ b/src/slashers/VetoableSlasher.sol
@@ -6,13 +6,22 @@ import {IAllocationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 import {SlasherBase} from "./base/SlasherBase.sol";
 import {ISlashingRegistryCoordinator} from "../interfaces/ISlashingRegistryCoordinator.sol";
+import {IVetoableSlasher, IVetoableSlasherTypes} from "../interfaces/IVetoableSlasher.sol";
 
-contract VetoableSlasher is SlasherBase {
-    uint256 public constant VETO_PERIOD = 3 days;
-    address public vetoCommittee;
+/// @title VetoableSlasher
+/// @notice A slashing contract that implements a veto mechanism allowing a designated committee to cancel slashing requests
+/// @dev Extends SlasherBase and adds a veto period during which slashing requests can be cancelled
+contract VetoableSlasher is IVetoableSlasher, SlasherBase {
+    /// @inheritdoc IVetoableSlasher
+    uint256 public constant override VETO_PERIOD = 3 days;
 
-    mapping(uint256 => SlashingRequest) public slashingRequests;
+    /// @inheritdoc IVetoableSlasher
+    address public override vetoCommittee;
 
+    /// @notice Mapping of request IDs to their corresponding slashing request details
+    mapping(uint256 => IVetoableSlasherTypes.VetoableSlashingRequest) public slashingRequests;
+
+    /// @notice Modifier to restrict function access to only the veto committee
     modifier onlyVetoCommittee() {
         _checkVetoCommittee(msg.sender);
         _;
@@ -23,52 +32,64 @@ contract VetoableSlasher is SlasherBase {
         ISlashingRegistryCoordinator _slashingRegistryCoordinator
     ) SlasherBase(_allocationManager, _slashingRegistryCoordinator) {}
 
-    function initialize(address _vetoCommittee, address _slasher) external virtual initializer {
+    /// @inheritdoc IVetoableSlasher
+    function initialize(
+        address _vetoCommittee,
+        address _slasher
+    ) external virtual override initializer {
         __SlasherBase_init(_slasher);
         vetoCommittee = _vetoCommittee;
     }
 
+    /// @inheritdoc IVetoableSlasher
     function queueSlashingRequest(
         IAllocationManager.SlashingParams calldata params
-    ) external virtual onlySlasher {
+    ) external virtual override onlySlasher {
         _queueSlashingRequest(params);
     }
 
+    /// @inheritdoc IVetoableSlasher
     function cancelSlashingRequest(
         uint256 requestId
-    ) external virtual onlyVetoCommittee {
+    ) external virtual override onlyVetoCommittee {
         require(
             block.timestamp < slashingRequests[requestId].requestTimestamp + VETO_PERIOD,
             VetoPeriodPassed()
         );
         require(
-            slashingRequests[requestId].status == SlashingStatus.Requested,
+            slashingRequests[requestId].status == IVetoableSlasherTypes.SlashingStatus.Requested,
             SlashingRequestNotRequested()
         );
 
         _cancelSlashingRequest(requestId);
     }
 
+    /// @inheritdoc IVetoableSlasher
     function fulfillSlashingRequest(
         uint256 requestId
-    ) external virtual onlySlasher {
-        SlashingRequest storage request = slashingRequests[requestId];
+    ) external virtual override onlySlasher {
+        IVetoableSlasherTypes.VetoableSlashingRequest storage request = slashingRequests[requestId];
         require(block.timestamp >= request.requestTimestamp + VETO_PERIOD, VetoPeriodNotPassed());
-        require(request.status == SlashingStatus.Requested, SlashingRequestIsCancelled());
+        require(
+            request.status == IVetoableSlasherTypes.SlashingStatus.Requested,
+            SlashingRequestIsCancelled()
+        );
 
-        request.status = SlashingStatus.Completed;
+        request.status = IVetoableSlasherTypes.SlashingStatus.Completed;
 
         _fulfillSlashingRequest(requestId, request.params);
     }
 
+    /// @notice Internal function to create and store a new slashing request
+    /// @param params Parameters defining the slashing request
     function _queueSlashingRequest(
         IAllocationManager.SlashingParams calldata params
     ) internal virtual {
         uint256 requestId = nextRequestId++;
-        slashingRequests[requestId] = SlashingRequest({
+        slashingRequests[requestId] = IVetoableSlasherTypes.VetoableSlashingRequest({
             params: params,
             requestTimestamp: block.timestamp,
-            status: SlashingStatus.Requested
+            status: IVetoableSlasherTypes.SlashingStatus.Requested
         });
 
         emit SlashingRequested(
@@ -76,13 +97,18 @@ contract VetoableSlasher is SlasherBase {
         );
     }
 
+    /// @notice Internal function to mark a slashing request as cancelled
+    /// @param requestId The ID of the slashing request to cancel
     function _cancelSlashingRequest(
         uint256 requestId
     ) internal virtual {
-        slashingRequests[requestId].status = SlashingStatus.Cancelled;
+        slashingRequests[requestId].status = IVetoableSlasherTypes.SlashingStatus.Cancelled;
         emit SlashingRequestCancelled(requestId);
     }
 
+    /// @notice Internal function to verify if an account is the veto committee
+    /// @param account The address to check
+    /// @dev Reverts if the account is not the veto committee
     function _checkVetoCommittee(
         address account
     ) internal view virtual {

--- a/src/slashers/base/SlasherBase.sol
+++ b/src/slashers/base/SlasherBase.sol
@@ -9,12 +9,19 @@ import {
 } from "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
 
+/// @title SlasherBase
+/// @notice Base contract for implementing slashing functionality in EigenLayer middleware
+/// @dev Provides core slashing functionality and interfaces with EigenLayer's AllocationManager
 abstract contract SlasherBase is Initializable, SlasherStorage {
+    /// @notice Ensures only the authorized slasher can call certain functions
     modifier onlySlasher() {
         _checkSlasher(msg.sender);
         _;
     }
 
+    /// @notice Constructs the base slasher contract
+    /// @param _allocationManager The EigenLayer allocation manager contract
+    /// @param _registryCoordinator The registry coordinator for this middleware
     constructor(
         IAllocationManager _allocationManager,
         ISlashingRegistryCoordinator _registryCoordinator
@@ -22,12 +29,18 @@ abstract contract SlasherBase is Initializable, SlasherStorage {
         _disableInitializers();
     }
 
+    /// @notice Initializes the slasher contract with authorized slasher address
+    /// @param _slasher Address authorized to create and fulfill slashing requests
     function __SlasherBase_init(
         address _slasher
     ) internal onlyInitializing {
         slasher = _slasher;
     }
 
+    /// @notice Internal function to execute a slashing request
+    /// @param _requestId The ID of the slashing request to fulfill
+    /// @param _params Parameters defining the slashing request including operator, strategies, and amounts
+    /// @dev Calls AllocationManager.slashOperator to perform the actual slashing
     function _fulfillSlashingRequest(
         uint256 _requestId,
         IAllocationManager.SlashingParams memory _params
@@ -45,6 +58,9 @@ abstract contract SlasherBase is Initializable, SlasherStorage {
         );
     }
 
+    /// @notice Internal function to verify if an account is the authorized slasher
+    /// @param account The address to check
+    /// @dev Reverts if the account is not the authorized slasher
     function _checkSlasher(
         address account
     ) internal view virtual {

--- a/src/slashers/base/SlasherBase.sol
+++ b/src/slashers/base/SlasherBase.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {Initializable} from "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";
 import {SlasherStorage, ISlashingRegistryCoordinator} from "./SlasherStorage.sol";
 import {
     IAllocationManagerTypes,
@@ -12,7 +11,7 @@ import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy
 /// @title SlasherBase
 /// @notice Base contract for implementing slashing functionality in EigenLayer middleware
 /// @dev Provides core slashing functionality and interfaces with EigenLayer's AllocationManager
-abstract contract SlasherBase is Initializable, SlasherStorage {
+abstract contract SlasherBase is SlasherStorage {
     /// @notice Ensures only the authorized slasher can call certain functions
     modifier onlySlasher() {
         _checkSlasher(msg.sender);
@@ -22,20 +21,12 @@ abstract contract SlasherBase is Initializable, SlasherStorage {
     /// @notice Constructs the base slasher contract
     /// @param _allocationManager The EigenLayer allocation manager contract
     /// @param _registryCoordinator The registry coordinator for this middleware
+    /// @param _slasher The address of the slasher
     constructor(
         IAllocationManager _allocationManager,
-        ISlashingRegistryCoordinator _registryCoordinator
-    ) SlasherStorage(_allocationManager, _registryCoordinator) {
-        _disableInitializers();
-    }
-
-    /// @notice Initializes the slasher contract with authorized slasher address
-    /// @param _slasher Address authorized to create and fulfill slashing requests
-    function __SlasherBase_init(
+        ISlashingRegistryCoordinator _registryCoordinator,
         address _slasher
-    ) internal onlyInitializing {
-        slasher = _slasher;
-    }
+    ) SlasherStorage(_allocationManager, _registryCoordinator, _slasher) {}
 
     /// @notice Internal function to execute a slashing request
     /// @param _requestId The ID of the slashing request to fulfill

--- a/src/slashers/base/SlasherStorage.sol
+++ b/src/slashers/base/SlasherStorage.sol
@@ -3,10 +3,13 @@ pragma solidity ^0.8.27;
 
 import {IAllocationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
-import {ISlasher} from "../../interfaces/ISlasher.sol";
 import {ISlashingRegistryCoordinator} from "../../interfaces/ISlashingRegistryCoordinator.sol";
+import {ISlasher} from "../../interfaces/ISlasher.sol";
 
-contract SlasherStorage is ISlasher {
+/// @title SlasherStorage
+/// @notice Base storage contract for slashing functionality
+/// @dev Provides storage variables and events for slashing operations
+abstract contract SlasherStorage is ISlasher {
     /**
      *
      *                            CONSTANTS AND IMMUTABLES
@@ -17,11 +20,7 @@ contract SlasherStorage is ISlasher {
     IAllocationManager public immutable allocationManager;
     /// @notice the SlashingRegistryCoordinator for this AVS
     ISlashingRegistryCoordinator public immutable slashingRegistryCoordinator;
-    /**
-     *
-     *                                    STATE
-     *
-     */
+
     address public slasher;
 
     uint256 public nextRequestId;

--- a/src/slashers/base/SlasherStorage.sol
+++ b/src/slashers/base/SlasherStorage.sol
@@ -20,18 +20,20 @@ abstract contract SlasherStorage is ISlasher {
     IAllocationManager public immutable allocationManager;
     /// @notice the SlashingRegistryCoordinator for this AVS
     ISlashingRegistryCoordinator public immutable slashingRegistryCoordinator;
-
-    address public slasher;
+    /// @notice the address of the slasher
+    address public immutable slasher;
 
     uint256 public nextRequestId;
 
     constructor(
         IAllocationManager _allocationManager,
-        ISlashingRegistryCoordinator _slashingRegistryCoordinator
+        ISlashingRegistryCoordinator _slashingRegistryCoordinator,
+        address _slasher
     ) {
         allocationManager = _allocationManager;
         slashingRegistryCoordinator = _slashingRegistryCoordinator;
+        slasher = _slasher;
     }
 
-    uint256[48] private __gap;
+    uint256[49] private __gap;
 }

--- a/test/events/IStakeRegistryEvents.sol
+++ b/test/events/IStakeRegistryEvents.sol
@@ -18,4 +18,6 @@ interface IStakeRegistryEvents {
     event StrategyMultiplierUpdated(
         uint8 indexed quorumNumber, IStrategy strategy, uint256 multiplier
     );
+    /// @notice Emitted when the look ahead period for checking operator shares is updated.
+    event LookAheadPeriodChanged(uint32 oldLookAheadBlocks, uint32 newLookAheadBlocks);
 }

--- a/test/ffi/UpdateOperators.t.sol
+++ b/test/ffi/UpdateOperators.t.sol
@@ -1077,7 +1077,8 @@ contract Integration_AVS_Sync_GasCosts_FFI is IntegrationChecks {
                 numQuorums: ONE,
                 numStrategies: TWENTYFIVE,
                 minimumStake: NO_MINIMUM,
-                fillTypes: FULL
+                fillTypes: FULL,
+                quorumType: DELEGATED_STAKE
             })
         });
         _updateOperators_SingleQuorum();
@@ -1093,7 +1094,8 @@ contract Integration_AVS_Sync_GasCosts_FFI is IntegrationChecks {
                 numQuorums: ONE,
                 numStrategies: TWENTY,
                 minimumStake: NO_MINIMUM,
-                fillTypes: FULL
+                fillTypes: FULL,
+                quorumType: DELEGATED_STAKE
             })
         });
 
@@ -1109,7 +1111,8 @@ contract Integration_AVS_Sync_GasCosts_FFI is IntegrationChecks {
                 numQuorums: ONE,
                 numStrategies: FIFTEEN,
                 minimumStake: NO_MINIMUM,
-                fillTypes: FULL
+                fillTypes: FULL,
+                quorumType: DELEGATED_STAKE
             })
         });
         _updateOperators_SingleQuorum();

--- a/test/harnesses/RegistryCoordinatorHarness.t.sol
+++ b/test/harnesses/RegistryCoordinatorHarness.t.sol
@@ -60,7 +60,7 @@ contract RegistryCoordinatorHarness is RegistryCoordinator, Test {
 
     // @notice exposes the internal `_deregisterOperator` function, overriding all access controls
     function _deregisterOperatorExternal(address operator, bytes calldata quorumNumbers) external {
-        _deregisterOperator(operator, quorumNumbers);
+        _deregisterOperator(operator, quorumNumbers, false);
     }
 
     // @notice exposes the internal `_updateOperatorBitmap` function, overriding all access controls

--- a/test/harnesses/RegistryCoordinatorHarness.t.sol
+++ b/test/harnesses/RegistryCoordinatorHarness.t.sol
@@ -49,21 +49,18 @@ contract RegistryCoordinatorHarness is RegistryCoordinator, Test {
         string memory socket,
         SignatureWithSaltAndExpiry memory operatorSignature
     ) external returns (RegisterResults memory results) {
-        return _registerOperator(operator, operatorId, quorumNumbers, socket);
+        return _registerOperator({
+            operator: operator,
+            operatorId: operatorId,
+            quorumNumbers: quorumNumbers,
+            socket: socket,
+            checkMaxOperatorCount: true
+        });
     }
 
     // @notice exposes the internal `_deregisterOperator` function, overriding all access controls
     function _deregisterOperatorExternal(address operator, bytes calldata quorumNumbers) external {
         _deregisterOperator(operator, quorumNumbers);
-    }
-
-    // @notice exposes the internal `_updateOperator` function, overriding all access controls
-    function _updateOperatorExternal(
-        address operator,
-        OperatorInfo memory operatorInfo,
-        bytes memory quorumsToUpdate
-    ) external {
-        _updateOperator(operator, operatorInfo, quorumsToUpdate);
     }
 
     // @notice exposes the internal `_updateOperatorBitmap` function, overriding all access controls
@@ -77,9 +74,15 @@ contract RegistryCoordinatorHarness is RegistryCoordinator, Test {
         operatorSetsEnabled = enabled;
     }
 
-    function setM2QuorumsDisabled(
+    function setM2QuorumRegistrationDisabled(
         bool disabled
     ) external {
-        m2QuorumsDisabled = disabled;
+        isM2QuorumRegistrationDisabled = disabled;
+    }
+
+    function setM2QuorumBitmap(
+        uint256 bitmap
+    ) external {
+        _m2QuorumBitmap = bitmap;
     }
 }

--- a/test/integration/CoreRegistration.t.sol
+++ b/test/integration/CoreRegistration.t.sol
@@ -188,14 +188,20 @@ contract Test_CoreRegistration is MockAVSDeployer {
         emit log_named_bytes("quorumNumbers", quorumNumbers);
         _registerOperator(quorumNumbers);
 
+        IAVSDirectoryTypes.OperatorAVSRegistrationStatus operatorStatus =
+            avsDirectory.avsOperatorStatus(address(serviceManager), operator);
+        assertEq(
+            uint8(operatorStatus),
+            uint8(IAVSDirectoryTypes.OperatorAVSRegistrationStatus.REGISTERED)
+        );
+
         // Deregister Operator with single quorum
         quorumNumbers = new bytes(1);
         cheats.prank(operator);
         registryCoordinator.deregisterOperator(quorumNumbers);
 
         // Check operator is still registered
-        IAVSDirectoryTypes.OperatorAVSRegistrationStatus operatorStatus =
-            avsDirectory.avsOperatorStatus(address(serviceManager), operator);
+        operatorStatus = avsDirectory.avsOperatorStatus(address(serviceManager), operator);
         assertEq(
             uint8(operatorStatus),
             uint8(IAVSDirectoryTypes.OperatorAVSRegistrationStatus.REGISTERED)

--- a/test/integration/IntegrationBase.t.sol
+++ b/test/integration/IntegrationBase.t.sol
@@ -22,7 +22,7 @@ abstract contract IntegrationBase is IntegrationConfig {
 
     function assert_HasOperatorInfoWithId(User user, string memory err) internal {
         bytes32 expectedId = user.operatorId();
-        bytes32 actualId = registryCoordinator.getOperatorId(address(user));
+        bytes32 actualId = slashingRegistryCoordinator.getOperatorId(address(user));
 
         assertEq(expectedId, actualId, err);
     }
@@ -39,20 +39,20 @@ abstract contract IntegrationBase is IntegrationConfig {
 
     function assert_HasRegisteredStatus(User user, string memory err) internal {
         ISlashingRegistryCoordinatorTypes.OperatorStatus status =
-            registryCoordinator.getOperatorStatus(address(user));
+            slashingRegistryCoordinator.getOperatorStatus(address(user));
 
         assertTrue(status == ISlashingRegistryCoordinatorTypes.OperatorStatus.REGISTERED, err);
     }
 
     function assert_HasDeregisteredStatus(User user, string memory err) internal {
         ISlashingRegistryCoordinatorTypes.OperatorStatus status =
-            registryCoordinator.getOperatorStatus(address(user));
+            slashingRegistryCoordinator.getOperatorStatus(address(user));
 
         assertTrue(status == ISlashingRegistryCoordinatorTypes.OperatorStatus.DEREGISTERED, err);
     }
 
     function assert_EmptyQuorumBitmap(User user, string memory err) internal {
-        uint192 bitmap = registryCoordinator.getCurrentQuorumBitmap(user.operatorId());
+        uint192 bitmap = slashingRegistryCoordinator.getCurrentQuorumBitmap(user.operatorId());
 
         assertTrue(bitmap == 0, err);
     }
@@ -62,7 +62,7 @@ abstract contract IntegrationBase is IntegrationConfig {
         bytes memory quorums,
         string memory err
     ) internal {
-        uint192 bitmap = registryCoordinator.getCurrentQuorumBitmap(user.operatorId());
+        uint192 bitmap = slashingRegistryCoordinator.getCurrentQuorumBitmap(user.operatorId());
 
         for (uint256 i = 0; i < quorums.length; i++) {
             uint8 quorum = uint8(quorums[i]);
@@ -77,15 +77,30 @@ abstract contract IntegrationBase is IntegrationConfig {
         bytes memory quorums,
         string memory err
     ) internal {
-        uint192 currentBitmap = registryCoordinator.getCurrentQuorumBitmap(user.operatorId());
+        uint192 currentBitmap =
+            slashingRegistryCoordinator.getCurrentQuorumBitmap(user.operatorId());
         uint192 subsetBitmap = uint192(quorums.orderedBytesArrayToBitmap());
 
         assertTrue(subsetBitmap.isSubsetOf(currentBitmap), err);
     }
 
+    /// @dev Checks that the user is registered for each of the operator sets in the AllocationManager
+    function assert_RegisteredForOperatorSets(
+        User user,
+        bytes memory operatorSetIds,
+        string memory err
+    ) internal {
+        for (uint256 i = 0; i < operatorSetIds.length; i++) {
+            uint32 operatorSetId = uint32(uint8(operatorSetIds[i]));
+            OperatorSet memory operatorSet =
+                OperatorSet({avs: avsAccountIdentifier, id: operatorSetId});
+            assertTrue(allocationManager.isMemberOfOperatorSet(address(user), operatorSet), err);
+        }
+    }
+
     /// @dev Checks whether each of the quorums has been initialized in the RegistryCoordinator
     function assert_QuorumsExist(bytes memory quorums, string memory err) internal {
-        uint8 count = registryCoordinator.quorumCount();
+        uint8 count = slashingRegistryCoordinator.quorumCount();
         for (uint256 i = 0; i < quorums.length; i++) {
             uint8 quorum = uint8(quorums[i]);
 
@@ -176,7 +191,7 @@ abstract contract IntegrationBase is IntegrationConfig {
             uint8 quorum = uint8(quorums[i]);
 
             uint32 maxOperatorCount =
-                registryCoordinator.getOperatorSetParams(quorum).maxOperatorCount;
+                slashingRegistryCoordinator.getOperatorSetParams(quorum).maxOperatorCount;
             uint32 curOperatorCount = indexRegistry.totalOperatorsForQuorum(quorum);
 
             assertTrue(curOperatorCount < maxOperatorCount, err);
@@ -242,6 +257,20 @@ abstract contract IntegrationBase is IntegrationConfig {
         // were set in the previous bitmap, and are NOT set in the current bitmap
         assertTrue(quorumsRemoved.isSubsetOf(prevBitmap), err);
         assertTrue(quorumsRemoved.noBitsInCommon(curBitmap), err);
+    }
+
+    /// @dev Checks that user has deregistered from all operator sets in the AllocationManager
+    function assert_Snap_Deregistered_FromOperatorSets(
+        User user,
+        bytes memory quorums,
+        string memory err
+    ) internal {
+        for (uint256 i = 0; i < quorums.length; i++) {
+            uint32 operatorSetId = uint32(uint8(quorums[i]));
+            OperatorSet memory operatorSet =
+                OperatorSet({avs: avsAccountIdentifier, id: operatorSetId});
+            assertFalse(allocationManager.isMemberOfOperatorSet(address(user), operatorSet), err);
+        }
     }
 
     function assert_Snap_Unchanged_OperatorInfo(User user, string memory err) internal {
@@ -869,7 +898,7 @@ abstract contract IntegrationBase is IntegrationConfig {
     function _getOperatorInfo(
         User user
     ) internal view returns (ISlashingRegistryCoordinatorTypes.OperatorInfo memory) {
-        return registryCoordinator.getOperator(address(user));
+        return slashingRegistryCoordinator.getOperator(address(user));
     }
 
     function _getPrevOperatorInfo(
@@ -881,7 +910,7 @@ abstract contract IntegrationBase is IntegrationConfig {
     function _getQuorumBitmap(
         bytes32 operatorId
     ) internal view returns (uint192) {
-        return registryCoordinator.getCurrentQuorumBitmap(operatorId);
+        return slashingRegistryCoordinator.getCurrentQuorumBitmap(operatorId);
     }
 
     function _getPrevQuorumBitmap(

--- a/test/integration/IntegrationChecks.t.sol
+++ b/test/integration/IntegrationChecks.t.sol
@@ -39,6 +39,11 @@ contract IntegrationChecks is IntegrationBase {
     function check_Register_State(User operator, bytes memory quorums) internal {
         _log("check_Register_State", operator);
 
+        // AllocationManager
+        assert_RegisteredForOperatorSets(
+            operator, quorums, "operator did not register for all operator sets"
+        );
+
         // RegistryCoordinator
         assert_HasOperatorInfoWithId(operator, "operatorInfo should have operatorId");
         assert_HasRegisteredStatus(operator, "operatorInfo status should be REGISTERED");
@@ -74,7 +79,7 @@ contract IntegrationChecks is IntegrationBase {
         );
 
         // AVSDirectory
-        assert_IsRegisteredToAVS(operator, "operator should be registered to AVS");
+        // assert_IsRegisteredToAVS(operator, "operator should be registered to AVS");
     }
 
     /// @dev Combines many checks of check_Register_State and check_Deregister_State
@@ -153,7 +158,7 @@ contract IntegrationChecks is IntegrationBase {
         );
 
         // AVSDirectory
-        assert_IsRegisteredToAVS(incomingOperator, "operator should be registered to AVS");
+        // assert_IsRegisteredToAVS(incomingOperator, "operator should be registered to AVS");
 
         // Check that churnedOperators are deregistered from churnedQuorums
         for (uint256 i = 0; i < churnedOperators.length; i++) {
@@ -175,6 +180,13 @@ contract IntegrationChecks is IntegrationBase {
                 churnedOperator,
                 churnedQuorum,
                 "churned operator did not deregister from churned quorum"
+            );
+
+            // AllocationManager
+            assert_Snap_Deregistered_FromOperatorSets(
+                churnedOperator,
+                churnedQuorum,
+                "churned operator did not deregister from operatorSets"
             );
 
             // BLSApkRegistry
@@ -276,7 +288,7 @@ contract IntegrationChecks is IntegrationBase {
         );
 
         // AVSDirectory
-        assert_IsRegisteredToAVS(operator, "operator should be registered to AVS");
+        // assert_IsRegisteredToAVS(operator, "operator should be registered to AVS");
     }
 
     /// @dev Validate state directly after the operator exits from Eigenlayer core (by queuing withdrawals)
@@ -319,6 +331,11 @@ contract IntegrationChecks is IntegrationBase {
     /// NOTE: This is a combination of check_Deregister_State and check_CompleteDeregister_State
     function check_WithdrawUpdate_State(User operator, bytes memory quorums) internal {
         _log("check_WithdrawUpdate_State", operator);
+
+        // AllocationManager
+        assert_Snap_Deregistered_FromOperatorSets(
+            operator, quorums, "operator did not deregister from all operator sets"
+        );
 
         // RegistryCoordinator
         assert_HasOperatorInfoWithId(operator, "operatorInfo should still have operatorId");
@@ -392,6 +409,11 @@ contract IntegrationChecks is IntegrationBase {
     /// @dev Check that the operator correctly deregistered from some quorums
     function check_Deregister_State(User operator, bytes memory quorums) internal {
         _log("check_Deregister_State", operator);
+
+        // AllocationManager
+        assert_Snap_Deregistered_FromOperatorSets(
+            operator, quorums, "operator did not deregister from all operator sets"
+        );
 
         // RegistryCoordinator
         assert_HasOperatorInfoWithId(operator, "operatorInfo should still have operatorId");

--- a/test/integration/IntegrationConfig.t.sol
+++ b/test/integration/IntegrationConfig.t.sol
@@ -47,12 +47,16 @@ contract IntegrationConfig is IntegrationDeployer, G2Operations, Constants {
     bytes numStrategyFlags;
     bytes minStakeFlags;
     bytes fillTypeFlags;
-
+    bytes quorumTypeFlags;
     uint256 constant FLAG = 1;
 
     /// @dev Flags for userTypes
     uint256 constant DEFAULT = (FLAG << 0);
     uint256 constant ALT_METHODS = (FLAG << 1);
+
+    /// @dev Flags for using SlashingRegistryCoordinator or RegistryCoordinator (M2)
+    uint256 constant SLASHING = (FLAG << 0);
+    uint256 constant M2 = (FLAG << 1);
 
     /// @dev Flags for numQuorums and numStrategies
     uint256 constant ONE = (FLAG << 0);
@@ -70,6 +74,11 @@ contract IntegrationConfig is IntegrationDeployer, G2Operations, Constants {
     uint256 constant EMPTY = (FLAG << 0);
     uint256 constant SOME_FILL = (FLAG << 1);
     uint256 constant FULL = (FLAG << 2);
+
+    /// @dev Flags for quorumType
+    uint256 constant DELEGATED_STAKE = (FLAG << 0);
+    uint256 constant SLASHABLE_STAKE = (FLAG << 1);
+    uint256 constant BOTH = (FLAG << 2);
 
     /// @dev Tracking variables for pregenerated BLS keypairs:
     /// (See _fetchKeypair)
@@ -121,6 +130,8 @@ contract IntegrationConfig is IntegrationDeployer, G2Operations, Constants {
         /// @dev Whether each quorum created is pre-populated with operators
         /// NOTE: Default
         uint256 fillTypes; // EMPTY | SOME_FILL | FULL
+        /// @dev Whether quorums created are delegated stake quorum, slashable stake quorums, or both
+        uint256 quorumType; // DELEGATED_STAKE | SLASHABLE_STAKE | BOTH
     }
 
     /**
@@ -143,7 +154,7 @@ contract IntegrationConfig is IntegrationDeployer, G2Operations, Constants {
         numStrategyFlags = _bitmapToBytes(_quorumConfig.numStrategies);
         minStakeFlags = _bitmapToBytes(_quorumConfig.minimumStake);
         fillTypeFlags = _bitmapToBytes(_quorumConfig.fillTypes);
-
+        quorumTypeFlags = _bitmapToBytes(_quorumConfig.quorumType);
         // Sanity check config
         assertTrue(userFlags.length != 0, "_configRand: invalid _userTypes, no flags passed");
         assertTrue(numQuorumFlags.length != 0, "_configRand: invalid numQuorums, no flags passed");
@@ -152,7 +163,7 @@ contract IntegrationConfig is IntegrationDeployer, G2Operations, Constants {
         );
         assertTrue(minStakeFlags.length != 0, "_configRand: invalid minimumStake, no flags passed");
         assertTrue(fillTypeFlags.length != 0, "_configRand: invalid fillTypes, no flags passed");
-
+        assertTrue(quorumTypeFlags.length != 0, "_configRand: invalid quorumType, no flags passed");
         // Decide how many quorums to initialize
         quorumCount = _randQuorumCount();
         quorumBitmap = uint192((1 << quorumCount) - 1);
@@ -172,13 +183,52 @@ contract IntegrationConfig is IntegrationDeployer, G2Operations, Constants {
             IStakeRegistryTypes.StrategyParams[] memory strategyParams = _randStrategyParams();
             uint96 minimumStake = _randMinStake();
 
+            uint256 quorumType = _randValue(quorumTypeFlags);
+
             emit log_named_uint("_configRand: creating quorum", i);
             emit log_named_uint("- Max operator count", operatorSet.maxOperatorCount);
             emit log_named_uint("- Num strategies considered", strategyParams.length);
             emit log_named_uint("- Minimum stake", minimumStake);
+            emit log_named_uint("- Quorum type", quorumType);
+
+            if (quorumType == DELEGATED_STAKE) {
+                cheats.prank(registryCoordinatorOwner);
+                slashingRegistryCoordinator.createTotalDelegatedStakeQuorum({
+                    operatorSetParams: operatorSet,
+                    minimumStake: minimumStake,
+                    strategyParams: strategyParams
+                });
+            } else if (quorumType == SLASHABLE_STAKE) {
+                cheats.prank(registryCoordinatorOwner);
+                slashingRegistryCoordinator.createSlashableStakeQuorum({
+                    operatorSetParams: operatorSet,
+                    minimumStake: minimumStake,
+                    strategyParams: strategyParams,
+                    lookAheadPeriod: 0
+                });
+            } else if (quorumType == BOTH) {
+                // randomly choose one of the two
+                uint256 randomChoice = _randValue(quorumTypeFlags);
+                if (randomChoice == DELEGATED_STAKE) {
+                    cheats.prank(registryCoordinatorOwner);
+                    slashingRegistryCoordinator.createTotalDelegatedStakeQuorum({
+                        operatorSetParams: operatorSet,
+                        minimumStake: minimumStake,
+                        strategyParams: strategyParams
+                    });
+                } else if (randomChoice == SLASHABLE_STAKE) {
+                    cheats.prank(registryCoordinatorOwner);
+                    slashingRegistryCoordinator.createSlashableStakeQuorum({
+                        operatorSetParams: operatorSet,
+                        minimumStake: minimumStake,
+                        strategyParams: strategyParams,
+                        lookAheadPeriod: 0
+                    });
+                }
+            }
 
             cheats.prank(registryCoordinatorOwner);
-            registryCoordinator.createTotalDelegatedStakeQuorum({
+            slashingRegistryCoordinator.createTotalDelegatedStakeQuorum({
                 operatorSetParams: operatorSet,
                 minimumStake: minimumStake,
                 strategyParams: strategyParams
@@ -250,10 +300,10 @@ contract IntegrationConfig is IntegrationDeployer, G2Operations, Constants {
         uint256 userType = _randValue(userFlags);
 
         if (userType == DEFAULT) {
-            user = new User(name, privKey, pubkey);
+            user = new OperatorSetUser(name, privKey, pubkey);
         } else if (userType == ALT_METHODS) {
             name = string.concat(name, "_Alt");
-            user = new User_AltMethods(name, privKey, pubkey);
+            user = new OperatorSetUser_AltMethods(name, privKey, pubkey);
         }
 
         emit log_named_string("_randUser: Created user", user.NAME());
@@ -329,7 +379,7 @@ contract IntegrationConfig is IntegrationDeployer, G2Operations, Constants {
             uint8 quorum = uint8(churnQuorums[i]);
 
             ISlashingRegistryCoordinatorTypes.OperatorSetParam memory params =
-                registryCoordinator.getOperatorSetParams(quorum);
+                slashingRegistryCoordinator.getOperatorSetParams(quorum);
 
             // Sanity check - make sure we're at the operator cap
             uint32 curNumOperators = indexRegistry.totalOperatorsForQuorum(quorum);
@@ -402,7 +452,7 @@ contract IntegrationConfig is IntegrationDeployer, G2Operations, Constants {
         for (uint256 i = 0; i < quorums.length; i++) {
             uint8 quorum = uint8(quorums[i]);
             uint32 maxOperatorCount =
-                registryCoordinator.getOperatorSetParams(quorum).maxOperatorCount;
+                slashingRegistryCoordinator.getOperatorSetParams(quorum).maxOperatorCount;
 
             // Continue deregistering until we're under the cap
             // This uses while in case we tested a config change that lowered the max count

--- a/test/integration/IntegrationConfig.t.sol
+++ b/test/integration/IntegrationConfig.t.sol
@@ -185,6 +185,13 @@ contract IntegrationConfig is IntegrationDeployer, G2Operations, Constants {
             });
         }
 
+        /// Setup the RegistryCoordinator as M2 RegistryCoordinator with M2 quorums
+        /// TODO: refactor Integration framework to test both M2 upgrade path and new
+        /// registration/deregistration flow of operatorSets
+        _setOperatorSetsEnabled(false);
+        _setM2QuorumsDisabled(false);
+        _setM2QuorumBitmap(0);
+
         // Decide how many operators to register for each quorum initially
         uint256 initialOperators = _randInitialOperators(operatorSet);
         emit log(

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -40,6 +40,7 @@ import "src/libraries/BitmapUtils.sol";
 import "eigenlayer-contracts/src/test/mocks/EmptyContract.sol";
 // import "src/test/integration/mocks/ServiceManagerMock.t.sol";
 import "test/integration/User.t.sol";
+import "test/integration/OperatorSetUser.t.sol";
 
 abstract contract IntegrationDeployer is Test, IUserDeployer {
     using Strings for *;
@@ -56,15 +57,16 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
     IBeacon eigenPodBeacon;
     EigenPod pod;
     ETHPOSDepositMock ethPOSDeposit;
-    AllocationManager allocationManager;
+    AllocationManager public allocationManager;
     PermissionController permissionController;
 
     // Base strategy implementation in case we want to create more strategies later
     StrategyBase baseStrategyImplementation;
 
     // Middleware contracts to deploy
+    SlashingRegistryCoordinator public slashingRegistryCoordinator;
     RegistryCoordinator public registryCoordinator;
-    ServiceManagerMock serviceManager;
+    ServiceManagerMock public serviceManager;
     BLSApkRegistry blsApkRegistry;
     StakeRegistry stakeRegistry;
     IndexRegistry indexRegistry;
@@ -89,6 +91,12 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
     address public churnApprover = cheats.addr(churnApproverPrivateKey);
     address ejector = address(uint160(uint256(keccak256("ejector"))));
     address rewardsUpdater = address(uint160(uint256(keccak256("rewardsUpdater"))));
+
+    /// @dev Account identifier for the AVS. This is the unique identifier address for the AVS in the AllocationManager.
+    /// This address is by default a UAM PermissionController admin and can transfer admin permissions to other addresses.
+    /// For existing AVSs using ServiceManagers, this should be the same address as the ServiceManager and there exist
+    /// interfaces on the ServiceManager to interact with UAM.
+    address avsAccountIdentifier = address(uint160(uint256(keccak256("avsAccountIdentifier"))));
 
     // Constants/Defaults
     uint64 constant GENESIS_TIME_LOCAL = 1 hours * 12;
@@ -314,6 +322,11 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
                 new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
             )
         );
+        slashingRegistryCoordinator = SlashingRegistryCoordinator(
+            address(
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
+            )
+        );
 
         stakeRegistry = StakeRegistry(
             address(
@@ -347,25 +360,25 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
         cheats.stopPrank();
 
         StakeRegistry stakeRegistryImplementation = new StakeRegistry(
-            ISlashingRegistryCoordinator(registryCoordinator),
+            ISlashingRegistryCoordinator(slashingRegistryCoordinator),
             IDelegationManager(delegationManager),
             IAVSDirectory(avsDirectory),
             allocationManager
         );
         BLSApkRegistry blsApkRegistryImplementation =
-            new BLSApkRegistry(ISlashingRegistryCoordinator(registryCoordinator));
+            new BLSApkRegistry(ISlashingRegistryCoordinator(slashingRegistryCoordinator));
         IndexRegistry indexRegistryImplementation =
-            new IndexRegistry(ISlashingRegistryCoordinator(registryCoordinator));
+            new IndexRegistry(ISlashingRegistryCoordinator(slashingRegistryCoordinator));
         ServiceManagerMock serviceManagerImplementation = new ServiceManagerMock(
             IAVSDirectory(avsDirectory),
             rewardsCoordinator,
-            ISlashingRegistryCoordinator(registryCoordinator),
+            ISlashingRegistryCoordinator(slashingRegistryCoordinator),
             stakeRegistry,
             permissionController,
             allocationManager
         );
         SocketRegistry socketRegistryImplementation =
-            new SocketRegistry(IRegistryCoordinator(registryCoordinator));
+            new SocketRegistry(ISlashingRegistryCoordinator(slashingRegistryCoordinator));
 
         proxyAdmin.upgrade(
             TransparentUpgradeableProxy(payable(address(stakeRegistry))),
@@ -423,6 +436,27 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
             )
         );
 
+        SlashingRegistryCoordinator slashingRegistryCoordinatorImplementation = new SlashingRegistryCoordinator(
+            stakeRegistry,
+            blsApkRegistry,
+            indexRegistry,
+            socketRegistry,
+            allocationManager,
+            pauserRegistry
+        );
+        proxyAdmin.upgradeAndCall(
+            TransparentUpgradeableProxy(payable(address(slashingRegistryCoordinator))),
+            address(slashingRegistryCoordinatorImplementation),
+            abi.encodeWithSelector(
+                SlashingRegistryCoordinator.initialize.selector,
+                registryCoordinatorOwner,
+                churnApprover,
+                ejector,
+                0, /*initialPausedStatus*/
+                avsAccountIdentifier /* accountIdentifier */
+            )
+        );
+
         operatorStateRetriever = new OperatorStateRetriever();
 
         // Setup UAM Permissions
@@ -458,10 +492,48 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
             selector: IAllocationManager.removeStrategiesFromOperatorSet.selector
         });
         cheats.stopPrank();
-
         _setOperatorSetsEnabled(false);
         _setM2QuorumsDisabled(false);
         _setM2QuorumBitmap(0);
+
+        /// Setup UAM Permissions for SlashingRegistryCoordinator
+        cheats.startPrank(avsAccountIdentifier);
+        permissionController.setAppointee({
+            account: avsAccountIdentifier,
+            appointee: address(avsAccountIdentifier),
+            target: address(allocationManager),
+            selector: IAllocationManager.setAVSRegistrar.selector
+        });
+        permissionController.setAppointee({
+            account: avsAccountIdentifier,
+            appointee: address(slashingRegistryCoordinator),
+            target: address(allocationManager),
+            selector: IAllocationManager.createOperatorSets.selector
+        });
+        permissionController.setAppointee({
+            account: avsAccountIdentifier,
+            appointee: address(slashingRegistryCoordinator),
+            target: address(allocationManager),
+            selector: IAllocationManager.deregisterFromOperatorSets.selector
+        });
+        permissionController.setAppointee({
+            account: avsAccountIdentifier,
+            appointee: address(stakeRegistry),
+            target: address(allocationManager),
+            selector: IAllocationManager.addStrategiesToOperatorSet.selector
+        });
+        permissionController.setAppointee({
+            account: avsAccountIdentifier,
+            appointee: address(stakeRegistry),
+            target: address(allocationManager),
+            selector: IAllocationManager.removeStrategiesFromOperatorSet.selector
+        });
+        // set AVS Registrar to slashingRegistryCoordinator
+        allocationManager.setAVSRegistrar(
+            avsAccountIdentifier, IAVSRegistrar(address(slashingRegistryCoordinator))
+        );
+
+        cheats.stopPrank();
     }
 
     /// @notice Overwrite RegistryCoordinator.operatorSetsEnabled to the specified value.

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -419,11 +419,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
                 churnApprover,
                 ejector,
                 0, /*initialPausedStatus*/
-                new IRegistryCoordinator.OperatorSetParam[](0),
-                new uint96[](0),
-                new IStakeRegistryTypes.StrategyParams[][](0),
-                quorumStakeTypes,
-                slashableStakeQuorumLookAheadPeriods
+                address(serviceManager) /* accountIdentifier */
             )
         );
 
@@ -465,6 +461,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
 
         _setOperatorSetsEnabled(false);
         _setM2QuorumsDisabled(false);
+        _setM2QuorumBitmap(0);
     }
 
     /// @notice Overwrite RegistryCoordinator.operatorSetsEnabled to the specified value.
@@ -474,14 +471,14 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
     ) internal {
         // 1. First read the current value of the entire slot
         // which holds operatorSetsEnabled, m2QuorumsDisabled, and accountIdentifier
-        bytes32 currentSlot = cheats.load(address(registryCoordinator), bytes32(uint256(161)));
+        bytes32 currentSlot = cheats.load(address(registryCoordinator), bytes32(uint256(200)));
 
         // 2. Clear only the first byte (operatorSetsEnabled) while keeping the rest
         bytes32 newSlot = (currentSlot & ~bytes32(uint256(0xff)))
             | bytes32(uint256(operatorSetsEnabled ? 0x01 : 0x00));
 
         // 3. Store the modified slot
-        cheats.store(address(registryCoordinator), bytes32(uint256(161)), newSlot);
+        cheats.store(address(registryCoordinator), bytes32(uint256(200)), newSlot);
     }
 
     /// @notice Overwrite RegistryCoordinator.m2QuorumsDisabled to the specified value.
@@ -490,14 +487,23 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
     ) internal {
         // 1. First read the current value of the entire slot
         // which holds operatorSetsEnabled, m2QuorumsDisabled, and accountIdentifier
-        bytes32 currentSlot = cheats.load(address(registryCoordinator), bytes32(uint256(161)));
+        bytes32 currentSlot = cheats.load(address(registryCoordinator), bytes32(uint256(200)));
 
         // 2. Clear only the second byte (m2QuorumsDisabled) while keeping the rest
         bytes32 newSlot = (currentSlot & ~bytes32(uint256(0xff) << 8))
             | bytes32(uint256(m2QuorumsDisabled ? 0x01 : 0x00) << 8);
 
         // 3. Store the modified slot
-        cheats.store(address(registryCoordinator), bytes32(uint256(161)), newSlot);
+        cheats.store(address(registryCoordinator), bytes32(uint256(200)), newSlot);
+    }
+
+    /// @notice Overwrite RegistryCoordinator._m2QuorumBitmap to the specified value
+    function _setM2QuorumBitmap(
+        uint256 m2QuorumBitmap
+    ) internal {
+        bytes32 currentSlot = cheats.load(address(registryCoordinator), bytes32(uint256(200)));
+
+        cheats.store(address(registryCoordinator), bytes32(uint256(200)), bytes32(m2QuorumBitmap));
     }
 
     /// @dev Deploy a strategy and its underlying token, push to global lists of tokens/strategies, and whitelist

--- a/test/integration/OperatorSetUser.t.sol
+++ b/test/integration/OperatorSetUser.t.sol
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import "test/integration/User.t.sol";
+import "forge-std/console.sol";
+
+contract OperatorSetUser is User {
+    using BN254 for *;
+    using Strings for *;
+    using BitmapStrings for *;
+    using BitmapUtils for *;
+
+    SlashingRegistryCoordinator slashingRegistryCoordinator;
+    AllocationManager allocationManager;
+    address avs;
+
+    constructor(
+        string memory name,
+        uint256 _privKey,
+        IBLSApkRegistryTypes.PubkeyRegistrationParams memory _pubkeyParams
+    ) User(name, _privKey, _pubkeyParams) {
+        IUserDeployer deployer = IUserDeployer(msg.sender);
+
+        slashingRegistryCoordinator = deployer.slashingRegistryCoordinator();
+        allocationManager = AllocationManager(deployer.allocationManager());
+
+        avs = slashingRegistryCoordinator.accountIdentifier();
+
+        // Generate BN254 keypair and registration signature
+        privKey = _privKey;
+        pubkeyParams = _pubkeyParams;
+
+        BN254.G1Point memory registrationMessageHash =
+            slashingRegistryCoordinator.pubkeyRegistrationMessageHash(address(this));
+        pubkeyParams.pubkeyRegistrationSignature = registrationMessageHash.scalar_mul(privKey);
+
+        operatorId = pubkeyParams.pubkeyG1.hashG1Point();
+    }
+
+    function registerOperator(
+        bytes calldata quorums
+    ) public virtual override createSnapshot returns (bytes32) {
+        _log("registerOperator", quorums);
+
+        vm.warp(block.timestamp + 1);
+        // If operator has previously registered and is still slashable, roll blocks until they are
+        // no longer slashable
+        vm.roll(block.number + uint256(allocationManager.DEALLOCATION_DELAY()) + 1);
+
+        // encode bytes data field passed into SlashingRegistryCoordinator.registerOperator
+        // Register params for AllocationManager
+        bytes memory data = abi.encode(
+            ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, NAME, pubkeyParams
+        );
+        IAllocationManagerTypes.RegisterParams memory registerParams = IAllocationManagerTypes
+            .RegisterParams({avs: avs, operatorSetIds: _getOperatorSetIds(quorums), data: data});
+
+        allocationManager.registerForOperatorSets({operator: address(this), params: registerParams});
+
+        return pubkeyParams.pubkeyG1.hashG1Point();
+    }
+
+    function registerOperatorWithChurn(
+        bytes calldata churnQuorums,
+        User[] calldata churnTargets,
+        bytes calldata standardQuorums
+    ) public virtual override createSnapshot {
+        _logChurn("registerOperatorWithChurn", churnQuorums, churnTargets, standardQuorums);
+
+        vm.warp(block.timestamp + 1);
+        // If operator has previously registered and is still slashable, roll blocks until they are
+        // no longer slashable
+        vm.roll(block.number + uint256(allocationManager.DEALLOCATION_DELAY()) + 1);
+
+        // Sanity check input:
+        // - churnQuorums and churnTargets should have equal length
+        // - churnQuorums and standardQuorums should not have any bits in common
+        uint192 churnBitmap = uint192(churnQuorums.orderedBytesArrayToBitmap());
+        uint192 standardBitmap = uint192(standardQuorums.orderedBytesArrayToBitmap());
+        assertEq(
+            churnQuorums.length,
+            churnTargets.length,
+            "User.registerOperatorWithChurn: input length mismatch"
+        );
+        assertTrue(
+            churnBitmap.noBitsInCommon(standardBitmap),
+            "User.registerOperatorWithChurn: input quorums have common bits"
+        );
+        bytes memory allQuorums = churnBitmap.plus(standardBitmap).bitmapToBytesArray();
+
+        (
+            ISlashingRegistryCoordinatorTypes.OperatorKickParam[] memory kickParams,
+            ISignatureUtils.SignatureWithSaltAndExpiry memory churnApproverSignature
+        ) = _generateOperatorKickParams(allQuorums, churnQuorums, churnTargets, standardQuorums);
+
+        // Encode with RegistrationType.CHURN
+        bytes memory data = abi.encode(
+            ISlashingRegistryCoordinatorTypes.RegistrationType.CHURN,
+            NAME,
+            pubkeyParams,
+            kickParams,
+            churnApproverSignature
+        );
+
+        IAllocationManagerTypes.RegisterParams memory registerParams = IAllocationManagerTypes
+            .RegisterParams({avs: avs, operatorSetIds: _getOperatorSetIds(allQuorums), data: data});
+        allocationManager.registerForOperatorSets({operator: address(this), params: registerParams});
+    }
+
+    function deregisterOperator(
+        bytes calldata quorums
+    ) public virtual override createSnapshot {
+        _log("deregisterOperator", quorums);
+        uint32[] memory operatorSetIds = _getOperatorSetIds(quorums);
+        IAllocationManagerTypes.DeregisterParams memory deregisterParams = IAllocationManagerTypes
+            .DeregisterParams({avs: avs, operator: address(this), operatorSetIds: operatorSetIds});
+        allocationManager.deregisterFromOperatorSets({params: deregisterParams});
+    }
+
+    /// @dev Uses updateOperators to update this user's stake
+    function updateStakes() public virtual override createSnapshot {
+        _log("updateStakes (updateOperators)");
+
+        // get all quorums this operator is registered for
+        uint192 currentBitmap = slashingRegistryCoordinator.getCurrentQuorumBitmap(operatorId);
+        bytes memory quorumNumbers = currentBitmap.bitmapToBytesArray();
+
+        // get all operators in those quorums
+        address[][] memory operatorsPerQuorum = new address[][](quorumNumbers.length);
+        for (uint256 i = 0; i < quorumNumbers.length; i++) {
+            bytes32[] memory operatorIds = indexRegistry.getOperatorListAtBlockNumber(
+                uint8(quorumNumbers[i]), uint32(block.number)
+            );
+            operatorsPerQuorum[i] = new address[](operatorIds.length);
+            for (uint256 j = 0; j < operatorIds.length; j++) {
+                operatorsPerQuorum[i][j] = blsApkRegistry.pubkeyHashToOperator(operatorIds[j]);
+            }
+
+            operatorsPerQuorum[i] = Sort.sortAddresses(operatorsPerQuorum[i]);
+        }
+        slashingRegistryCoordinator.updateOperatorsForQuorum(operatorsPerQuorum, quorumNumbers);
+    }
+
+    function _getOperatorSetIds(
+        bytes memory quorums
+    ) internal pure returns (uint32[] memory) {
+        uint32[] memory operatorSetIds = new uint32[](quorums.length);
+        for (uint256 i = 0; i < quorums.length; i++) {
+            operatorSetIds[i] = uint32(uint8(quorums[i]));
+        }
+        return operatorSetIds;
+    }
+
+    function _generateOperatorKickParams(
+        bytes memory allQuorums,
+        bytes calldata churnQuorums,
+        User[] calldata churnTargets,
+        bytes calldata standardQuorums
+    )
+        internal
+        virtual
+        override
+        returns (
+            ISlashingRegistryCoordinatorTypes.OperatorKickParam[] memory,
+            ISignatureUtils.SignatureWithSaltAndExpiry memory
+        )
+    {
+        ISlashingRegistryCoordinator.OperatorKickParam[] memory kickParams =
+            new ISlashingRegistryCoordinator.OperatorKickParam[](allQuorums.length);
+
+        // this constructs OperatorKickParam[] in ascending quorum order
+        // (yikes)
+        uint256 churnIdx;
+        uint256 stdIdx;
+        while (churnIdx + stdIdx < allQuorums.length) {
+            if (churnIdx == churnQuorums.length) {
+                kickParams[churnIdx + stdIdx] = ISlashingRegistryCoordinatorTypes.OperatorKickParam({
+                    quorumNumber: 0,
+                    operator: address(0)
+                });
+                stdIdx++;
+            } else if (
+                stdIdx == standardQuorums.length || churnQuorums[churnIdx] < standardQuorums[stdIdx]
+            ) {
+                kickParams[churnIdx + stdIdx] = ISlashingRegistryCoordinatorTypes.OperatorKickParam({
+                    quorumNumber: uint8(churnQuorums[churnIdx]),
+                    operator: address(churnTargets[churnIdx])
+                });
+                churnIdx++;
+            } else if (standardQuorums[stdIdx] < churnQuorums[churnIdx]) {
+                kickParams[churnIdx + stdIdx] = ISlashingRegistryCoordinatorTypes.OperatorKickParam({
+                    quorumNumber: 0,
+                    operator: address(0)
+                });
+                stdIdx++;
+            } else {
+                revert("User.registerOperatorWithChurn: malformed input");
+            }
+        }
+
+        // Generate churn approver signature
+        bytes32 _salt = keccak256(abi.encodePacked(++salt, address(this)));
+        uint256 expiry = type(uint256).max;
+        bytes32 digest = slashingRegistryCoordinator.calculateOperatorChurnApprovalDigestHash({
+            registeringOperator: address(this),
+            registeringOperatorId: operatorId,
+            operatorKickParams: kickParams,
+            salt: _salt,
+            expiry: expiry
+        });
+
+        // Sign digest
+        (uint8 v, bytes32 r, bytes32 s) = cheats.sign(churnApproverPrivateKey, digest);
+        bytes memory signature = new bytes(65);
+        assembly {
+            mstore(add(signature, 0x20), r)
+            mstore(add(signature, 0x40), s)
+        }
+        signature[signature.length - 1] = bytes1(v);
+        ISignatureUtils.SignatureWithSaltAndExpiry memory churnApproverSignature = ISignatureUtils
+            .SignatureWithSaltAndExpiry({signature: signature, salt: _salt, expiry: expiry});
+
+        return (kickParams, churnApproverSignature);
+    }
+}
+
+contract OperatorSetUser_AltMethods is OperatorSetUser {
+    using BitmapUtils for *;
+
+    modifier createSnapshot() virtual override {
+        cheats.roll(block.number + 1);
+        timeMachine.createSnapshot();
+        _;
+    }
+
+    constructor(
+        string memory name,
+        uint256 _privKey,
+        IBLSApkRegistryTypes.PubkeyRegistrationParams memory _pubkeyParams
+    ) OperatorSetUser(name, _privKey, _pubkeyParams) {}
+
+    /// @dev Rather than calling deregisterOperator, this pranks the ejector and calls
+    /// ejectOperator
+    function deregisterOperator(
+        bytes calldata quorums
+    ) public virtual override createSnapshot {
+        _log("deregisterOperator (eject)", quorums);
+
+        address ejector = slashingRegistryCoordinator.ejector();
+
+        cheats.prank(ejector);
+        slashingRegistryCoordinator.ejectOperator(address(this), quorums);
+    }
+
+    /// @dev Uses updateOperatorsForQuorum to update stakes of all operators in all quorums
+    function updateStakes() public virtual override createSnapshot {
+        _log("updateStakes (updateOperatorsForQuorum)");
+
+        bytes memory allQuorums =
+            ((1 << slashingRegistryCoordinator.quorumCount()) - 1).bitmapToBytesArray();
+        address[][] memory operatorsPerQuorum = new address[][](allQuorums.length);
+
+        for (uint256 i = 0; i < allQuorums.length; i++) {
+            uint8 quorum = uint8(allQuorums[i]);
+            bytes32[] memory operatorIds =
+                indexRegistry.getOperatorListAtBlockNumber(quorum, uint32(block.number));
+
+            operatorsPerQuorum[i] = new address[](operatorIds.length);
+
+            for (uint256 j = 0; j < operatorIds.length; j++) {
+                operatorsPerQuorum[i][j] = blsApkRegistry.getOperatorFromPubkeyHash(operatorIds[j]);
+            }
+
+            operatorsPerQuorum[i] = Sort.sortAddresses(operatorsPerQuorum[i]);
+        }
+
+        slashingRegistryCoordinator.updateOperatorsForQuorum(operatorsPerQuorum, allQuorums);
+    }
+}

--- a/test/integration/User.t.sol
+++ b/test/integration/User.t.sol
@@ -14,6 +14,7 @@ import "eigenlayer-contracts/src/contracts/core/DelegationManager.sol";
 import "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
 import "eigenlayer-contracts/src/contracts/core/StrategyManager.sol";
 import "eigenlayer-contracts/src/contracts/core/AVSDirectory.sol";
+import "eigenlayer-contracts/src/contracts/core/AllocationManager.sol";
 
 // Middleware
 import "src/interfaces/IRegistryCoordinator.sol";
@@ -28,10 +29,14 @@ import "src/libraries/BitmapUtils.sol";
 import "test/integration/TimeMachine.t.sol";
 import "test/integration/utils/Sort.t.sol";
 import "test/integration/utils/BitmapStrings.t.sol";
+import "test/mocks/ServiceManagerMock.sol";
 
 interface IUserDeployer {
+    function slashingRegistryCoordinator() external view returns (SlashingRegistryCoordinator);
     function registryCoordinator() external view returns (RegistryCoordinator);
     function avsDirectory() external view returns (AVSDirectory);
+    function allocationManager() external view returns (AllocationManager);
+    function serviceManager() external view returns (ServiceManagerMock);
     function timeMachine() external view returns (TimeMachine);
     function churnApproverPrivateKey() external view returns (uint256);
     function churnApprover() external view returns (address);
@@ -82,7 +87,7 @@ contract User is Test {
 
         registryCoordinator = deployer.registryCoordinator();
         avsDirectory = deployer.avsDirectory();
-        serviceManager = ServiceManagerBase(address(registryCoordinator.serviceManager()));
+        serviceManager = ServiceManagerBase(address(deployer.serviceManager()));
 
         blsApkRegistry = BLSApkRegistry(address(registryCoordinator.blsApkRegistry()));
         stakeRegistry = StakeRegistry(address(registryCoordinator.stakeRegistry()));
@@ -124,6 +129,7 @@ contract User is Test {
         _log("registerOperator", quorums);
 
         vm.warp(block.timestamp + 1);
+
         registryCoordinator.registerOperator({
             quorumNumbers: quorums,
             socket: NAME,
@@ -161,61 +167,10 @@ contract User is Test {
 
         bytes memory allQuorums = churnBitmap.plus(standardBitmap).bitmapToBytesArray();
 
-        ISlashingRegistryCoordinator.OperatorKickParam[] memory kickParams =
-            new ISlashingRegistryCoordinator.OperatorKickParam[](allQuorums.length);
-
-        // this constructs OperatorKickParam[] in ascending quorum order
-        // (yikes)
-        uint256 churnIdx;
-        uint256 stdIdx;
-        while (churnIdx + stdIdx < allQuorums.length) {
-            if (churnIdx == churnQuorums.length) {
-                kickParams[churnIdx + stdIdx] = ISlashingRegistryCoordinatorTypes.OperatorKickParam({
-                    quorumNumber: 0,
-                    operator: address(0)
-                });
-                stdIdx++;
-            } else if (
-                stdIdx == standardQuorums.length || churnQuorums[churnIdx] < standardQuorums[stdIdx]
-            ) {
-                kickParams[churnIdx + stdIdx] = ISlashingRegistryCoordinatorTypes.OperatorKickParam({
-                    quorumNumber: uint8(churnQuorums[churnIdx]),
-                    operator: address(churnTargets[churnIdx])
-                });
-                churnIdx++;
-            } else if (standardQuorums[stdIdx] < churnQuorums[churnIdx]) {
-                kickParams[churnIdx + stdIdx] = ISlashingRegistryCoordinatorTypes.OperatorKickParam({
-                    quorumNumber: 0,
-                    operator: address(0)
-                });
-                stdIdx++;
-            } else {
-                revert("User.registerOperatorWithChurn: malformed input");
-            }
-        }
-
-        // Generate churn approver signature
-        bytes32 _salt = keccak256(abi.encodePacked(++salt, address(this)));
-        uint256 expiry = type(uint256).max;
-        bytes32 digest = registryCoordinator.calculateOperatorChurnApprovalDigestHash({
-            registeringOperator: address(this),
-            registeringOperatorId: operatorId,
-            operatorKickParams: kickParams,
-            salt: _salt,
-            expiry: expiry
-        });
-
-        // Sign digest
-        (uint8 v, bytes32 r, bytes32 s) = cheats.sign(churnApproverPrivateKey, digest);
-        bytes memory signature = new bytes(65);
-        assembly {
-            mstore(add(signature, 0x20), r)
-            mstore(add(signature, 0x40), s)
-        }
-        signature[signature.length - 1] = bytes1(v);
-
-        ISignatureUtils.SignatureWithSaltAndExpiry memory churnApproverSignature = ISignatureUtils
-            .SignatureWithSaltAndExpiry({signature: signature, salt: _salt, expiry: expiry});
+        (
+            ISlashingRegistryCoordinatorTypes.OperatorKickParam[] memory kickParams,
+            ISignatureUtils.SignatureWithSaltAndExpiry memory churnApproverSignature
+        ) = _generateOperatorKickParams(allQuorums, churnQuorums, churnTargets, standardQuorums);
 
         vm.warp(block.timestamp + 1);
         registryCoordinator.registerOperatorWithChurn({
@@ -388,6 +343,77 @@ contract User is Test {
         targetString = string.concat(targetString, "]");
 
         emit log_named_string("- churnTargets", targetString);
+    }
+
+    function _generateOperatorKickParams(
+        bytes memory allQuorums,
+        bytes calldata churnQuorums,
+        User[] calldata churnTargets,
+        bytes calldata standardQuorums
+    )
+        internal
+        virtual
+        returns (
+            ISlashingRegistryCoordinatorTypes.OperatorKickParam[] memory,
+            ISignatureUtils.SignatureWithSaltAndExpiry memory
+        )
+    {
+        ISlashingRegistryCoordinator.OperatorKickParam[] memory kickParams =
+            new ISlashingRegistryCoordinator.OperatorKickParam[](allQuorums.length);
+
+        // this constructs OperatorKickParam[] in ascending quorum order
+        // (yikes)
+        uint256 churnIdx;
+        uint256 stdIdx;
+        while (churnIdx + stdIdx < allQuorums.length) {
+            if (churnIdx == churnQuorums.length) {
+                kickParams[churnIdx + stdIdx] = ISlashingRegistryCoordinatorTypes.OperatorKickParam({
+                    quorumNumber: 0,
+                    operator: address(0)
+                });
+                stdIdx++;
+            } else if (
+                stdIdx == standardQuorums.length || churnQuorums[churnIdx] < standardQuorums[stdIdx]
+            ) {
+                kickParams[churnIdx + stdIdx] = ISlashingRegistryCoordinatorTypes.OperatorKickParam({
+                    quorumNumber: uint8(churnQuorums[churnIdx]),
+                    operator: address(churnTargets[churnIdx])
+                });
+                churnIdx++;
+            } else if (standardQuorums[stdIdx] < churnQuorums[churnIdx]) {
+                kickParams[churnIdx + stdIdx] = ISlashingRegistryCoordinatorTypes.OperatorKickParam({
+                    quorumNumber: 0,
+                    operator: address(0)
+                });
+                stdIdx++;
+            } else {
+                revert("User.registerOperatorWithChurn: malformed input");
+            }
+        }
+
+        // Generate churn approver signature
+        bytes32 _salt = keccak256(abi.encodePacked(++salt, address(this)));
+        uint256 expiry = type(uint256).max;
+        bytes32 digest = registryCoordinator.calculateOperatorChurnApprovalDigestHash({
+            registeringOperator: address(this),
+            registeringOperatorId: operatorId,
+            operatorKickParams: kickParams,
+            salt: _salt,
+            expiry: expiry
+        });
+
+        // Sign digest
+        (uint8 v, bytes32 r, bytes32 s) = cheats.sign(churnApproverPrivateKey, digest);
+        bytes memory signature = new bytes(65);
+        assembly {
+            mstore(add(signature, 0x20), r)
+            mstore(add(signature, 0x40), s)
+        }
+        signature[signature.length - 1] = bytes1(v);
+        ISignatureUtils.SignatureWithSaltAndExpiry memory churnApproverSignature = ISignatureUtils
+            .SignatureWithSaltAndExpiry({signature: signature, salt: _salt, expiry: expiry});
+
+        return (kickParams, churnApproverSignature);
     }
 }
 

--- a/test/integration/User.t.sol
+++ b/test/integration/User.t.sol
@@ -240,10 +240,24 @@ contract User is Test {
     function updateStakes() public virtual createSnapshot {
         _log("updateStakes (updateOperators)");
 
-        address[] memory addrs = new address[](1);
-        addrs[0] = address(this);
+        // get all quorums this operator is registered for
+        uint192 currentBitmap = registryCoordinator.getCurrentQuorumBitmap(operatorId);
+        bytes memory quorumNumbers = currentBitmap.bitmapToBytesArray();
 
-        registryCoordinator.updateOperators(addrs);
+        // get all operators in those quorums
+        address[][] memory operatorsPerQuorum = new address[][](quorumNumbers.length);
+        for (uint256 i = 0; i < quorumNumbers.length; i++) {
+            bytes32[] memory operatorIds = indexRegistry.getOperatorListAtBlockNumber(
+                uint8(quorumNumbers[i]), uint32(block.number)
+            );
+            operatorsPerQuorum[i] = new address[](operatorIds.length);
+            for (uint256 j = 0; j < operatorIds.length; j++) {
+                operatorsPerQuorum[i][j] = blsApkRegistry.pubkeyHashToOperator(operatorIds[j]);
+            }
+
+            operatorsPerQuorum[i] = Sort.sortAddresses(operatorsPerQuorum[i]);
+        }
+        registryCoordinator.updateOperatorsForQuorum(operatorsPerQuorum, quorumNumbers);
     }
 
     /**

--- a/test/integration/tests/Full_Register_Deregister.t.sol
+++ b/test/integration/tests/Full_Register_Deregister.t.sol
@@ -21,7 +21,8 @@ contract Integration_Full_Register_Deregister is IntegrationChecks {
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: NO_MINIMUM | HAS_MINIMUM,
-                fillTypes: FULL
+                fillTypes: FULL,
+                quorumType: DELEGATED_STAKE
             })
         });
 
@@ -71,7 +72,8 @@ contract Integration_Full_Register_Deregister is IntegrationChecks {
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: NO_MINIMUM | HAS_MINIMUM,
-                fillTypes: FULL
+                fillTypes: FULL,
+                quorumType: DELEGATED_STAKE
             })
         });
 
@@ -136,7 +138,8 @@ contract Integration_Full_Register_Deregister is IntegrationChecks {
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: NO_MINIMUM | HAS_MINIMUM,
-                fillTypes: FULL
+                fillTypes: FULL,
+                quorumType: DELEGATED_STAKE
             })
         });
 

--- a/test/integration/tests/NonFull_Register_CoreBalanceChange_Update.t.sol
+++ b/test/integration/tests/NonFull_Register_CoreBalanceChange_Update.t.sol
@@ -20,7 +20,8 @@ contract Integration_NonFull_Register_CoreBalanceChange_Update is IntegrationChe
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: HAS_MINIMUM,
-                fillTypes: EMPTY | SOME_FILL
+                fillTypes: EMPTY | SOME_FILL,
+                quorumType: DELEGATED_STAKE
             })
         });
 
@@ -64,7 +65,8 @@ contract Integration_NonFull_Register_CoreBalanceChange_Update is IntegrationChe
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: HAS_MINIMUM,
-                fillTypes: EMPTY | SOME_FILL
+                fillTypes: EMPTY | SOME_FILL,
+                quorumType: DELEGATED_STAKE
             })
         });
 
@@ -103,7 +105,8 @@ contract Integration_NonFull_Register_CoreBalanceChange_Update is IntegrationChe
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: HAS_MINIMUM,
-                fillTypes: EMPTY | SOME_FILL
+                fillTypes: EMPTY | SOME_FILL,
+                quorumType: DELEGATED_STAKE
             })
         });
 
@@ -138,7 +141,8 @@ contract Integration_NonFull_Register_CoreBalanceChange_Update is IntegrationChe
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: HAS_MINIMUM,
-                fillTypes: EMPTY | SOME_FILL
+                fillTypes: EMPTY | SOME_FILL,
+                quorumType: DELEGATED_STAKE
             })
         });
 
@@ -174,7 +178,8 @@ contract Integration_NonFull_Register_CoreBalanceChange_Update is IntegrationChe
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: HAS_MINIMUM,
-                fillTypes: EMPTY | SOME_FILL
+                fillTypes: EMPTY | SOME_FILL,
+                quorumType: DELEGATED_STAKE
             })
         });
 

--- a/test/integration/tests/NonFull_Register_Deregister.t.sol
+++ b/test/integration/tests/NonFull_Register_Deregister.t.sol
@@ -20,7 +20,8 @@ contract Integration_NonFull_Register_Deregister is IntegrationChecks {
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: NO_MINIMUM | HAS_MINIMUM,
-                fillTypes: EMPTY | SOME_FILL
+                fillTypes: EMPTY | SOME_FILL,
+                quorumType: DELEGATED_STAKE
             })
         });
 
@@ -52,7 +53,8 @@ contract Integration_NonFull_Register_Deregister is IntegrationChecks {
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: NO_MINIMUM | HAS_MINIMUM,
-                fillTypes: EMPTY | SOME_FILL
+                fillTypes: EMPTY | SOME_FILL,
+                quorumType: DELEGATED_STAKE
             })
         });
 
@@ -93,7 +95,8 @@ contract Integration_NonFull_Register_Deregister is IntegrationChecks {
                 numQuorums: ONE | TWO | MANY,
                 numStrategies: ONE | TWO | MANY,
                 minimumStake: NO_MINIMUM | HAS_MINIMUM,
-                fillTypes: EMPTY | SOME_FILL
+                fillTypes: EMPTY | SOME_FILL,
+                quorumType: DELEGATED_STAKE
             })
         });
 

--- a/test/mocks/DelegationMock.sol
+++ b/test/mocks/DelegationMock.sol
@@ -282,6 +282,20 @@ contract DelegationMock is DelegationIntermediate {
         return shares;
     }
 
+    function getOperatorsShares(
+        address[] memory operators,
+        IStrategy[] memory strategies
+    ) external view override returns (uint256[][] memory) {
+        uint256[][] memory operatorSharesArray = new uint256[][](operators.length);
+        for (uint256 i = 0; i < operators.length; i++) {
+            operatorSharesArray[i] = new uint256[](strategies.length);
+            for (uint256 j = 0; j < strategies.length; j++) {
+                operatorSharesArray[i][j] = _weightOf[operators[i]][strategies[j]];
+            }
+        }
+        return operatorSharesArray;
+    }
+
     function minWithdrawalDelayBlocks() external view override returns (uint32) {
         return 10000;
     }

--- a/test/mocks/StakeRegistryMock.sol
+++ b/test/mocks/StakeRegistryMock.sol
@@ -264,12 +264,12 @@ contract StakeRegistryMock is IStakeRegistry {
      * If the operator no longer has the minimum stake required for a quorum, they are
      * added to the
      */
-    function updateOperatorStake(
-        address, /*operator*/
-        bytes32, /*operatorId*/
-        bytes calldata /*quorumNumbers*/
-    ) external returns (uint192) {
-        return updateOperatorStakeReturnBitmap;
+    function updateOperatorsStake(
+        address[] memory operators,
+        bytes32[] memory,
+        uint8
+    ) external pure returns (bool[] memory) {
+        return new bool[](operators.length);
     }
 
     function getMockOperatorId(

--- a/test/unit/BLSApkRegistryUnit.t.sol
+++ b/test/unit/BLSApkRegistryUnit.t.sol
@@ -927,4 +927,33 @@ contract BLSApkRegistryUnitTests_quorumApkUpdates is BLSApkRegistryUnitTests {
             assertEq(quorumApk.Y, 0, "quorum apk not set to zero");
         }
     }
+
+    /**
+     * @dev test that attempting to get APK indices for a block number before the first update reverts
+     */
+    function testFuzz_quorumApkUpdates_BlockNumberBeforeFirstUpdate(
+        uint32 blockNumber,
+        uint8 quorumNumber
+    ) external {
+        // Initialize quorum if not already initialized
+        if (!initializedQuorums[quorumNumber]) {
+            _initializeFuzzedQuorum(quorumNumber);
+        }
+
+        bytes memory quorumNumbers = new bytes(1);
+        quorumNumbers[0] = bytes1(quorumNumber);
+
+        // Register an operator to create first update
+        address operator = _selectNewOperator();
+        _registerDefaultBLSPubkey(operator);
+        _registerOperator(operator, quorumNumbers);
+        uint32 firstUpdateBlock = uint32(block.number);
+
+        // Ensure blockNumber is before first update
+        cheats.assume(blockNumber < firstUpdateBlock);
+
+        // Expect revert when querying block before first update
+        cheats.expectRevert(IBLSApkRegistryErrors.BlockNumberBeforeFirstUpdate.selector);
+        blsApkRegistry.getApkIndicesAtBlockNumber(quorumNumbers, blockNumber);
+    }
 }

--- a/test/unit/BLSSignatureCheckerUnit.t.sol
+++ b/test/unit/BLSSignatureCheckerUnit.t.sol
@@ -582,4 +582,75 @@ contract BLSSignatureCheckerUnitTests is BLSMockAVSDeployer {
             msgHash, quorumNumbers, referenceBlockNumber, nonSignerStakesAndSignature
         );
     }
+
+    function test_trySignatureAndApkVerification_success() public {
+        uint256 numNonSigners = 0;
+        uint256 quorumBitmap = 1;
+        (
+            uint32 referenceBlockNumber,
+            BLSSignatureChecker.NonSignerStakesAndSignature memory nonSignerStakesAndSignature
+        ) = _registerSignatoriesAndGetNonSignerStakeAndSignatureRandom(
+            1, numNonSigners, quorumBitmap
+        );
+
+        (bool pairingSuccessful, bool signatureIsValid) = blsSignatureChecker
+            .trySignatureAndApkVerification(
+            msgHash,
+            nonSignerStakesAndSignature.quorumApks[0],
+            nonSignerStakesAndSignature.apkG2,
+            nonSignerStakesAndSignature.sigma
+        );
+
+        assertTrue(pairingSuccessful, "Pairing should be successful");
+        assertTrue(signatureIsValid, "Signature should be valid");
+    }
+
+    function test_trySignatureAndApkVerification_invalidSignature() public {
+        uint256 numNonSigners = 0;
+        uint256 quorumBitmap = 1;
+        (
+            uint32 referenceBlockNumber,
+            BLSSignatureChecker.NonSignerStakesAndSignature memory nonSignerStakesAndSignature
+        ) = _registerSignatoriesAndGetNonSignerStakeAndSignatureRandom(
+            1, numNonSigners, quorumBitmap
+        );
+
+        // Modify sigma to make it invalid
+        nonSignerStakesAndSignature.sigma.X++;
+
+        cheats.expectRevert();
+        blsSignatureChecker.trySignatureAndApkVerification(
+            msgHash,
+            nonSignerStakesAndSignature.quorumApks[0],
+            nonSignerStakesAndSignature.apkG2,
+            nonSignerStakesAndSignature.sigma
+        );
+    }
+
+    function test_trySignatureAndApkVerification_invalidPairing() public {
+        uint256 numNonSigners = 0;
+        uint256 quorumBitmap = 1;
+        (
+            uint32 referenceBlockNumber,
+            BLSSignatureChecker.NonSignerStakesAndSignature memory nonSignerStakesAndSignature
+        ) = _registerSignatoriesAndGetNonSignerStakeAndSignatureRandom(
+            1, numNonSigners, quorumBitmap
+        );
+
+        // Create invalid G2 point
+        BN254.G2Point memory invalidG2Point = BN254.G2Point(
+            [type(uint256).max, type(uint256).max], [type(uint256).max, type(uint256).max]
+        );
+
+        (bool pairingSuccessful, bool signatureIsValid) = blsSignatureChecker
+            .trySignatureAndApkVerification(
+            msgHash,
+            nonSignerStakesAndSignature.quorumApks[0],
+            invalidG2Point,
+            nonSignerStakesAndSignature.sigma
+        );
+
+        assertFalse(pairingSuccessful, "Pairing should fail");
+        assertFalse(signatureIsValid, "Signature should be invalid");
+    }
 }

--- a/test/unit/ECDSAServiceManager.t.sol
+++ b/test/unit/ECDSAServiceManager.t.sol
@@ -1,192 +1,217 @@
-// // SPDX-License-Identifier: MIT
-// pragma solidity ^0.8.27;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
 
-// import {Test, console} from "forge-std/Test.sol";
+import {Test, console} from "forge-std/Test.sol";
 
-// import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
-// import {IDelegationManager} from "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
-// import {IRewardsCoordinator} from "eigenlayer-contracts/src/contracts/interfaces/IRewardsCoordinator.sol";
-// import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
+import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
+import {IDelegationManager} from
+    "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
+import {IRewardsCoordinator} from
+    "eigenlayer-contracts/src/contracts/interfaces/IRewardsCoordinator.sol";
+import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
+import {IAVSRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IAVSRegistrar.sol";
 
-// import {ECDSAServiceManagerMock} from "../mocks/ECDSAServiceManagerMock.sol";
-// import {ECDSAStakeRegistryMock} from "../mocks/ECDSAStakeRegistryMock.sol";
-// import {IECDSAStakeRegistryTypes.Quorum, StrategyParams} from "../../src/interfaces/IECDSAStakeRegistry.sol";
+import {ECDSAServiceManagerMock} from "../mocks/ECDSAServiceManagerMock.sol";
+import {ECDSAStakeRegistryMock} from "../mocks/ECDSAStakeRegistryMock.sol";
+import {IECDSAStakeRegistryTypes} from "../../src/interfaces/IECDSAStakeRegistry.sol";
 
-// contract MockDelegationManager {
-//     function operatorShares(address, address) external pure returns (uint256) {
-//         return 1000; // Return a dummy value for simplicity
-//     }
+contract MockDelegationManager {
+    function operatorShares(address, address) external pure returns (uint256) {
+        return 1000; // Return a dummy value for simplicity
+    }
 
-//     function getOperatorShares(
-//         address,
-//         IStrategy[] memory strategies
-//     ) external pure returns (uint256[] memory) {
-//         uint256[] memory response = new uint256[](strategies.length);
-//         for (uint256 i; i < strategies.length; i++) {
-//             response[i] = 1000;
-//         }
-//         return response; // Return a dummy value for simplicity
-//     }
-// }
+    function getOperatorShares(
+        address,
+        IStrategy[] memory strategies
+    ) external pure returns (uint256[] memory) {
+        uint256[] memory response = new uint256[](strategies.length);
+        for (uint256 i; i < strategies.length; i++) {
+            response[i] = 1000;
+        }
+        return response; // Return a dummy value for simplicity
+    }
+}
 
-// contract MockAVSDirectory {
-//     function registerOperatorToAVS(
-//         address,
-//         ISignatureUtils.SignatureWithSaltAndExpiry memory
-//     ) external pure {}
+contract MockAVSDirectory {
+    function registerOperatorToAVS(
+        address,
+        ISignatureUtils.SignatureWithSaltAndExpiry memory
+    ) external pure {}
 
-//     function deregisterOperatorFromAVS(address) external pure {}
+    function deregisterOperatorFromAVS(
+        address
+    ) external pure {}
 
-//     function updateAVSMetadataURI(string memory) external pure {}
-// }
+    function updateAVSMetadataURI(
+        string memory
+    ) external pure {}
+}
 
-// contract MockAllocationManager {}
+contract MockAllocationManager {
+    function setAVSRegistrar(address avs, address registrar) external {}
+}
 
-// contract MockRewardsCoordinator {
-//     function createAVSRewardsSubmission(
-//         address avs,
-//         IRewardsCoordinator.RewardsSubmission[] calldata
-//     ) external pure {}
-// }
+contract MockRewardsCoordinator {
+    function createAVSRewardsSubmission(
+        address avs,
+        IRewardsCoordinator.RewardsSubmission[] calldata
+    ) external pure {}
 
-// contract ECDSAServiceManagerSetup is Test {
-//     MockDelegationManager public mockDelegationManager;
-//     MockAVSDirectory public mockAVSDirectory;
-//     MockAllocationManager public mockAllocationManager;
-//     ECDSAStakeRegistryMock public mockStakeRegistry;
-//     MockRewardsCoordinator public mockRewardsCoordinator;
-//     ECDSAServiceManagerMock public serviceManager;
-//     address internal operator1;
-//     address internal operator2;
-//     uint256 internal operator1Pk;
-//     uint256 internal operator2Pk;
+    function createOperatorDirectedAVSRewardsSubmission(
+        address avs,
+        IRewardsCoordinator.OperatorDirectedRewardsSubmission[] calldata
+    ) external pure {}
 
-//     function setUp() public {
-//         mockDelegationManager = new MockDelegationManager();
-//         mockAVSDirectory = new MockAVSDirectory();
-//         mockAllocationManager = new MockAllocationManager();
-//         mockStakeRegistry = new ECDSAStakeRegistryMock(
-//             IDelegationManager(address(mockDelegationManager))
-//         );
-//         mockRewardsCoordinator = new MockRewardsCoordinator();
+    function setClaimerFor(
+        address claimer
+    ) external pure {}
+}
 
-//         serviceManager = new ECDSAServiceManagerMock(
-//             address(mockAVSDirectory),
-//             address(mockStakeRegistry),
-//             address(mockRewardsCoordinator),
-//             address(mockDelegationManager),
-//             address(mockAllocationManager)
-//         );
+contract ECDSAServiceManagerSetup is Test {
+    MockDelegationManager public mockDelegationManager;
+    MockAVSDirectory public mockAVSDirectory;
+    MockAllocationManager public mockAllocationManager;
+    ECDSAStakeRegistryMock public mockStakeRegistry;
+    MockRewardsCoordinator public mockRewardsCoordinator;
+    ECDSAServiceManagerMock public serviceManager;
+    address internal operator1;
+    address internal operator2;
+    uint256 internal operator1Pk;
+    uint256 internal operator2Pk;
 
-//         operator1Pk = 1;
-//         operator2Pk = 2;
-//         operator1 = vm.addr(operator1Pk);
-//         operator2 = vm.addr(operator2Pk);
+    function setUp() public {
+        mockDelegationManager = new MockDelegationManager();
+        mockAVSDirectory = new MockAVSDirectory();
+        mockAllocationManager = new MockAllocationManager();
+        mockStakeRegistry =
+            new ECDSAStakeRegistryMock(IDelegationManager(address(mockDelegationManager)));
+        mockRewardsCoordinator = new MockRewardsCoordinator();
 
-//         // Create a quorum
-//         IECDSAStakeRegistryTypes.Quorum memory quorum = IECDSAStakeRegistryTypes.Quorum({strategies: new StrategyParams[](2)});
-//         quorum.strategies[0] = StrategyParams({
-//             strategy: IStrategy(address(420)),
-//             multiplier: 5000
-//         });
-//         quorum.strategies[1] = StrategyParams({
-//             strategy: IStrategy(address(421)),
-//             multiplier: 5000
-//         });
-//         address[] memory operators = new address[](0);
+        serviceManager = new ECDSAServiceManagerMock(
+            address(mockAVSDirectory),
+            address(mockStakeRegistry),
+            address(mockRewardsCoordinator),
+            address(mockDelegationManager),
+            address(mockAllocationManager)
+        );
 
-//         vm.prank(mockStakeRegistry.owner());
-//         mockStakeRegistry.initialize(
-//             address(serviceManager),
-//             10_000, // Assuming a threshold weight of 10000 basis points
-//             quorum
-//         );
-//         ISignatureUtils.SignatureWithSaltAndExpiry memory dummySignature;
+        operator1Pk = 1;
+        operator2Pk = 2;
+        operator1 = vm.addr(operator1Pk);
+        operator2 = vm.addr(operator2Pk);
 
-//         vm.prank(operator1);
-//         mockStakeRegistry.registerOperatorWithSignature(
-//             dummySignature,
-//             operator1
-//         );
+        // Create a quorum
+        IECDSAStakeRegistryTypes.Quorum memory quorum = IECDSAStakeRegistryTypes.Quorum({
+            strategies: new IECDSAStakeRegistryTypes.StrategyParams[](2)
+        });
+        quorum.strategies[0] = IECDSAStakeRegistryTypes.StrategyParams({
+            strategy: IStrategy(address(420)),
+            multiplier: 5000
+        });
+        quorum.strategies[1] = IECDSAStakeRegistryTypes.StrategyParams({
+            strategy: IStrategy(address(421)),
+            multiplier: 5000
+        });
+        address[] memory operators = new address[](0);
 
-//         vm.prank(operator2);
-//         mockStakeRegistry.registerOperatorWithSignature(
-//             dummySignature,
-//             operator2
-//         );
-//     }
+        vm.prank(mockStakeRegistry.owner());
+        mockStakeRegistry.initialize(
+            address(serviceManager),
+            10000, // Assuming a threshold weight of 10000 basis points
+            quorum
+        );
+        ISignatureUtils.SignatureWithSaltAndExpiry memory dummySignature;
 
-//     function testRegisterOperatorToAVS() public {
-//         address operator = operator1;
-//         ISignatureUtils.SignatureWithSaltAndExpiry memory signature;
+        vm.prank(operator1);
+        mockStakeRegistry.registerOperatorWithSignature(dummySignature, operator1);
 
-//         vm.prank(address(mockStakeRegistry));
-//         serviceManager.registerOperatorToAVS(operator, signature);
-//     }
+        vm.prank(operator2);
+        mockStakeRegistry.registerOperatorWithSignature(dummySignature, operator2);
+    }
 
-//     function testDeregisterOperatorFromAVS() public {
-//         address operator = operator1;
+    function testRegisterOperatorToAVS() public {
+        address operator = operator1;
+        ISignatureUtils.SignatureWithSaltAndExpiry memory signature;
 
-//         vm.prank(address(mockStakeRegistry));
-//         serviceManager.deregisterOperatorFromAVS(operator);
-//     }
+        vm.prank(address(mockStakeRegistry));
+        serviceManager.registerOperatorToAVS(operator, signature);
+    }
 
-//     function testGetRestakeableStrategies() public {
-//         address[] memory strategies = serviceManager.getRestakeableStrategies();
-//     }
+    function testDeregisterOperatorFromAVS() public {
+        address operator = operator1;
 
-//     function testGetOperatorRestakedStrategies() public {
-//         address operator = operator1;
-//         address[] memory strategies = serviceManager
-//             .getOperatorRestakedStrategies(operator);
-//     }
+        vm.prank(address(mockStakeRegistry));
+        serviceManager.deregisterOperatorFromAVS(operator);
+    }
 
-//     function test_Regression_GetOperatorRestakedStrategies_NoShares() public {
-//         address operator = operator1;
-//         IStrategy[] memory strategies = new IStrategy[](2);
-//         strategies[0] = IStrategy(address(420));
-//         strategies[1] = IStrategy(address(421));
+    function testGetRestakeableStrategies() public {
+        address[] memory strategies = serviceManager.getRestakeableStrategies();
+    }
 
-//         uint96[] memory shares = new uint96[](2);
-//         shares[0] = 0;
-//         shares[1] = 1;
+    function testGetOperatorRestakedStrategies() public {
+        address operator = operator1;
+        address[] memory strategies = serviceManager.getOperatorRestakedStrategies(operator);
+    }
 
-//         vm.mockCall(
-//             address(mockDelegationManager),
-//             abi.encodeCall(
-//                 IDelegationManager.getOperatorShares,
-//                 (operator, strategies)
-//             ),
-//             abi.encode(shares)
-//         );
+    function test_Regression_GetOperatorRestakedStrategies_NoShares() public {
+        address operator = operator1;
+        IStrategy[] memory strategies = new IStrategy[](2);
+        strategies[0] = IStrategy(address(420));
+        strategies[1] = IStrategy(address(421));
 
-//         address[] memory restakedStrategies = serviceManager
-//             .getOperatorRestakedStrategies(operator);
-//         assertEq(
-//             restakedStrategies.length,
-//             1,
-//             "Expected no restaked strategies"
-//         );
-//     }
+        uint96[] memory shares = new uint96[](2);
+        shares[0] = 0;
+        shares[1] = 1;
 
-//     function testUpdateAVSMetadataURI() public {
-//         string memory newURI = "https://new-metadata-uri.com";
+        vm.mockCall(
+            address(mockDelegationManager),
+            abi.encodeCall(IDelegationManager.getOperatorShares, (operator, strategies)),
+            abi.encode(shares)
+        );
 
-//         vm.prank(mockStakeRegistry.owner());
-//         serviceManager.updateAVSMetadataURI(newURI);
-//     }
+        address[] memory restakedStrategies = serviceManager.getOperatorRestakedStrategies(operator);
+        assertEq(restakedStrategies.length, 1, "Expected no restaked strategies");
+    }
 
-//     function testCreateAVSRewardsSubmission() public {
-//         IRewardsCoordinator.RewardsSubmission[] memory submissions;
+    function testUpdateAVSMetadataURI() public {
+        string memory newURI = "https://new-metadata-uri.com";
 
-//         vm.prank(serviceManager.rewardsInitiator());
-//         serviceManager.createAVSRewardsSubmission(submissions);
-//     }
+        vm.prank(mockStakeRegistry.owner());
+        serviceManager.updateAVSMetadataURI(newURI);
+    }
 
-//     function testSetRewardsInitiator() public {
-//         address newInitiator = address(0x123);
+    // function testCreateAVSRewardsSubmission() public {
+    //     IRewardsCoordinator.RewardsSubmission[] memory submissions;
 
-//         vm.prank(mockStakeRegistry.owner());
-//         serviceManager.setRewardsInitiator(newInitiator);
-//     }
-// }
+    //     vm.prank(serviceManager.rewardsInitiator());
+    //     serviceManager.createAVSRewardsSubmission(submissions);
+    // }
+
+    function testSetRewardsInitiator() public {
+        address newInitiator = address(0x123);
+
+        vm.prank(mockStakeRegistry.owner());
+        serviceManager.setRewardsInitiator(newInitiator);
+    }
+
+    function testCreateOperatorDirectedAVSRewardsSubmission() public {
+        IRewardsCoordinator.OperatorDirectedRewardsSubmission[] memory submissions;
+
+        vm.prank(serviceManager.rewardsInitiator());
+        serviceManager.createOperatorDirectedAVSRewardsSubmission(submissions);
+    }
+
+    function testSetClaimerFor() public {
+        address claimer = address(0x123);
+
+        vm.prank(mockStakeRegistry.owner());
+        serviceManager.setClaimerFor(claimer);
+    }
+
+    function testSetAVSRegistrar() public {
+        address registrar = address(0x123);
+
+        vm.prank(mockStakeRegistry.owner());
+        serviceManager.setAVSRegistrar(IAVSRegistrar(registrar));
+    }
+}

--- a/test/unit/InstantSlasher.t.sol
+++ b/test/unit/InstantSlasher.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, console2 as console} from "forge-std/Test.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {InstantSlasher} from "../../src/slashers/InstantSlasher.sol";
 import {
@@ -165,6 +165,7 @@ contract InstantSlasherTest is Test {
         middlewareConfig.stakeRegistry.strategyParams = 0;
         middlewareConfig.stakeRegistry.delegationManager = coreDeployment.delegationManager;
         middlewareConfig.stakeRegistry.avsDirectory = coreDeployment.avsDirectory;
+        middlewareConfig.instantSlasher.slasher = slasher;
         {
             IStakeRegistryTypes.StrategyParams[] memory stratParams =
                 new IStakeRegistryTypes.StrategyParams[](1);
@@ -186,14 +187,6 @@ contract InstantSlasherTest is Test {
         );
         vm.stopPrank();
 
-        instantSlasher = InstantSlasher(middlewareDeployments.instantSlasher);
-        slashingRegistryCoordinator =
-            SlashingRegistryCoordinator(middlewareDeployments.slashingRegistryCoordinator);
-        stakeRegistry = StakeRegistry(middlewareDeployments.stakeRegistry);
-        blsApkRegistry = BLSApkRegistry(middlewareDeployments.blsApkRegistry);
-        indexRegistry = IndexRegistry(middlewareDeployments.indexRegistry);
-        socketRegistry = SocketRegistry(middlewareDeployments.socketRegistry);
-
         vm.startPrank(serviceManager);
         PermissionController(coreDeployment.permissionController).setAppointee(
             address(serviceManager),
@@ -202,11 +195,22 @@ contract InstantSlasherTest is Test {
             AllocationManager.slashOperator.selector
         );
 
+        slashingRegistryCoordinator =
+            SlashingRegistryCoordinator(middlewareDeployments.slashingRegistryCoordinator);
+        instantSlasher = InstantSlasher(middlewareDeployments.instantSlasher);
+
         PermissionController(coreDeployment.permissionController).setAppointee(
             address(serviceManager),
             address(slashingRegistryCoordinator),
             coreDeployment.allocationManager,
             AllocationManager.createOperatorSets.selector
+        );
+
+        PermissionController(coreDeployment.permissionController).setAppointee(
+            address(serviceManager),
+            address(instantSlasher),
+            coreDeployment.allocationManager,
+            AllocationManager.slashOperator.selector
         );
 
         vm.stopPrank();

--- a/test/unit/InstantSlasher.t.sol
+++ b/test/unit/InstantSlasher.t.sol
@@ -1,0 +1,454 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {InstantSlasher} from "../../src/slashers/InstantSlasher.sol";
+import {
+    IAllocationManager,
+    IAllocationManagerTypes
+} from "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IAVSRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IAVSRegistrar.sol";
+import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
+import {IRegistryCoordinator} from "../../src/interfaces/IRegistryCoordinator.sol";
+import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
+import {ISlasher, ISlasherTypes, ISlasherErrors} from "../../src/interfaces/ISlasher.sol";
+import {ISlashingRegistryCoordinator} from "../../src/interfaces/ISlashingRegistryCoordinator.sol";
+import {IStakeRegistry, IStakeRegistryTypes} from "../../src/interfaces/IStakeRegistry.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {TransparentUpgradeableProxy} from
+    "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {EmptyContract} from "eigenlayer-contracts/src/test/mocks/EmptyContract.sol";
+import {AllocationManager} from "eigenlayer-contracts/src/contracts/core/AllocationManager.sol";
+import {PermissionController} from
+    "eigenlayer-contracts/src/contracts/permissions/PermissionController.sol";
+import {PauserRegistry} from "eigenlayer-contracts/src/contracts/permissions/PauserRegistry.sol";
+import {IPauserRegistry} from "eigenlayer-contracts/src/contracts/interfaces/IPauserRegistry.sol";
+import {IDelegationManager} from
+    "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
+import {IStrategyManager} from "eigenlayer-contracts/src/contracts/interfaces/IStrategyManager.sol";
+import {DelegationMock} from "../mocks/DelegationMock.sol";
+import {SlashingRegistryCoordinator} from "../../src/SlashingRegistryCoordinator.sol";
+import {ISlashingRegistryCoordinatorTypes} from
+    "../../src/interfaces/ISlashingRegistryCoordinator.sol";
+import {IBLSApkRegistry, IBLSApkRegistryTypes} from "../../src/interfaces/IBLSApkRegistry.sol";
+import {IIndexRegistry} from "../../src/interfaces/IIndexRegistry.sol";
+import {ISocketRegistry} from "../../src/interfaces/ISocketRegistry.sol";
+import {CoreDeploymentLib} from "../utils/CoreDeployLib.sol";
+import {
+    OperatorWalletLib,
+    Operator,
+    Wallet,
+    BLSWallet,
+    SigningKeyOperationsLib
+} from "../utils/OperatorWalletLib.sol";
+import {OperatorSet} from "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/ERC20Mock.sol";
+import {StrategyFactory} from "eigenlayer-contracts/src/contracts/strategies/StrategyFactory.sol";
+import {StakeRegistry} from "../../src/StakeRegistry.sol";
+import {BLSApkRegistry} from "../../src/BLSApkRegistry.sol";
+import {IndexRegistry} from "../../src/IndexRegistry.sol";
+import {SocketRegistry} from "../../src/SocketRegistry.sol";
+
+contract InstantSlasherTest is Test {
+    InstantSlasher public instantSlasher;
+    InstantSlasher public instantSlasherImplementation;
+    ProxyAdmin public proxyAdmin;
+    EmptyContract public emptyContract;
+    SlashingRegistryCoordinator public slashingRegistryCoordinator;
+    SlashingRegistryCoordinator public slashingRegistryCoordinatorImplementation;
+    CoreDeploymentLib.DeploymentData public coreDeployment;
+    PauserRegistry public pauserRegistry;
+    ERC20Mock public mockToken;
+    StrategyFactory public strategyFactory;
+    StakeRegistry public stakeRegistry;
+    BLSApkRegistry public blsApkRegistry;
+    IndexRegistry public indexRegistry;
+    SocketRegistry public socketRegistry;
+
+    address public slasher;
+    address public serviceManager;
+    Operator public operatorWallet;
+    IStrategy public mockStrategy;
+    address public proxyAdminOwner = address(uint160(uint256(keccak256("proxyAdminOwner"))));
+    address public pauser = address(uint160(uint256(keccak256("pauser"))));
+    address public unpauser = address(uint160(uint256(keccak256("unpauser"))));
+    address public churnApprover = address(uint160(uint256(keccak256("churnApprover"))));
+    address public ejector = address(uint160(uint256(keccak256("ejector"))));
+
+    uint32 constant DEALLOCATION_DELAY = 7 days;
+    uint32 constant ALLOCATION_CONFIGURATION_DELAY = 1 days;
+
+    function setUp() public {
+        serviceManager = address(0x2);
+        slasher = address(0x3);
+        operatorWallet = OperatorWalletLib.createOperator("operator");
+
+        mockToken = new ERC20Mock("Mock Token", "MOCK", address(this), 0);
+
+        vm.startPrank(proxyAdminOwner);
+        proxyAdmin = new ProxyAdmin();
+        emptyContract = new EmptyContract();
+
+        address[] memory pausers = new address[](1);
+        pausers[0] = pauser;
+        pauserRegistry = new PauserRegistry(pausers, unpauser);
+
+        CoreDeploymentLib.DeploymentConfigData memory configData;
+        configData.strategyManager.initialOwner = proxyAdminOwner;
+        configData.strategyManager.initialStrategyWhitelister = proxyAdminOwner;
+        configData.strategyManager.initPausedStatus = 0;
+
+        configData.delegationManager.initialOwner = proxyAdminOwner;
+        configData.delegationManager.minWithdrawalDelayBlocks = 50400;
+        configData.delegationManager.initPausedStatus = 0;
+
+        configData.eigenPodManager.initialOwner = proxyAdminOwner;
+        configData.eigenPodManager.initPausedStatus = 0;
+
+        configData.allocationManager.initialOwner = proxyAdminOwner;
+        configData.allocationManager.deallocationDelay = DEALLOCATION_DELAY;
+        configData.allocationManager.allocationConfigurationDelay = ALLOCATION_CONFIGURATION_DELAY;
+        configData.allocationManager.initPausedStatus = 0;
+
+        configData.strategyFactory.initialOwner = proxyAdminOwner;
+        configData.strategyFactory.initPausedStatus = 0;
+
+        configData.avsDirectory.initialOwner = proxyAdminOwner;
+        configData.avsDirectory.initPausedStatus = 0;
+
+        configData.rewardsCoordinator.initialOwner = proxyAdminOwner;
+        configData.rewardsCoordinator.rewardsUpdater =
+            address(0x14dC79964da2C08b23698B3D3cc7Ca32193d9955);
+        configData.rewardsCoordinator.initPausedStatus = 0;
+        configData.rewardsCoordinator.activationDelay = 0;
+        configData.rewardsCoordinator.defaultSplitBips = 1000;
+        configData.rewardsCoordinator.calculationIntervalSeconds = 86400;
+        configData.rewardsCoordinator.maxRewardsDuration = 864000;
+        configData.rewardsCoordinator.maxRetroactiveLength = 86400;
+        configData.rewardsCoordinator.maxFutureLength = 86400;
+        configData.rewardsCoordinator.genesisRewardsTimestamp = 1672531200;
+
+        configData.ethPOSDeposit.ethPOSDepositAddress = address(0x123);
+
+        coreDeployment = CoreDeploymentLib.deployContracts(address(proxyAdmin), configData);
+
+        address strategyManagerOwner = Ownable(coreDeployment.strategyManager).owner();
+        vm.stopPrank();
+
+        vm.startPrank(strategyManagerOwner);
+        IStrategyManager(coreDeployment.strategyManager).setStrategyWhitelister(
+            coreDeployment.strategyFactory
+        );
+        vm.stopPrank();
+
+        vm.startPrank(proxyAdminOwner);
+        mockStrategy = IStrategy(
+            StrategyFactory(coreDeployment.strategyFactory).deployNewStrategy(
+                IERC20(address(mockToken))
+            )
+        );
+
+        // Deploy empty proxies for all registries
+        stakeRegistry = StakeRegistry(
+            address(
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
+            )
+        );
+
+        blsApkRegistry = BLSApkRegistry(
+            address(
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
+            )
+        );
+
+        indexRegistry = IndexRegistry(
+            address(
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
+            )
+        );
+
+        socketRegistry = SocketRegistry(
+            address(
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
+            )
+        );
+
+        slashingRegistryCoordinatorImplementation = new SlashingRegistryCoordinator(
+            IStakeRegistry(address(stakeRegistry)),
+            IBLSApkRegistry(address(blsApkRegistry)),
+            IIndexRegistry(address(indexRegistry)),
+            ISocketRegistry(address(socketRegistry)),
+            IAllocationManager(coreDeployment.allocationManager),
+            IPauserRegistry(address(pauserRegistry))
+        );
+
+        slashingRegistryCoordinator = SlashingRegistryCoordinator(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(slashingRegistryCoordinatorImplementation), address(proxyAdmin), ""
+                )
+            )
+        );
+
+        // Deploy registry implementations pointing to the coordinator
+        StakeRegistry stakeRegistryImplementation = new StakeRegistry(
+            ISlashingRegistryCoordinator(address(slashingRegistryCoordinator)),
+            IDelegationManager(coreDeployment.delegationManager),
+            IAVSDirectory(coreDeployment.avsDirectory),
+            IAllocationManager(coreDeployment.allocationManager)
+        );
+        BLSApkRegistry blsApkRegistryImplementation =
+            new BLSApkRegistry(ISlashingRegistryCoordinator(address(slashingRegistryCoordinator)));
+        IndexRegistry indexRegistryImplementation =
+            new IndexRegistry(ISlashingRegistryCoordinator(address(slashingRegistryCoordinator)));
+        SocketRegistry socketRegistryImplementation =
+            new SocketRegistry(IRegistryCoordinator(address(slashingRegistryCoordinator)));
+
+        // Upgrade all registry proxies
+        proxyAdmin.upgrade(
+            TransparentUpgradeableProxy(payable(address(stakeRegistry))),
+            address(stakeRegistryImplementation)
+        );
+        proxyAdmin.upgrade(
+            TransparentUpgradeableProxy(payable(address(blsApkRegistry))),
+            address(blsApkRegistryImplementation)
+        );
+        proxyAdmin.upgrade(
+            TransparentUpgradeableProxy(payable(address(indexRegistry))),
+            address(indexRegistryImplementation)
+        );
+        proxyAdmin.upgrade(
+            TransparentUpgradeableProxy(payable(address(socketRegistry))),
+            address(socketRegistryImplementation)
+        );
+
+        // Initialize the SlashingRegistryCoordinator first
+        slashingRegistryCoordinator.initialize(
+            proxyAdminOwner, churnApprover, ejector, 0, serviceManager
+        );
+
+        vm.stopPrank();
+
+        instantSlasherImplementation = new InstantSlasher(
+            IAllocationManager(coreDeployment.allocationManager),
+            ISlashingRegistryCoordinator(slashingRegistryCoordinator),
+            slasher
+        );
+
+        vm.startPrank(proxyAdminOwner);
+        instantSlasher = InstantSlasher(
+            address(
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
+            )
+        );
+
+        proxyAdmin.upgrade(
+            TransparentUpgradeableProxy(payable(address(instantSlasher))),
+            address(instantSlasherImplementation)
+        );
+        vm.stopPrank();
+
+        instantSlasher.initialize(slasher);
+
+        vm.startPrank(serviceManager);
+        PermissionController(coreDeployment.permissionController).setAppointee(
+            address(serviceManager),
+            address(instantSlasher),
+            coreDeployment.allocationManager,
+            AllocationManager.slashOperator.selector
+        );
+
+        PermissionController(coreDeployment.permissionController).setAppointee(
+            address(serviceManager),
+            address(slashingRegistryCoordinator),
+            coreDeployment.allocationManager,
+            AllocationManager.createOperatorSets.selector
+        );
+
+        vm.stopPrank();
+
+        uint8 quorumNumber = 0;
+        IStrategy[] memory strategies = new IStrategy[](1);
+        strategies[0] = mockStrategy;
+
+        uint96[] memory minimumStakes = new uint96[](1);
+        minimumStakes[0] = 1 ether;
+
+        IStakeRegistryTypes.StrategyParams[] memory strategyParams =
+            new IStakeRegistryTypes.StrategyParams[](1);
+        strategyParams[0] =
+            IStakeRegistryTypes.StrategyParams({strategy: mockStrategy, multiplier: 1 ether});
+
+        ISlashingRegistryCoordinatorTypes.OperatorSetParam memory operatorSetParams =
+        ISlashingRegistryCoordinatorTypes.OperatorSetParam({
+            maxOperatorCount: 10,
+            kickBIPsOfOperatorStake: 0,
+            kickBIPsOfTotalStake: 0
+        });
+
+        vm.startPrank(proxyAdminOwner);
+        slashingRegistryCoordinator.createSlashableStakeQuorum(
+            operatorSetParams, 1 ether, strategyParams, 0
+        );
+        vm.stopPrank();
+
+        vm.label(address(instantSlasher), "InstantSlasher Proxy");
+        vm.label(address(instantSlasherImplementation), "InstantSlasher Implementation");
+        vm.label(address(slashingRegistryCoordinator), "SlashingRegistryCoordinator Proxy");
+        vm.label(
+            address(slashingRegistryCoordinatorImplementation),
+            "SlashingRegistryCoordinator Implementation"
+        );
+        vm.label(address(proxyAdmin), "ProxyAdmin");
+        vm.label(coreDeployment.allocationManager, "AllocationManager Proxy");
+    }
+
+    function test_initialization() public {
+        assertEq(instantSlasher.slasher(), slasher);
+    }
+
+    function _createMockSlashingParams()
+        internal
+        view
+        returns (IAllocationManagerTypes.SlashingParams memory)
+    {
+        IStrategy[] memory strategies = new IStrategy[](1);
+        strategies[0] = mockStrategy;
+
+        uint256[] memory wadsToSlash = new uint256[](1);
+        wadsToSlash[0] = 0.5e18; // 50% slash
+
+        return IAllocationManagerTypes.SlashingParams({
+            operator: operatorWallet.key.addr,
+            operatorSetId: 1,
+            strategies: strategies,
+            wadsToSlash: wadsToSlash,
+            description: "Test slashing"
+        });
+    }
+
+    function test_fulfillSlashingRequest_revert_notSlasher() public {
+        IAllocationManagerTypes.SlashingParams memory params = _createMockSlashingParams();
+        vm.expectRevert(ISlasherErrors.OnlySlasher.selector);
+        instantSlasher.fulfillSlashingRequest(params);
+    }
+
+    function test_fulfillSlashingRequest() public {
+        vm.skip(false);
+        vm.startPrank(operatorWallet.key.addr);
+        IDelegationManager(coreDeployment.delegationManager).registerAsOperator(
+            address(0), 1, "metadata"
+        );
+
+        // Mint tokens and deposit into strategy
+        uint256 depositAmount = 1 ether;
+        mockToken.mint(operatorWallet.key.addr, depositAmount);
+        mockToken.approve(address(coreDeployment.strategyManager), depositAmount);
+        IStrategyManager(coreDeployment.strategyManager).depositIntoStrategy(
+            mockStrategy, mockToken, depositAmount
+        );
+
+        // Set allocation delay
+        uint32 minDelay = 1;
+        IAllocationManager(coreDeployment.allocationManager).setAllocationDelay(
+            operatorWallet.key.addr, minDelay
+        );
+        vm.stopPrank();
+
+        // Assert operator has allocation delay set
+        (bool isSet,) = IAllocationManager(coreDeployment.allocationManager).getAllocationDelay(
+            operatorWallet.key.addr
+        );
+        assertFalse(isSet, "Operator allocation delay not set");
+
+        vm.roll(block.number + ALLOCATION_CONFIGURATION_DELAY + 1);
+
+        // Set up allocation parameters
+        IStrategy[] memory allocStrategies = new IStrategy[](1);
+        allocStrategies[0] = mockStrategy;
+
+        uint64[] memory magnitudes = new uint64[](1);
+        magnitudes[0] = uint64(1 ether); // Allocate full magnitude
+
+        OperatorSet memory operatorSet = OperatorSet({avs: address(serviceManager), id: 0});
+
+        vm.startPrank(serviceManager);
+        IAllocationManagerTypes.CreateSetParams[] memory createParams =
+            new IAllocationManagerTypes.CreateSetParams[](1);
+        createParams[0] =
+            IAllocationManagerTypes.CreateSetParams({operatorSetId: 0, strategies: allocStrategies});
+        IAllocationManager(coreDeployment.allocationManager).setAVSRegistrar(
+            address(serviceManager), IAVSRegistrar(address(slashingRegistryCoordinator))
+        );
+        vm.stopPrank();
+
+        vm.startPrank(operatorWallet.key.addr);
+
+        IAllocationManagerTypes.AllocateParams[] memory allocParams =
+            new IAllocationManagerTypes.AllocateParams[](1);
+        allocParams[0] = IAllocationManagerTypes.AllocateParams({
+            operatorSet: operatorSet,
+            strategies: allocStrategies,
+            newMagnitudes: magnitudes
+        });
+
+        IAllocationManager(coreDeployment.allocationManager).modifyAllocations(
+            operatorWallet.key.addr, allocParams
+        );
+        vm.roll(block.number + 100);
+
+        uint32[] memory operatorSetIds = new uint32[](1);
+        operatorSetIds[0] = 0;
+        // Create BLS signing key params
+        bytes32 messageHash = slashingRegistryCoordinator.calculatePubkeyRegistrationMessageHash(
+            operatorWallet.key.addr
+        );
+        IBLSApkRegistryTypes.PubkeyRegistrationParams memory pubkeyParams = IBLSApkRegistryTypes
+            .PubkeyRegistrationParams({
+            pubkeyRegistrationSignature: SigningKeyOperationsLib.sign(
+                operatorWallet.signingKey, messageHash
+            ),
+            pubkeyG1: operatorWallet.signingKey.publicKeyG1,
+            pubkeyG2: operatorWallet.signingKey.publicKeyG2
+        });
+
+        // Encode registration data with socket and pubkey params
+        bytes memory registrationData = abi.encode(
+            ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, "socket", pubkeyParams
+        );
+
+        IAllocationManagerTypes.RegisterParams memory registerParams = IAllocationManagerTypes
+            .RegisterParams({
+            avs: address(serviceManager),
+            operatorSetIds: operatorSetIds,
+            data: registrationData
+        });
+        IAllocationManager(coreDeployment.allocationManager).registerForOperatorSets(
+            operatorWallet.key.addr, registerParams
+        );
+        vm.stopPrank();
+
+        vm.roll(block.number + 100);
+
+        // Create slashing params
+        IAllocationManagerTypes.SlashingParams memory params = IAllocationManagerTypes
+            .SlashingParams({
+            operator: operatorWallet.key.addr,
+            operatorSetId: 0,
+            strategies: allocStrategies,
+            wadsToSlash: new uint256[](allocStrategies.length),
+            description: "Test slashing"
+        });
+
+        // Set each wad to slash to 1e18 (100% slash)
+        for (uint256 i = 0; i < params.wadsToSlash.length; i++) {
+            params.wadsToSlash[i] = 1e18;
+        }
+
+        // Execute slashing
+        vm.prank(slasher);
+        instantSlasher.fulfillSlashingRequest(params);
+    }
+}

--- a/test/unit/InstantSlasher.t.sol
+++ b/test/unit/InstantSlasher.t.sol
@@ -50,14 +50,13 @@ import {StakeRegistry} from "../../src/StakeRegistry.sol";
 import {BLSApkRegistry} from "../../src/BLSApkRegistry.sol";
 import {IndexRegistry} from "../../src/IndexRegistry.sol";
 import {SocketRegistry} from "../../src/SocketRegistry.sol";
+import {MiddlewareDeployLib} from "../utils/MiddlewareDeployLib.sol";
 
 contract InstantSlasherTest is Test {
     InstantSlasher public instantSlasher;
-    InstantSlasher public instantSlasherImplementation;
     ProxyAdmin public proxyAdmin;
     EmptyContract public emptyContract;
     SlashingRegistryCoordinator public slashingRegistryCoordinator;
-    SlashingRegistryCoordinator public slashingRegistryCoordinatorImplementation;
     CoreDeploymentLib.DeploymentData public coreDeployment;
     PauserRegistry public pauserRegistry;
     ERC20Mock public mockToken;
@@ -149,108 +148,51 @@ contract InstantSlasherTest is Test {
                 IERC20(address(mockToken))
             )
         );
-
-        // Deploy empty proxies for all registries
-        stakeRegistry = StakeRegistry(
-            address(
-                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
-            )
-        );
-
-        blsApkRegistry = BLSApkRegistry(
-            address(
-                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
-            )
-        );
-
-        indexRegistry = IndexRegistry(
-            address(
-                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
-            )
-        );
-
-        socketRegistry = SocketRegistry(
-            address(
-                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
-            )
-        );
-
-        slashingRegistryCoordinatorImplementation = new SlashingRegistryCoordinator(
-            IStakeRegistry(address(stakeRegistry)),
-            IBLSApkRegistry(address(blsApkRegistry)),
-            IIndexRegistry(address(indexRegistry)),
-            ISocketRegistry(address(socketRegistry)),
-            IAllocationManager(coreDeployment.allocationManager),
-            IPauserRegistry(address(pauserRegistry))
-        );
-
-        slashingRegistryCoordinator = SlashingRegistryCoordinator(
-            address(
-                new TransparentUpgradeableProxy(
-                    address(slashingRegistryCoordinatorImplementation), address(proxyAdmin), ""
-                )
-            )
-        );
-
-        // Deploy registry implementations pointing to the coordinator
-        StakeRegistry stakeRegistryImplementation = new StakeRegistry(
-            ISlashingRegistryCoordinator(address(slashingRegistryCoordinator)),
-            IDelegationManager(coreDeployment.delegationManager),
-            IAVSDirectory(coreDeployment.avsDirectory),
-            IAllocationManager(coreDeployment.allocationManager)
-        );
-        BLSApkRegistry blsApkRegistryImplementation =
-            new BLSApkRegistry(ISlashingRegistryCoordinator(address(slashingRegistryCoordinator)));
-        IndexRegistry indexRegistryImplementation =
-            new IndexRegistry(ISlashingRegistryCoordinator(address(slashingRegistryCoordinator)));
-        SocketRegistry socketRegistryImplementation =
-            new SocketRegistry(IRegistryCoordinator(address(slashingRegistryCoordinator)));
-
-        // Upgrade all registry proxies
-        proxyAdmin.upgrade(
-            TransparentUpgradeableProxy(payable(address(stakeRegistry))),
-            address(stakeRegistryImplementation)
-        );
-        proxyAdmin.upgrade(
-            TransparentUpgradeableProxy(payable(address(blsApkRegistry))),
-            address(blsApkRegistryImplementation)
-        );
-        proxyAdmin.upgrade(
-            TransparentUpgradeableProxy(payable(address(indexRegistry))),
-            address(indexRegistryImplementation)
-        );
-        proxyAdmin.upgrade(
-            TransparentUpgradeableProxy(payable(address(socketRegistry))),
-            address(socketRegistryImplementation)
-        );
-
-        // Initialize the SlashingRegistryCoordinator first
-        slashingRegistryCoordinator.initialize(
-            proxyAdminOwner, churnApprover, ejector, 0, serviceManager
-        );
-
         vm.stopPrank();
 
-        instantSlasherImplementation = new InstantSlasher(
-            IAllocationManager(coreDeployment.allocationManager),
-            ISlashingRegistryCoordinator(slashingRegistryCoordinator),
-            slasher
-        );
+        MiddlewareDeployLib.MiddlewareDeployConfig memory middlewareConfig;
+        middlewareConfig.instantSlasher.initialOwner = proxyAdminOwner;
+        middlewareConfig.instantSlasher.slasher = slasher;
+        middlewareConfig.slashingRegistryCoordinator.initialOwner = proxyAdminOwner;
+        middlewareConfig.slashingRegistryCoordinator.churnApprover = churnApprover;
+        middlewareConfig.slashingRegistryCoordinator.ejector = ejector;
+        middlewareConfig.slashingRegistryCoordinator.initPausedStatus = 0;
+        middlewareConfig.slashingRegistryCoordinator.serviceManager = serviceManager;
+        middlewareConfig.socketRegistry.initialOwner = proxyAdminOwner;
+        middlewareConfig.indexRegistry.initialOwner = proxyAdminOwner;
+        middlewareConfig.stakeRegistry.initialOwner = proxyAdminOwner;
+        middlewareConfig.stakeRegistry.minimumStake = 1 ether;
+        middlewareConfig.stakeRegistry.strategyParams = 0;
+        middlewareConfig.stakeRegistry.delegationManager = coreDeployment.delegationManager;
+        middlewareConfig.stakeRegistry.avsDirectory = coreDeployment.avsDirectory;
+        {
+            IStakeRegistryTypes.StrategyParams[] memory stratParams =
+                new IStakeRegistryTypes.StrategyParams[](1);
+            stratParams[0] =
+                IStakeRegistryTypes.StrategyParams({strategy: mockStrategy, multiplier: 1 ether});
+            middlewareConfig.stakeRegistry.strategyParamsArray = stratParams;
+        }
+        middlewareConfig.stakeRegistry.lookAheadPeriod = 0;
+        middlewareConfig.stakeRegistry.stakeType = IStakeRegistryTypes.StakeType(1);
+        middlewareConfig.blsApkRegistry.initialOwner = proxyAdminOwner;
 
         vm.startPrank(proxyAdminOwner);
-        instantSlasher = InstantSlasher(
-            address(
-                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
-            )
-        );
-
-        proxyAdmin.upgrade(
-            TransparentUpgradeableProxy(payable(address(instantSlasher))),
-            address(instantSlasherImplementation)
+        MiddlewareDeployLib.MiddlewareDeployData memory middlewareDeployments = MiddlewareDeployLib
+            .deployMiddleware(
+            address(proxyAdmin),
+            coreDeployment.allocationManager,
+            address(pauserRegistry),
+            middlewareConfig
         );
         vm.stopPrank();
 
-        instantSlasher.initialize(slasher);
+        instantSlasher = InstantSlasher(middlewareDeployments.instantSlasher);
+        slashingRegistryCoordinator =
+            SlashingRegistryCoordinator(middlewareDeployments.slashingRegistryCoordinator);
+        stakeRegistry = StakeRegistry(middlewareDeployments.stakeRegistry);
+        blsApkRegistry = BLSApkRegistry(middlewareDeployments.blsApkRegistry);
+        indexRegistry = IndexRegistry(middlewareDeployments.indexRegistry);
+        socketRegistry = SocketRegistry(middlewareDeployments.socketRegistry);
 
         vm.startPrank(serviceManager);
         PermissionController(coreDeployment.permissionController).setAppointee(
@@ -295,12 +237,7 @@ contract InstantSlasherTest is Test {
         vm.stopPrank();
 
         vm.label(address(instantSlasher), "InstantSlasher Proxy");
-        vm.label(address(instantSlasherImplementation), "InstantSlasher Implementation");
         vm.label(address(slashingRegistryCoordinator), "SlashingRegistryCoordinator Proxy");
-        vm.label(
-            address(slashingRegistryCoordinatorImplementation),
-            "SlashingRegistryCoordinator Implementation"
-        );
         vm.label(address(proxyAdmin), "ProxyAdmin");
         vm.label(coreDeployment.allocationManager, "AllocationManager Proxy");
     }

--- a/test/unit/OperatorStateRetrieverUnit.t.sol
+++ b/test/unit/OperatorStateRetrieverUnit.t.sol
@@ -649,4 +649,82 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
             }
         }
     }
+
+    function test_getBatchOperatorId_emptyArray() public {
+        address[] memory operators = new address[](0);
+        bytes32[] memory operatorIds =
+            operatorStateRetriever.getBatchOperatorId(registryCoordinator, operators);
+        assertEq(operatorIds.length, 0, "Should return empty array for empty input");
+    }
+
+    function test_getBatchOperatorId_unregisteredOperators() public {
+        address[] memory operators = new address[](2);
+        operators[0] = address(1);
+        operators[1] = address(2);
+
+        bytes32[] memory operatorIds =
+            operatorStateRetriever.getBatchOperatorId(registryCoordinator, operators);
+
+        assertEq(operatorIds.length, 2, "Should return array of same length as input");
+        assertEq(operatorIds[0], bytes32(0), "Unregistered operator should return 0");
+        assertEq(operatorIds[1], bytes32(0), "Unregistered operator should return 0");
+    }
+
+    function test_getBatchOperatorId_mixedRegistration() public {
+        // Register one operator
+        cheats.roll(registrationBlockNumber);
+        _registerOperatorWithCoordinator(defaultOperator, 1, defaultPubKey);
+
+        // Create test array with one registered and one unregistered operator
+        address[] memory operators = new address[](2);
+        operators[0] = defaultOperator;
+        operators[1] = address(2); // unregistered
+
+        bytes32[] memory operatorIds =
+            operatorStateRetriever.getBatchOperatorId(registryCoordinator, operators);
+
+        assertEq(operatorIds.length, 2, "Should return array of same length as input");
+        assertEq(
+            operatorIds[0], defaultOperatorId, "Should return correct ID for registered operator"
+        );
+        assertEq(operatorIds[1], bytes32(0), "Should return 0 for unregistered operator");
+    }
+
+    function test_getBatchOperatorFromId_emptyArray() public {
+        bytes32[] memory operatorIds = new bytes32[](0);
+        address[] memory operators =
+            operatorStateRetriever.getBatchOperatorFromId(registryCoordinator, operatorIds);
+        assertEq(operators.length, 0, "Should return empty array for empty input");
+    }
+
+    function test_getBatchOperatorFromId_unregisteredIds() public {
+        bytes32[] memory operatorIds = new bytes32[](2);
+        operatorIds[0] = bytes32(uint256(1));
+        operatorIds[1] = bytes32(uint256(2));
+
+        address[] memory operators =
+            operatorStateRetriever.getBatchOperatorFromId(registryCoordinator, operatorIds);
+
+        assertEq(operators.length, 2, "Should return array of same length as input");
+        assertEq(operators[0], address(0), "Unregistered ID should return address(0)");
+        assertEq(operators[1], address(0), "Unregistered ID should return address(0)");
+    }
+
+    function test_getBatchOperatorFromId_mixedRegistration() public {
+        // Register one operator
+        cheats.roll(registrationBlockNumber);
+        _registerOperatorWithCoordinator(defaultOperator, 1, defaultPubKey);
+
+        // Create test array with one registered and one unregistered operator ID
+        bytes32[] memory operatorIds = new bytes32[](2);
+        operatorIds[0] = defaultOperatorId;
+        operatorIds[1] = bytes32(uint256(2)); // unregistered
+
+        address[] memory operators =
+            operatorStateRetriever.getBatchOperatorFromId(registryCoordinator, operatorIds);
+
+        assertEq(operators.length, 2, "Should return array of same length as input");
+        assertEq(operators[0], defaultOperator, "Should return correct address for registered ID");
+        assertEq(operators[1], address(0), "Should return address(0) for unregistered ID");
+    }
 }

--- a/test/unit/RegistryCoordinatorUnit.t.sol
+++ b/test/unit/RegistryCoordinatorUnit.t.sol
@@ -8,6 +8,12 @@ import {
     ISlashingRegistryCoordinatorErrors
 } from "../../src/interfaces/ISlashingRegistryCoordinator.sol";
 
+import {
+    IRegistryCoordinator,
+    IRegistryCoordinatorTypes,
+    IRegistryCoordinatorErrors
+} from "../../src/interfaces/IRegistryCoordinator.sol";
+
 import {IBLSApkRegistryTypes} from "../../src/interfaces/IBLSApkRegistry.sol";
 import {QuorumBitmapHistoryLib} from "../../src/libraries/QuorumBitmapHistoryLib.sol";
 import {BitmapUtils} from "../../src/libraries/BitmapUtils.sol";
@@ -302,7 +308,7 @@ contract RegistryCoordinatorUnitTests_RegisterOperator is RegistryCoordinatorUni
 
         quorumNumbersTooLarge[0] = 0xC0;
 
-        cheats.expectRevert(BitmapUtils.BitmapValueTooLarge.selector);
+        cheats.expectRevert(IRegistryCoordinatorErrors.OnlyM2QuorumsAllowed.selector);
         cheats.prank(defaultOperator);
         registryCoordinator.registerOperator(
             quorumNumbersTooLarge, defaultSocket, pubkeyRegistrationParams, emptySig
@@ -317,7 +323,7 @@ contract RegistryCoordinatorUnitTests_RegisterOperator is RegistryCoordinatorUni
         quorumNumbersNotCreated[0] = 0x0B;
 
         cheats.prank(defaultOperator);
-        cheats.expectRevert(BitmapUtils.BitmapValueTooLarge.selector);
+        cheats.expectRevert(IRegistryCoordinatorErrors.OnlyM2QuorumsAllowed.selector);
         registryCoordinator.registerOperator(
             quorumNumbersNotCreated, defaultSocket, pubkeyRegistrationParams, emptySig
         );
@@ -395,6 +401,8 @@ contract RegistryCoordinatorUnitTests_RegisterOperator is RegistryCoordinatorUni
 
         cheats.expectEmit(true, true, true, true, address(registryCoordinator));
         emit OperatorSocketUpdate(defaultOperatorId, defaultSocket);
+        cheats.expectEmit(true, true, true, true, address(registryCoordinator));
+        emit OperatorRegistered(defaultOperator, defaultOperatorId);
         cheats.expectEmit(true, true, true, true, address(blsApkRegistry));
         emit OperatorAddedToQuorums(defaultOperator, defaultOperatorId, quorumNumbers);
         for (uint256 i = 0; i < quorumNumbers.length; i++) {
@@ -405,8 +413,6 @@ contract RegistryCoordinatorUnitTests_RegisterOperator is RegistryCoordinatorUni
             cheats.expectEmit(true, true, true, true, address(indexRegistry));
             emit QuorumIndexUpdate(defaultOperatorId, uint8(quorumNumbers[i]), 0);
         }
-        cheats.expectEmit(true, true, true, true, address(registryCoordinator));
-        emit OperatorRegistered(defaultOperator, defaultOperatorId);
 
         uint256 gasBefore = gasleft();
         cheats.prank(defaultOperator);
@@ -636,6 +642,8 @@ contract RegistryCoordinatorUnitTests_RegisterOperator is RegistryCoordinatorUni
 
         cheats.expectEmit(true, true, true, true, address(registryCoordinator));
         emit OperatorSocketUpdate(defaultOperatorId, defaultSocket);
+        cheats.expectEmit(true, true, true, true, address(registryCoordinator));
+        emit OperatorRegistered(defaultOperator, defaultOperatorId);
         cheats.expectEmit(true, true, true, true, address(blsApkRegistry));
         emit OperatorAddedToQuorums(defaultOperator, defaultOperatorId, quorumNumbers);
         cheats.expectEmit(true, true, true, true, address(stakeRegistry));
@@ -688,10 +696,6 @@ contract RegistryCoordinatorUnitTests_DeregisterOperator_EjectOperator is
     }
 
     function test_deregisterOperator_revert_notRegistered() public {
-        // enable operatorSets
-        cheats.prank(registryCoordinator.owner());
-        registryCoordinator.enableOperatorSets();
-
         bytes memory quorumNumbers = new bytes(1);
         quorumNumbers[0] = bytes1(defaultQuorumNumber);
 
@@ -701,10 +705,6 @@ contract RegistryCoordinatorUnitTests_DeregisterOperator_EjectOperator is
     }
 
     function test_deregisterOperator_revert_incorrectQuorums() public {
-        // enable operatorSets
-        cheats.prank(registryCoordinator.owner());
-        registryCoordinator.enableOperatorSets();
-
         console.log("quorumCount", registryCoordinator.quorumCount());
 
         assertTrue(
@@ -1714,6 +1714,9 @@ contract RegistryCoordinatorUnitTests_RegisterOperatorWithChurn is RegistryCoord
         cheats.expectEmit(true, true, true, true, address(registryCoordinator));
         emit OperatorSocketUpdate(operatorToRegisterId, defaultSocket);
 
+        cheats.expectEmit(true, true, true, true, address(registryCoordinator));
+        emit OperatorRegistered(operatorToRegister, operatorToRegisterId);
+
         cheats.expectEmit(true, true, true, true, address(blsApkRegistry));
         emit OperatorAddedToQuorums(operatorToRegister, operatorToRegisterId, quorumNumbers);
         cheats.expectEmit(true, true, true, false, address(stakeRegistry));
@@ -1732,8 +1735,6 @@ contract RegistryCoordinatorUnitTests_RegisterOperatorWithChurn is RegistryCoord
         emit OperatorStakeUpdate(operatorToKickId, defaultQuorumNumber, 0);
         cheats.expectEmit(true, true, true, true, address(indexRegistry));
         emit QuorumIndexUpdate(operatorToRegisterId, defaultQuorumNumber, numOperators - 1);
-        cheats.expectEmit(true, true, true, true, address(registryCoordinator));
-        emit OperatorRegistered(operatorToRegister, operatorToRegisterId);
 
         {
             ISignatureUtils.SignatureWithSaltAndExpiry memory emptyAVSRegSig;
@@ -2401,30 +2402,19 @@ contract RegistryCoordinatorUnitTests_BeforeMigration is RegistryCoordinatorUnit
         });
         uint32 lookAheadPeriod = 100;
 
+        assertEq(registryCoordinator.quorumCount(), 0, "No quorums should exist before");
+
         // Attempt to create quorum with slashable stake type before enabling operator sets
         cheats.prank(registryCoordinatorOwner);
-        cheats.expectRevert();
         registryCoordinator.createSlashableStakeQuorum(
             operatorSetParams, minimumStake, strategyParams, lookAheadPeriod
         );
-    }
-
-    function test_MigrateToOperatorSets() public {
-        _deployMockEigenLayerAndAVS(0);
-        cheats.prank(registryCoordinatorOwner);
-        registryCoordinator.enableOperatorSets();
-        assertTrue(registryCoordinator.operatorSetsEnabled());
+        assertEq(registryCoordinator.quorumCount(), 1, "New quorum 0 should be created");
+        assertFalse(registryCoordinator.isM2Quorum(0), "Quorum created should not be an M2 quorum");
     }
 }
 
 contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitTests {
-    function test_MigrateToOperatorSets() public {
-        cheats.prank(registryCoordinatorOwner);
-        registryCoordinator.enableOperatorSets();
-        assertTrue(registryCoordinator.operatorSetsEnabled());
-    }
-
-    ///
     function test_M2_Deregister() public {
         _deployMockEigenLayerAndAVS(2);
 
@@ -2467,10 +2457,6 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
             operatorSignature
         );
 
-        /// migrate to operator sets
-        vm.prank(registryCoordinatorOwner);
-        registryCoordinator.enableOperatorSets();
-
         /// Deregistration for m2 should for the first two operator sets
         vm.prank(operatorToRegister.key.addr);
         registryCoordinator.deregisterOperator(new bytes(1));
@@ -2491,9 +2477,6 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
     }
 
     function test_M2_Register_Reverts() public {
-        cheats.prank(registryCoordinatorOwner);
-        registryCoordinator.enableOperatorSets();
-
         bytes memory quorumNumbers = new bytes(1);
         quorumNumbers[0] = bytes1(uint8(0));
         IBLSApkRegistryTypes.PubkeyRegistrationParams memory params;
@@ -2508,10 +2491,6 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
     function test_createSlashableStakeQuorum() public {
         // Deploy with 0 quorums
         _deployMockEigenLayerAndAVS(0);
-
-        // Enable operator sets first
-        cheats.prank(registryCoordinatorOwner);
-        registryCoordinator.enableOperatorSets();
 
         // Create quorum params
         ISlashingRegistryCoordinatorTypes.OperatorSetParam memory operatorSetParams =
@@ -2538,10 +2517,6 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
         // Deploy with 0 quorums
         _deployMockEigenLayerAndAVS(0);
 
-        // Enable operator sets first
-        cheats.prank(registryCoordinatorOwner);
-        registryCoordinator.enableOperatorSets();
-
         // Create quorum params
         ISlashingRegistryCoordinatorTypes.OperatorSetParam memory operatorSetParams =
         ISlashingRegistryCoordinatorTypes.OperatorSetParam({
@@ -2566,10 +2541,6 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
         vm.skip(true);
 
         _deployMockEigenLayerAndAVS(0);
-
-        // Enable operator sets first
-        cheats.prank(registryCoordinatorOwner);
-        registryCoordinator.enableOperatorSets();
 
         // Create quorum params
         ISlashingRegistryCoordinatorTypes.OperatorSetParam memory operatorSetParams =
@@ -2612,9 +2583,6 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
     function test_registerHook_WithChurn() public {
         vm.skip(true);
         _deployMockEigenLayerAndAVS(0);
-        // Enable operator sets first
-        cheats.prank(registryCoordinatorOwner);
-        registryCoordinator.enableOperatorSets();
 
         // Create quorum params
         ISlashingRegistryCoordinatorTypes.OperatorSetParam memory operatorSetParams =
@@ -2698,9 +2666,6 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
 
     function test_deregisterHook() public {
         _deployMockEigenLayerAndAVS(0);
-        // Enable operator sets first
-        cheats.prank(registryCoordinatorOwner);
-        registryCoordinator.enableOperatorSets();
 
         // Create quorum params
         ISlashingRegistryCoordinatorTypes.OperatorSetParam memory operatorSetParams =
@@ -2748,10 +2713,6 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
     function test_registerHook_Reverts_WhenNotALM() public {
         _deployMockEigenLayerAndAVS(0);
 
-        // Enable operator sets first
-        cheats.prank(registryCoordinatorOwner);
-        registryCoordinator.enableOperatorSets();
-
         // Create quorum params
         ISlashingRegistryCoordinatorTypes.OperatorSetParam memory operatorSetParams =
         ISlashingRegistryCoordinatorTypes.OperatorSetParam({
@@ -2793,12 +2754,6 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
     function test_deregisterHook_Reverts_WhenNotALM() public {
         _deployMockEigenLayerAndAVS(0);
 
-        // Enable operator sets first
-        cheats.prank(registryCoordinatorOwner);
-        registryCoordinator.enableOperatorSets();
-
-        assertTrue(registryCoordinator.operatorSetsEnabled(), "operatorSetsEnabled should be true");
-
         // Create quorum params
         ISlashingRegistryCoordinatorTypes.OperatorSetParam memory operatorSetParams =
         ISlashingRegistryCoordinatorTypes.OperatorSetParam({
@@ -2816,6 +2771,9 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
         // Create total delegated stake quorum
         cheats.prank(registryCoordinatorOwner);
         registryCoordinator.createTotalDelegatedStakeQuorum(operatorSetParams, 0, strategyParams);
+
+        // operator sets should be enabled after creating a new quorum
+        assertTrue(registryCoordinator.operatorSetsEnabled(), "operatorSetsEnabled should be true");
 
         // Prank as allocation manager and call register hook
         uint32[] memory operatorSetIds = new uint32[](1);

--- a/test/unit/RegistryCoordinatorUnit.t.sol
+++ b/test/unit/RegistryCoordinatorUnit.t.sol
@@ -12,6 +12,12 @@ import {IBLSApkRegistryTypes} from "../../src/interfaces/IBLSApkRegistry.sol";
 import {QuorumBitmapHistoryLib} from "../../src/libraries/QuorumBitmapHistoryLib.sol";
 import {BitmapUtils} from "../../src/libraries/BitmapUtils.sol";
 import {console} from "forge-std/console.sol";
+import {
+    OperatorWalletLib,
+    SigningKeyOperationsLib,
+    OperatorKeyOperationsLib,
+    Operator
+} from "../utils/OperatorWalletLib.sol";
 
 contract RegistryCoordinatorUnitTests is MockAVSDeployer {
     using BN254 for BN254.G1Point;
@@ -2418,52 +2424,68 @@ contract RegistryCoordinatorUnitTests_AfterMigration is RegistryCoordinatorUnitT
         assertTrue(registryCoordinator.operatorSetsEnabled());
     }
 
+    ///
     function test_M2_Deregister() public {
-        vm.skip(true);
-        /// Create 2 M2 quorums
         _deployMockEigenLayerAndAVS(2);
 
-        address operatorToRegister = address(420);
+        Operator memory operatorToRegister = OperatorWalletLib.createOperator("4");
 
-        ISignatureUtils.SignatureWithSaltAndExpiry memory emptySignature = ISignatureUtils
-            .SignatureWithSaltAndExpiry({signature: new bytes(0), salt: bytes32(0), expiry: 0});
+        /// NOTE: resolves stack too deep
+        {
+            // Set operator shares for quorum 0
+            (IStrategy strategy,) = stakeRegistry.strategyParams(0, 0);
+            delegationMock.setOperatorShares(operatorToRegister.key.addr, strategy, 1 ether);
+        }
+        bytes32 salt = bytes32(uint256(1));
+        uint256 expiry = block.timestamp + 1 days;
+        bytes32 digestHash = avsDirectory.calculateOperatorAVSRegistrationDigestHash(
+            operatorToRegister.key.addr, address(registryCoordinator), salt, expiry
+        );
+        bytes memory signature = OperatorKeyOperationsLib.sign(operatorToRegister.key, digestHash);
+        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = ISignatureUtils
+            .SignatureWithSaltAndExpiry({signature: signature, salt: salt, expiry: expiry});
 
+        bytes32 messageHash =
+            registryCoordinator.calculatePubkeyRegistrationMessageHash(operatorToRegister.key.addr);
         IBLSApkRegistryTypes.PubkeyRegistrationParams memory operatorRegisterApkParams =
         IBLSApkRegistryTypes.PubkeyRegistrationParams({
-            pubkeyRegistrationSignature: BN254.G1Point({X: 0, Y: 0}),
-            pubkeyG1: BN254.G1Point({X: 0, Y: 0}),
-            pubkeyG2: BN254.G2Point({X: [uint256(0), uint256(0)], Y: [uint256(0), uint256(0)]})
+            pubkeyRegistrationSignature: SigningKeyOperationsLib.sign(
+                operatorToRegister.signingKey, messageHash
+            ),
+            pubkeyG1: operatorToRegister.signingKey.publicKeyG1,
+            pubkeyG2: operatorToRegister.signingKey.publicKeyG2
         });
 
         string memory socket = "socket";
 
         // register for quorum 0
-        vm.prank(operatorToRegister);
+        vm.prank(operatorToRegister.key.addr);
         registryCoordinator.registerOperator(
             new bytes(1), // Convert 0 to bytes1 first
             socket,
             operatorRegisterApkParams,
-            emptySignature
+            operatorSignature
         );
 
         /// migrate to operator sets
+        vm.prank(registryCoordinatorOwner);
         registryCoordinator.enableOperatorSets();
 
         /// Deregistration for m2 should for the first two operator sets
-        vm.prank(defaultOperator);
+        vm.prank(operatorToRegister.key.addr);
         registryCoordinator.deregisterOperator(new bytes(1));
 
         // Verify operator was deregistered by checking their bitmap is empty
-        bytes32 operatorId = registryCoordinator.getOperatorId(operatorToRegister);
+        bytes32 operatorId = registryCoordinator.getOperatorId(operatorToRegister.key.addr);
         uint192 bitmap = registryCoordinator.getCurrentQuorumBitmap(operatorId);
         assertEq(bitmap, 0, "Operator bitmap should be empty after deregistration");
 
         // Verify operator status is NEVER_REGISTERED
         ISlashingRegistryCoordinatorTypes.OperatorStatus status =
-            registryCoordinator.getOperatorStatus(operatorToRegister);
+            registryCoordinator.getOperatorStatus(operatorToRegister.key.addr);
         assertEq(
             uint8(status),
-            uint8(ISlashingRegistryCoordinatorTypes.OperatorStatus.NEVER_REGISTERED),
+            uint8(ISlashingRegistryCoordinatorTypes.OperatorStatus.DEREGISTERED),
             "Operator status should be NEVER_REGISTERED"
         );
     }

--- a/test/unit/ServiceManagerBase.t.sol
+++ b/test/unit/ServiceManagerBase.t.sol
@@ -15,6 +15,11 @@ import {IStrategyManager} from "eigenlayer-contracts/src/contracts/interfaces/IS
 import {IServiceManagerBaseEvents} from "../events/IServiceManagerBaseEvents.sol";
 import {IServiceManagerErrors} from "../../src/interfaces/IServiceManager.sol";
 
+import {
+    IAllocationManagerTypes,
+    IAllocationManager
+} from "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+
 import "../utils/MockAVSDeployer.sol";
 
 contract ServiceManagerBase_UnitTests is MockAVSDeployer, IServiceManagerBaseEvents {
@@ -543,5 +548,384 @@ contract ServiceManagerBase_UnitTests is MockAVSDeployer, IServiceManagerBaseEve
         cheats.expectRevert("Ownable: caller is not the owner");
         cheats.prank(caller);
         serviceManager.setRewardsInitiator(newRewardsInitiator);
+    }
+
+    function testFuzz_addPendingAdmin(
+        address admin
+    ) public filterFuzzedAddressInputs(admin) {
+        // Mock the expected call to permissionController
+        cheats.expectCall(
+            address(permissionControllerMock),
+            abi.encodeCall(PermissionController.addPendingAdmin, (address(serviceManager), admin))
+        );
+
+        // Call should only work from owner
+        cheats.prank(serviceManagerOwner);
+        serviceManager.addPendingAdmin(admin);
+    }
+
+    function testFuzz_addPendingAdmin_revert_notOwner(
+        address admin,
+        address caller
+    ) public filterFuzzedAddressInputs(admin) filterFuzzedAddressInputs(caller) {
+        cheats.assume(caller != serviceManagerOwner);
+
+        cheats.expectRevert("Ownable: caller is not the owner");
+        cheats.prank(caller);
+        serviceManager.addPendingAdmin(admin);
+    }
+
+    function testFuzz_removePendingAdmin(
+        address pendingAdmin
+    ) public filterFuzzedAddressInputs(pendingAdmin) {
+        // Mock the expected call to permissionController
+        cheats.expectCall(
+            address(permissionControllerMock),
+            abi.encodeCall(
+                PermissionController.removePendingAdmin, (address(serviceManager), pendingAdmin)
+            )
+        );
+
+        // Call should only work from owner
+        cheats.prank(serviceManagerOwner);
+        serviceManager.removePendingAdmin(pendingAdmin);
+    }
+
+    function testFuzz_removePendingAdmin_revert_notOwner(
+        address pendingAdmin,
+        address caller
+    ) public filterFuzzedAddressInputs(pendingAdmin) filterFuzzedAddressInputs(caller) {
+        cheats.assume(caller != serviceManagerOwner);
+
+        cheats.expectRevert("Ownable: caller is not the owner");
+        cheats.prank(caller);
+        serviceManager.removePendingAdmin(pendingAdmin);
+    }
+
+    function testFuzz_removeAdmin(
+        address admin
+    ) public filterFuzzedAddressInputs(admin) {
+        // Mock the expected call to permissionController
+        cheats.expectCall(
+            address(permissionControllerMock),
+            abi.encodeCall(PermissionController.removeAdmin, (address(serviceManager), admin))
+        );
+
+        // Call should only work from owner
+        cheats.prank(serviceManagerOwner);
+        serviceManager.removeAdmin(admin);
+    }
+
+    function testFuzz_removeAdmin_revert_notOwner(
+        address admin,
+        address caller
+    ) public filterFuzzedAddressInputs(admin) filterFuzzedAddressInputs(caller) {
+        cheats.assume(caller != serviceManagerOwner);
+
+        cheats.expectRevert("Ownable: caller is not the owner");
+        cheats.prank(caller);
+        serviceManager.removeAdmin(admin);
+    }
+
+    function testFuzz_removeAppointee(
+        address appointee,
+        address target,
+        bytes4 selector
+    ) public filterFuzzedAddressInputs(appointee) filterFuzzedAddressInputs(target) {
+        // Mock the expected call to permissionController
+        cheats.expectCall(
+            address(permissionControllerMock),
+            abi.encodeCall(
+                PermissionController.removeAppointee,
+                (address(serviceManager), appointee, target, selector)
+            )
+        );
+
+        // Call should only work from owner
+        cheats.prank(serviceManagerOwner);
+        serviceManager.removeAppointee(appointee, target, selector);
+    }
+
+    function testFuzz_removeAppointee_revert_notOwner(
+        address appointee,
+        address target,
+        bytes4 selector,
+        address caller
+    )
+        public
+        filterFuzzedAddressInputs(appointee)
+        filterFuzzedAddressInputs(target)
+        filterFuzzedAddressInputs(caller)
+    {
+        cheats.assume(caller != serviceManagerOwner);
+
+        cheats.expectRevert("Ownable: caller is not the owner");
+        cheats.prank(caller);
+        serviceManager.removeAppointee(appointee, target, selector);
+    }
+
+    function testFuzz_createOperatorDirectedAVSRewardsSubmission_Revert_WhenNotOwner(
+        address caller
+    ) public filterFuzzedAddressInputs(caller) {
+        cheats.assume(caller != rewardsInitiator);
+        IRewardsCoordinatorTypes.OperatorDirectedRewardsSubmission[] memory rewardsSubmissions;
+
+        cheats.prank(caller);
+        cheats.expectRevert(IServiceManagerErrors.OnlyRewardsInitiator.selector);
+        serviceManager.createOperatorDirectedAVSRewardsSubmission(rewardsSubmissions);
+    }
+
+    function test_createOperatorDirectedAVSRewardsSubmission_Revert_WhenERC20NotApproved() public {
+        IERC20 token = new ERC20PresetFixedSupply(
+            "dog wif hat", "MOCK1", mockTokenInitialSupply, rewardsInitiator
+        );
+
+        IRewardsCoordinatorTypes.OperatorReward[] memory operatorRewards =
+            new IRewardsCoordinatorTypes.OperatorReward[](1);
+        operatorRewards[0] =
+            IRewardsCoordinatorTypes.OperatorReward({operator: address(0x1), amount: 100});
+
+        IRewardsCoordinatorTypes.OperatorDirectedRewardsSubmission[] memory rewardsSubmissions =
+            new IRewardsCoordinatorTypes.OperatorDirectedRewardsSubmission[](1);
+        rewardsSubmissions[0] = IRewardsCoordinatorTypes.OperatorDirectedRewardsSubmission({
+            strategiesAndMultipliers: defaultStrategyAndMultipliers,
+            token: token,
+            operatorRewards: operatorRewards,
+            startTimestamp: uint32(block.timestamp),
+            duration: uint32(1 weeks),
+            description: "Test Rewards"
+        });
+
+        cheats.prank(rewardsInitiator);
+        cheats.expectRevert("ERC20: insufficient allowance");
+        serviceManager.createOperatorDirectedAVSRewardsSubmission(rewardsSubmissions);
+    }
+
+    function testFuzz_createOperatorDirectedAVSRewardsSubmission_SingleSubmission(
+        uint256 startTimestamp,
+        uint256 duration,
+        uint256 amount
+    ) public {
+        // 1. Bound fuzz inputs to valid ranges and amounts
+        IERC20 rewardToken = new ERC20PresetFixedSupply(
+            "dog wif hat", "MOCK1", mockTokenInitialSupply, rewardsInitiator
+        );
+        amount = bound(amount, 1, MAX_REWARDS_AMOUNT);
+        duration = bound(duration, 0, MAX_REWARDS_DURATION);
+        duration = duration - (duration % CALCULATION_INTERVAL_SECONDS);
+        startTimestamp = bound(
+            startTimestamp,
+            uint256(
+                _maxTimestamp(
+                    GENESIS_REWARDS_TIMESTAMP, uint32(block.timestamp) - MAX_RETROACTIVE_LENGTH
+                )
+            ) + CALCULATION_INTERVAL_SECONDS - 1,
+            block.timestamp + uint256(MAX_FUTURE_LENGTH)
+        );
+        startTimestamp = startTimestamp - (startTimestamp % CALCULATION_INTERVAL_SECONDS);
+
+        vm.warp(startTimestamp + duration + 1);
+
+        // 2. Create reward submission input param
+        // Create operator rewards array
+        IRewardsCoordinatorTypes.OperatorReward[] memory operatorRewards =
+            new IRewardsCoordinatorTypes.OperatorReward[](1);
+        operatorRewards[0] =
+            IRewardsCoordinatorTypes.OperatorReward({operator: address(0x1), amount: amount});
+
+        // Create rewards submission
+        IRewardsCoordinatorTypes.OperatorDirectedRewardsSubmission[] memory rewardsSubmissions =
+            new IRewardsCoordinatorTypes.OperatorDirectedRewardsSubmission[](1);
+        rewardsSubmissions[0] = IRewardsCoordinatorTypes.OperatorDirectedRewardsSubmission({
+            strategiesAndMultipliers: defaultStrategyAndMultipliers,
+            token: rewardToken,
+            operatorRewards: operatorRewards,
+            startTimestamp: uint32(startTimestamp),
+            duration: uint32(duration),
+            description: "Test Rewards"
+        });
+
+        // 3. Approve serviceManager for ERC20
+        cheats.startPrank(rewardsInitiator);
+        rewardToken.approve(address(serviceManager), amount);
+
+        // 4. call createAVSRewardsSubmission() with expected event emitted
+        uint256 rewardsInitiatorBalanceBefore = rewardToken.balanceOf(address(rewardsInitiator));
+        uint256 rewardsCoordinatorBalanceBefore = rewardToken.balanceOf(address(rewardsCoordinator));
+
+        rewardToken.approve(address(rewardsCoordinator), amount);
+        uint256 currSubmissionNonce = rewardsCoordinator.submissionNonce(address(serviceManager));
+        bytes32 avsSubmissionHash = keccak256(
+            abi.encode(address(serviceManager), currSubmissionNonce, rewardsSubmissions[0])
+        );
+
+        // cheats.expectEmit(true, true, true, true, address(rewardsCoordinator));
+        // emit AVSRewardsSubmissionCreated(
+        //     address(serviceManager), currSubmissionNonce, avsSubmissionHash, rewardsSubmissions[0]
+        // );
+        serviceManager.createOperatorDirectedAVSRewardsSubmission(rewardsSubmissions);
+        cheats.stopPrank();
+
+        assertTrue(
+            rewardsCoordinator.isOperatorDirectedAVSRewardsSubmissionHash(
+                address(serviceManager), avsSubmissionHash
+            ),
+            "reward submission hash not submitted"
+        );
+        assertEq(
+            currSubmissionNonce + 1,
+            rewardsCoordinator.submissionNonce(address(serviceManager)),
+            "submission nonce not incremented"
+        );
+        assertEq(
+            rewardsInitiatorBalanceBefore - amount,
+            rewardToken.balanceOf(rewardsInitiator),
+            "rewardsInitiator balance not decremented by amount of reward submission"
+        );
+        assertEq(
+            rewardsCoordinatorBalanceBefore + amount,
+            rewardToken.balanceOf(address(rewardsCoordinator)),
+            "RewardsCoordinator balance not incremented by amount of reward submission"
+        );
+    }
+
+    function testFuzz_createOperatorDirectedAVSRewardsSubmission_MultipleSubmissions(
+        uint256 startTimestamp,
+        uint256 duration,
+        uint256 amount,
+        uint256 numSubmissions
+    ) public {
+        numSubmissions = bound(numSubmissions, 2, 10);
+        cheats.prank(rewardsCoordinator.owner());
+
+        IRewardsCoordinator.OperatorDirectedRewardsSubmission[] memory rewardsSubmissions =
+            new IRewardsCoordinator.OperatorDirectedRewardsSubmission[](numSubmissions);
+        bytes32[] memory avsSubmissionHashes = new bytes32[](numSubmissions);
+        uint256 startSubmissionNonce = rewardsCoordinator.submissionNonce(address(serviceManager));
+        _deployMockRewardTokens(rewardsInitiator, numSubmissions);
+
+        uint256[] memory avsBalancesBefore = _getBalanceForTokens(rewardTokens, rewardsInitiator);
+        uint256[] memory rewardsCoordinatorBalancesBefore =
+            _getBalanceForTokens(rewardTokens, address(rewardsCoordinator));
+        // uint256[] memory amounts = new uint256[](numSubmissions);
+
+        uint256 latestStartTimestamp = 0;
+        uint256 longestDuration = 0;
+
+        // Create multiple rewards submissions and their expected event
+        for (uint256 i = 0; i < numSubmissions; ++i) {
+            // 1. Bound fuzz inputs to valid ranges and amounts using randSeed for each
+            amount = bound(amount + i, 1, MAX_REWARDS_AMOUNT);
+            // amounts[i] = amount;
+            duration = bound(duration + i, 0, MAX_REWARDS_DURATION);
+            duration = duration - (duration % CALCULATION_INTERVAL_SECONDS);
+            startTimestamp = bound(
+                startTimestamp + i,
+                uint256(
+                    _maxTimestamp(
+                        GENESIS_REWARDS_TIMESTAMP, uint32(block.timestamp) - MAX_RETROACTIVE_LENGTH
+                    )
+                ) + CALCULATION_INTERVAL_SECONDS - 1,
+                block.timestamp - 1 // Must be in past for operator directed rewards
+            );
+            startTimestamp = startTimestamp - (startTimestamp % CALCULATION_INTERVAL_SECONDS);
+
+            // loop and find the latest startTimestamp and the longest duration, then warp start + duration + 1
+
+            if (startTimestamp > latestStartTimestamp) {
+                latestStartTimestamp = startTimestamp;
+            }
+            if (duration > longestDuration) {
+                longestDuration = duration;
+            }
+
+            // 2. Create reward submission input param
+            IRewardsCoordinatorTypes.OperatorReward[] memory operatorRewards =
+                new IRewardsCoordinatorTypes.OperatorReward[](1);
+            operatorRewards[0] =
+                IRewardsCoordinatorTypes.OperatorReward({operator: address(0x1), amount: amount});
+
+            IRewardsCoordinatorTypes.OperatorDirectedRewardsSubmission memory rewardsSubmission =
+            IRewardsCoordinatorTypes.OperatorDirectedRewardsSubmission({
+                strategiesAndMultipliers: defaultStrategyAndMultipliers,
+                token: rewardTokens[i],
+                operatorRewards: operatorRewards,
+                startTimestamp: uint32(startTimestamp),
+                duration: uint32(duration),
+                description: "Test Rewards"
+            });
+            rewardsSubmissions[i] = rewardsSubmission;
+
+            // 3. expected event emitted for this rewardsSubmission
+            avsSubmissionHashes[i] = keccak256(
+                abi.encode(address(serviceManager), startSubmissionNonce + i, rewardsSubmissions[i])
+            );
+        }
+
+        vm.warp(latestStartTimestamp + longestDuration + 1);
+
+        // 4. call createOperatorDirectedAVSRewardsSubmission()
+        cheats.prank(rewardsInitiator);
+        serviceManager.createOperatorDirectedAVSRewardsSubmission(rewardsSubmissions);
+
+        // 5. Check for submissionNonce() and avsSubmissionHashes being set
+        assertEq(
+            startSubmissionNonce + numSubmissions,
+            rewardsCoordinator.submissionNonce(address(serviceManager)),
+            "avs submission nonce not incremented properly"
+        );
+
+        for (uint256 i = 0; i < numSubmissions; ++i) {
+            assertTrue(
+                rewardsCoordinator.isOperatorDirectedAVSRewardsSubmissionHash(
+                    address(serviceManager), avsSubmissionHashes[i]
+                ),
+                "rewards submission hash not submitted"
+            );
+            // assertEq(
+            //     avsBalancesBefore[i] - amounts[i],
+            //     rewardTokens[i].balanceOf(rewardsInitiator),
+            //     "AVS balance not decremented by amount of rewards submission"
+            // );
+            // assertEq(
+            //     rewardsCoordinatorBalancesBefore[i] + amounts[i],
+            //     rewardTokens[i].balanceOf(address(rewardsCoordinator)),
+            //     "RewardsCoordinator balance not incremented by amount of rewards submission"
+            // );
+        }
+    }
+
+    function testFuzz_deregisterOperatorFromOperatorSets(
+        address operator,
+        uint32[] memory operatorSetIds
+    ) public {
+        // Mock the expected call to allocationManager
+        IAllocationManagerTypes.DeregisterParams memory expectedParams = IAllocationManagerTypes
+            .DeregisterParams({
+            operator: operator,
+            avs: address(serviceManager),
+            operatorSetIds: operatorSetIds
+        });
+
+        cheats.expectCall(
+            address(allocationManagerMock),
+            abi.encodeCall(IAllocationManager.deregisterFromOperatorSets, (expectedParams))
+        );
+
+        // Call should only work from registryCoordinator
+        cheats.prank(address(registryCoordinatorImplementation));
+        serviceManager.deregisterOperatorFromOperatorSets(operator, operatorSetIds);
+    }
+
+    function testFuzz_deregisterOperatorFromOperatorSets_revert_notRegistryCoordinator(
+        address operator,
+        uint32[] memory operatorSetIds,
+        address caller
+    ) public filterFuzzedAddressInputs(caller) {
+        cheats.assume(caller != address(registryCoordinatorImplementation));
+
+        cheats.prank(caller);
+        cheats.expectRevert(IServiceManagerErrors.OnlyRegistryCoordinator.selector);
+        serviceManager.deregisterOperatorFromOperatorSets(operator, operatorSetIds);
     }
 }

--- a/test/unit/SocketRegistryUnit.t.sol
+++ b/test/unit/SocketRegistryUnit.t.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.12;
 
 import {SocketRegistry} from "../../src/SocketRegistry.sol";
+import {ISocketRegistry, ISocketRegistryErrors} from "../../src/interfaces/ISocketRegistry.sol";
 import {IRegistryCoordinator} from "../../src/interfaces/IRegistryCoordinator.sol";
 import "../utils/MockAVSDeployer.sol";
 
@@ -19,9 +20,7 @@ contract SocketRegistryUnitTests is MockAVSDeployer {
 
     function test_setOperatorSocket_revert_notSlashingRegistryCoordinator() public {
         vm.startPrank(address(0));
-        vm.expectRevert(
-            "SocketRegistry.onlySlashingRegistryCoordinator: caller is not the SlashingRegistryCoordinator"
-        );
+        vm.expectRevert(ISocketRegistryErrors.OnlySlashingRegistryCoordinator.selector);
         socketRegistry.setOperatorSocket(defaultOperatorId, "testSocket");
     }
 }

--- a/test/unit/SocketRegistryUnit.t.sol
+++ b/test/unit/SocketRegistryUnit.t.sol
@@ -2,14 +2,37 @@
 
 pragma solidity ^0.8.12;
 
-import {SocketRegistry} from "../../src/SocketRegistry.sol";
+import {SocketRegistry, ISlashingRegistryCoordinator} from "../../src/SocketRegistry.sol";
 import {ISocketRegistry, ISocketRegistryErrors} from "../../src/interfaces/ISocketRegistry.sol";
 import {IRegistryCoordinator} from "../../src/interfaces/IRegistryCoordinator.sol";
 import "../utils/MockAVSDeployer.sol";
 
+interface IOwnable {
+    function owner() external view returns (address);
+}
+
+contract MockSocketRegistry is SocketRegistry {
+    constructor(
+        ISlashingRegistryCoordinator _slashingRegistryCoordinator
+    ) SocketRegistry(_slashingRegistryCoordinator) {}
+
+    function onlyCoordinatorOwnerFn() external view onlyCoordinatorOwner {}
+}
+
 contract SocketRegistryUnitTests is MockAVSDeployer {
     function setUp() public virtual {
         _deployMockEigenLayerAndAVS();
+    }
+
+    function testFuzz_revert_onlyCoordinatorOwner(
+        address caller
+    ) public {
+        MockSocketRegistry _socketRegistry = new MockSocketRegistry(registryCoordinator);
+
+        vm.prank(caller);
+        vm.assume(caller != IOwnable(address(registryCoordinator)).owner());
+        vm.expectRevert(ISocketRegistryErrors.OnlySlashingRegistryCoordinatorOwner.selector);
+        _socketRegistry.onlyCoordinatorOwnerFn();
     }
 
     function test_setOperatorSocket() public {

--- a/test/unit/SocketRegistryUnit.t.sol
+++ b/test/unit/SocketRegistryUnit.t.sol
@@ -17,10 +17,10 @@ contract SocketRegistryUnitTests is MockAVSDeployer {
         assertEq(socketRegistry.getOperatorSocket(defaultOperatorId), "testSocket");
     }
 
-    function test_setOperatorSocket_revert_notRegistryCoordinator() public {
+    function test_setOperatorSocket_revert_notSlashingRegistryCoordinator() public {
         vm.startPrank(address(0));
         vm.expectRevert(
-            "SocketRegistry.onlyRegistryCoordinator: caller is not the RegistryCoordinator"
+            "SocketRegistry.onlySlashingRegistryCoordinator: caller is not the SlashingRegistryCoordinator"
         );
         socketRegistry.setOperatorSocket(defaultOperatorId, "testSocket");
     }

--- a/test/unit/SocketRegistryUnit.t.sol
+++ b/test/unit/SocketRegistryUnit.t.sol
@@ -11,28 +11,9 @@ interface IOwnable {
     function owner() external view returns (address);
 }
 
-contract MockSocketRegistry is SocketRegistry {
-    constructor(
-        ISlashingRegistryCoordinator _slashingRegistryCoordinator
-    ) SocketRegistry(_slashingRegistryCoordinator) {}
-
-    function onlyCoordinatorOwnerFn() external view onlyCoordinatorOwner {}
-}
-
 contract SocketRegistryUnitTests is MockAVSDeployer {
     function setUp() public virtual {
         _deployMockEigenLayerAndAVS();
-    }
-
-    function testFuzz_revert_onlyCoordinatorOwner(
-        address caller
-    ) public {
-        MockSocketRegistry _socketRegistry = new MockSocketRegistry(registryCoordinator);
-
-        vm.prank(caller);
-        vm.assume(caller != IOwnable(address(registryCoordinator)).owner());
-        vm.expectRevert(ISocketRegistryErrors.OnlySlashingRegistryCoordinatorOwner.selector);
-        _socketRegistry.onlyCoordinatorOwnerFn();
     }
 
     function test_setOperatorSocket() public {

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -1059,6 +1059,57 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
             assertEq(multiplier, newMultipliers[i], "invalid multiplier");
         }
     }
+
+    /**
+     *
+     *                         setSlashableStakeLookahead
+     *
+     */
+    function testFuzz_setSlashableStakeLookahead_Revert_WhenNotRegistryCoordinatorOwner(
+        uint8 quorumNumber,
+        uint32 lookAheadBlocks
+    ) public {
+        cheats.expectRevert(IStakeRegistryErrors.OnlySlashingRegistryCoordinatorOwner.selector);
+        stakeRegistry.setSlashableStakeLookahead(quorumNumber, lookAheadBlocks);
+    }
+
+    function testFuzz_setSlashableStakeLookahead_Revert_WhenQuorumDoesNotExist(
+        uint8 quorumNumber,
+        uint32 lookAheadBlocks
+    ) public {
+        // quorums [0,nextQuorum) are initialized, so use an invalid quorumNumber
+        cheats.assume(quorumNumber >= nextQuorum);
+        cheats.expectRevert(IStakeRegistryErrors.QuorumDoesNotExist.selector);
+        cheats.prank(registryCoordinatorOwner);
+        stakeRegistry.setSlashableStakeLookahead(quorumNumber, lookAheadBlocks);
+    }
+
+    function testFuzz_setSlashableStakeLookahead_Revert_WhenQourumNotSlashable(
+        uint8 quorumNumber,
+        uint32 lookAheadBlocks
+    ) public {
+        cheats.expectRevert(IStakeRegistryErrors.QuorumNotSlashable.selector);
+        cheats.prank(registryCoordinatorOwner);
+        stakeRegistry.setSlashableStakeLookahead(quorumNumber, lookAheadBlocks);
+    }
+
+    /// @dev Fuzzes initialized quorum numbers and stake look aheads
+    function testFuzz_setSlashableStakeLookahead(
+        uint8 quorumNumber,
+        uint32 lookAheadBlocks
+    ) public {
+        cheats.prank(registryCoordinatorOwner);
+        // quorums [0,nextQuorum) are initialized, so use an invalid quorumNumber
+        // cheats.assume(quorumNumber >= nextQuorum);
+        // assume all quorums are slashable
+        cheats.assume(stakeRegistry.stakeTypePerQuorum(quorumNumber) == IStakeRegistryTypes.StakeType.TOTAL_SLASHABLE);
+        stakeRegistry.setSlashableStakeLookahead(quorumNumber, lookAheadBlocks);
+        assertEq(
+            stakeRegistry.slashableStakeLookAheadPerQuorum(quorumNumber),
+            lookAheadBlocks,
+            "invalid slashable stake lookahead"
+        );
+    }
 }
 
 /// @notice Tests for StakeRegistry.registerOperator

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -1239,7 +1239,8 @@ contract StakeRegistryUnitTests_Register is StakeRegistryUnitTests {
         for (uint256 i = 0; i < setup.quorumNumbers.length; i++) {
             IStakeRegistry.StakeUpdate memory newOperatorStake = newOperatorStakes[i];
             IStakeRegistry.StakeUpdate memory newTotalStake = newTotalStakes[i];
-            IStakeRegistry.StakeUpdate[] memory newOperatorStakeHistory = newOperatorStakesHistory[i];
+            IStakeRegistry.StakeUpdate[] memory newOperatorStakeHistory =
+                newOperatorStakesHistory[i];
 
             // Check return value against weights, latest state read, and minimum stake
             assertEq(
@@ -1318,6 +1319,8 @@ contract StakeRegistryUnitTests_Register is StakeRegistryUnitTests {
                 _getLatestStakeUpdates(setup.operatorId, setup.quorumNumbers);
             uint256[] memory operatorStakeHistoryLengths =
                 _getStakeHistoryLengths(setup.operatorId, setup.quorumNumbers);
+            IStakeRegistry.StakeUpdate[][] memory newOperatorStakesHistory =
+                _getOperatorStakeHistories(setup.operatorId, setup.quorumNumbers);
 
             // Sum stakes in `_totalStakeAdded` to be checked later
             _tallyTotalStakeAdded(setup.quorumNumbers, resultingStakes);
@@ -1330,7 +1333,12 @@ contract StakeRegistryUnitTests_Register is StakeRegistryUnitTests {
                 totalStakes.length == setup.quorumNumbers.length,
                 "invalid return length for total stakes"
             );
+            assertTrue(
+                newOperatorStakesHistory.length == setup.quorumNumbers.length,
+                "invalid operator stake history length"
+            );
             for (uint256 j = 0; j < setup.quorumNumbers.length; j++) {
+                IStakeRegistry.StakeUpdate[] memory newOperatorStakeHistory = newOperatorStakesHistory[j];
                 // Check result against weights and latest state read
                 assertEq(
                     resultingStakes[j],
@@ -1358,6 +1366,7 @@ contract StakeRegistryUnitTests_Register is StakeRegistryUnitTests {
                 );
                 // Check this is the first entry in the operator stake history
                 assertEq(operatorStakeHistoryLengths[j], 1, "invalid total stake history length");
+                assertEq(newOperatorStakeHistory.length, 1, "invalid operator stake history length");
             }
         }
 
@@ -1556,6 +1565,8 @@ contract StakeRegistryUnitTests_Deregister is StakeRegistryUnitTests {
             _getLatestStakeUpdates(setup.operatorId, setup.registeredQuorumNumbers);
         IStakeRegistry.StakeUpdate[] memory newTotalStakes =
             _getLatestTotalStakeUpdates(setup.registeredQuorumNumbers);
+        IStakeRegistry.StakeUpdate[][] memory newOperatorStakesHistory =
+            _getOperatorStakeHistories(setup.operatorId, setup.registeredQuorumNumbers);
 
         for (uint256 i = 0; i < setup.registeredQuorumNumbers.length; i++) {
             uint8 registeredQuorum = uint8(setup.registeredQuorumNumbers[i]);
@@ -1565,6 +1576,8 @@ contract StakeRegistryUnitTests_Deregister is StakeRegistryUnitTests {
 
             IStakeRegistry.StakeUpdate memory newOperatorStake = newOperatorStakes[i];
             IStakeRegistry.StakeUpdate memory newTotalStake = newTotalStakes[i];
+
+            IStakeRegistry.StakeUpdate[] memory newOperatorStakeHistory = newOperatorStakesHistory[i];
 
             // Whether the operator was deregistered from this quorum
             bool deregistered = setup.quorumsToRemoveBitmap.isSet(registeredQuorum);
@@ -1598,6 +1611,12 @@ contract StakeRegistryUnitTests_Deregister is StakeRegistryUnitTests {
                     newTotalStake.nextUpdateBlockNumber,
                     0,
                     "total stake has incorrect next update block"
+                );
+                // Registration and deregistration were done in the same block
+                assertEq(
+                    newOperatorStakeHistory.length,
+                    1,
+                    "invalid operator stake history length"
                 );
             } else {
                 // Ensure no change to operator or total stakes

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -1298,7 +1298,7 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
         }
 
         // Force block to be mined to ensure new stake update is registered
-        cheats.roll(3);
+        cheats.roll(2);
 
         // deregisterOperator
         cheats.prank(address(registryCoordinator));
@@ -1326,8 +1326,59 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
         }
     }
 
-    // TODO:
-    // - add invariant based tests for getStakeUpdateAtIndex
+    function testFuzz_getStakeUpdateAtIndex_SingleBlock(uint192 quorumsToRemove, uint16 additionalStake) public {
+        DeregisterSetup memory setup = _fuzz_setupDeregisterOperator({
+            registeredFor: initializedQuorumBitmap,
+            fuzzy_toRemove: quorumsToRemove,
+            fuzzy_addtlStake: additionalStake
+        });
+
+        emit log_uint(block.number);
+        IStakeRegistry.StakeUpdate[] memory regOperatorStakes =
+            _getLatestStakeUpdates(setup.operatorId, setup.registeredQuorumNumbers);
+        IStakeRegistry.StakeUpdate[] memory operatorStakeUpdates =
+            _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.registeredQuorumNumbers, 0);
+        for (uint256 i = 0; i < setup.registeredQuorumNumbers.length; i++) {
+            assertEq(
+                operatorStakeUpdates[i].stake, regOperatorStakes[i].stake, "invalid operator stake"
+            );
+            assertEq(
+                operatorStakeUpdates[i].updateBlockNumber,
+                regOperatorStakes[i].updateBlockNumber,
+                "invalid operator stake update block number"
+            );
+            assertEq(
+                operatorStakeUpdates[i].nextUpdateBlockNumber,
+                regOperatorStakes[i].nextUpdateBlockNumber,
+                "invalid operator stake next update block number"
+            );
+        }
+
+        // deregisterOperator
+        cheats.prank(address(registryCoordinator));
+        stakeRegistry.deregisterOperator(setup.operatorId, setup.quorumsToRemove);
+        emit log_uint(block.number);
+
+        IStakeRegistry.StakeUpdate[] memory deregOperatorStakes =
+            _getLatestStakeUpdates(setup.operatorId, setup.quorumsToRemove);
+        IStakeRegistry.StakeUpdate[] memory operatorStakeUpdatesPost =
+            _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.quorumsToRemove, 0);
+        for (uint256 i = 0; i < setup.quorumsToRemove.length; i++) {
+            assertEq(
+                operatorStakeUpdatesPost[i].stake, deregOperatorStakes[i].stake, "invalid operator stake"
+            );
+            assertEq(
+                operatorStakeUpdatesPost[i].updateBlockNumber,
+                deregOperatorStakes[i].updateBlockNumber,
+                "invalid operator stake update block number"
+            );
+            assertEq(
+                operatorStakeUpdatesPost[i].nextUpdateBlockNumber,
+                deregOperatorStakes[i].nextUpdateBlockNumber,
+                "invalid operator stake next update block number"
+            );
+        }
+    }
 }
 
 /// @notice Tests for StakeRegistry.registerOperator

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -1220,6 +1220,42 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
                 );
             }
         }
+
+        cheats.roll(2);
+
+        // Deregister the Operator
+        cheats.prank(address(registryCoordinator));
+        stakeRegistry.deregisterOperator(setup.operatorId, setup.quorumNumbers);
+
+        // Check state history after deregistration
+        {
+            IStakeRegistry.StakeUpdate[] memory stakeUpdates =
+                _getLatestStakeUpdates(setup.operatorId, setup.quorumNumbers);
+            IStakeRegistry.StakeUpdate[][] memory stakeHistories =
+                _getOperatorStakeHistories(setup.operatorId, setup.quorumNumbers);
+            assertEq(
+                stakeHistories.length, setup.quorumNumbers.length, "invalid stake histories length"
+            );
+            for (uint256 i = 0; i < setup.quorumNumbers.length; i++) {
+                IStakeRegistry.StakeUpdate[] memory stakeHistory = stakeHistories[i];
+                assertTrue(stakeHistory.length == 2, "invalid operator stake history length");
+                assertEq(
+                    stakeHistory[1].stake,
+                    stakeUpdates[i].stake,
+                    "invalid operator stake history stake"
+                );
+                assertEq(
+                    stakeHistory[1].updateBlockNumber,
+                    stakeUpdates[i].updateBlockNumber,
+                    "invalid operator stake history update block number"
+                );
+                assertEq(
+                    stakeHistory[1].nextUpdateBlockNumber,
+                    stakeUpdates[i].nextUpdateBlockNumber,
+                    "invalid operator stake history next update block number"
+                );
+            }
+        }
     }
 
     function testFuzz_getStakeHistory_SingleBlock(

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -1782,12 +1782,30 @@ contract StakeRegistryUnitTests_Deregister is StakeRegistryUnitTests {
 contract StakeRegistryUnitTests_StakeUpdates is StakeRegistryUnitTests {
     using BitmapUtils for *;
 
+    function _wrap(
+        address operator
+    ) internal pure returns (address[] memory) {
+        address[] memory operators = new address[](1);
+        operators[0] = operator;
+        return operators;
+    }
+
+    function _wrap(
+        bytes32 operatorId
+    ) internal pure returns (bytes32[] memory) {
+        bytes32[] memory operatorIds = new bytes32[](1);
+        operatorIds[0] = operatorId;
+        return operatorIds;
+    }
+
     function test_updateOperatorStake_Revert_WhenNotRegistryCoordinator() public {
         UpdateSetup memory setup =
             _fuzz_setupUpdateOperatorStake({registeredFor: initializedQuorumBitmap, fuzzy_Delta: 0});
 
         cheats.expectRevert(IStakeRegistryErrors.OnlySlashingRegistryCoordinator.selector);
-        stakeRegistry.updateOperatorStake(setup.operator, setup.operatorId, setup.quorumNumbers);
+        stakeRegistry.updateOperatorsStake(
+            _wrap(setup.operator), _wrap(setup.operatorId), uint8(setup.quorumNumbers[0])
+        );
     }
 
     function testFuzz_updateOperatorStake_Revert_WhenQuorumDoesNotExist(
@@ -1799,10 +1817,13 @@ contract StakeRegistryUnitTests_StakeUpdates is StakeRegistryUnitTests {
 
         // Get a list of valid quorums ending in an invalid quorum number
         bytes memory invalidQuorums = _fuzz_getInvalidQuorums(rand);
+        uint256 length = invalidQuorums.length;
 
         cheats.expectRevert(IStakeRegistryErrors.QuorumDoesNotExist.selector);
         cheats.prank(address(registryCoordinator));
-        stakeRegistry.updateOperatorStake(setup.operator, setup.operatorId, invalidQuorums);
+        stakeRegistry.updateOperatorsStake(
+            _wrap(setup.operator), _wrap(setup.operatorId), uint8(invalidQuorums[length - 1])
+        );
     }
 
     /**
@@ -1828,9 +1849,14 @@ contract StakeRegistryUnitTests_StakeUpdates is StakeRegistryUnitTests {
             _getLatestTotalStakeUpdates(setup.quorumNumbers);
 
         // updateOperatorStake
-        cheats.prank(address(registryCoordinator));
-        uint192 quorumsToRemove =
-            stakeRegistry.updateOperatorStake(setup.operator, setup.operatorId, setup.quorumNumbers);
+        bool[] memory shouldBeDeregistered = new bool[](setup.quorumNumbers.length);
+        for (uint256 i = 0; i < setup.quorumNumbers.length; i++) {
+            cheats.prank(address(registryCoordinator));
+            bool[] memory shouldBeDeregisteredForQuorum = stakeRegistry.updateOperatorsStake(
+                _wrap(setup.operator), _wrap(setup.operatorId), uint8(setup.quorumNumbers[i])
+            );
+            shouldBeDeregistered[i] = shouldBeDeregisteredForQuorum[0];
+        }
 
         // Get ending state
         IStakeRegistry.StakeUpdate[] memory newOperatorStakes =
@@ -1873,7 +1899,8 @@ contract StakeRegistryUnitTests_StakeUpdates is StakeRegistryUnitTests {
                 );
                 // Return value should be empty since we're still above the minimum
                 assertTrue(
-                    quorumsToRemove.isEmpty(), "positive stake delta should not remove any quorums"
+                    !shouldBeDeregistered[i],
+                    "positive stake delta should not lead to deregistration"
                 );
             } else if (endingWeight < minimumStake) {
                 // Check updating an operator who is now below the minimum:
@@ -1892,9 +1919,7 @@ contract StakeRegistryUnitTests_StakeUpdates is StakeRegistryUnitTests {
                 );
                 assertEq(newOperatorStake.stake, 0, "operator stake should now be zero");
                 // IECDSAStakeRegistryTypes.Quorum should be added to return bitmap
-                assertTrue(
-                    quorumsToRemove.isSet(quorumNumber), "quorum should be in removal bitmap"
-                );
+                assertTrue(shouldBeDeregistered[i], "operator should be deregistered");
             } else {
                 // Check that no update occurs if weight remains the same
                 assertTrue(
@@ -1907,7 +1932,8 @@ contract StakeRegistryUnitTests_StakeUpdates is StakeRegistryUnitTests {
                 );
                 // Check that return value is empty - we're still at the minimum, so no quorums should be removed
                 assertTrue(
-                    quorumsToRemove.isEmpty(), "neutral stake delta should not remove any quorums"
+                    !shouldBeDeregistered[i],
+                    "neutral stake delta should not lead to deregistration"
                 );
             }
         }
@@ -1946,8 +1972,12 @@ contract StakeRegistryUnitTests_StakeUpdates is StakeRegistryUnitTests {
             UpdateSetup memory setup = setups[i];
 
             // updateOperatorStake
-            cheats.prank(address(registryCoordinator));
-            stakeRegistry.updateOperatorStake(setup.operator, setup.operatorId, setup.quorumNumbers);
+            for (uint256 j = 0; j < setup.quorumNumbers.length; j++) {
+                cheats.prank(address(registryCoordinator));
+                stakeRegistry.updateOperatorsStake(
+                    _wrap(setup.operator), _wrap(setup.operatorId), uint8(setup.quorumNumbers[j])
+                );
+            }
         }
 
         // Check final results for each quorum
@@ -2036,11 +2066,15 @@ contract StakeRegistryUnitTests_StakeUpdates is StakeRegistryUnitTests {
             uint256 currBlock = startBlock + j;
             cheats.roll(currBlock);
 
-            // updateOperatorStake
-            cheats.prank(address(registryCoordinator));
-            uint192 quorumsToRemove = stakeRegistry.updateOperatorStake(
-                setup.operator, setup.operatorId, setup.quorumNumbers
-            );
+            // updateOperatorsStake
+            bool[] memory shouldBeDeregistered = new bool[](setup.quorumNumbers.length);
+            for (uint256 i = 0; i < setup.quorumNumbers.length; i++) {
+                cheats.prank(address(registryCoordinator));
+                bool[] memory shouldBeDeregisteredForQuorum = stakeRegistry.updateOperatorsStake(
+                    _wrap(setup.operator), _wrap(setup.operatorId), uint8(setup.quorumNumbers[i])
+                );
+                shouldBeDeregistered[i] = shouldBeDeregisteredForQuorum[0];
+            }
 
             // Get ending state
             IStakeRegistry.StakeUpdate[] memory newOperatorStakes =
@@ -2084,8 +2118,8 @@ contract StakeRegistryUnitTests_StakeUpdates is StakeRegistryUnitTests {
                     );
                     // Return value should be empty since we're still above the minimum
                     assertTrue(
-                        quorumsToRemove.isEmpty(),
-                        "positive stake delta should not remove any quorums"
+                        !shouldBeDeregistered[i],
+                        "positive stake delta should not lead to deregistration"
                     );
                     assertEq(
                         prevOperatorHistoryLengths[i] + 1,
@@ -2105,9 +2139,7 @@ contract StakeRegistryUnitTests_StakeUpdates is StakeRegistryUnitTests {
                     // assertEq(prevTotalStake.stake - stakeRemoved, newTotalStake.stake, "failed to remove delta from total stake");
                     assertEq(newOperatorStake.stake, 0, "operator stake should now be zero");
                     // IECDSAStakeRegistryTypes.Quorum should be added to return bitmap
-                    assertTrue(
-                        quorumsToRemove.isSet(quorumNumber), "quorum should be in removal bitmap"
-                    );
+                    assertTrue(shouldBeDeregistered[i], "operator should be deregistered");
                     if (prevOperatorStake.stake >= minimumStake) {
                         // Total stakes and operator history should be updated
                         assertEq(
@@ -2145,7 +2177,7 @@ contract StakeRegistryUnitTests_StakeUpdates is StakeRegistryUnitTests {
                     );
                     // Check that return value is empty - we're still at the minimum, so no quorums should be removed
                     assertTrue(
-                        quorumsToRemove.isEmpty(),
+                        !shouldBeDeregistered[i],
                         "neutral stake delta should not remove any quorums"
                     );
                     assertEq(

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -541,7 +541,8 @@ contract StakeRegistryUnitTests is MockAVSDeployer, IStakeRegistryEvents {
         for (uint256 i = 0; i < quorumNumbers.length; i++) {
             uint8 quorumNumber = uint8(quorumNumbers[i]);
 
-            operatorStakeUpdates[i] = stakeRegistry.getStakeUpdateAtIndex(quorumNumber, operatorId, index);
+            operatorStakeUpdates[i] =
+                stakeRegistry.getStakeUpdateAtIndex(quorumNumber, operatorId, index);
         }
 
         return operatorStakeUpdates;
@@ -1243,7 +1244,8 @@ contract StakeRegistryUnitTests_Register is StakeRegistryUnitTests {
             _getStakeHistoryLengths(setup.operatorId, setup.quorumNumbers);
         IStakeRegistry.StakeUpdate[][] memory newOperatorStakesHistory =
             _getOperatorStakeHistories(setup.operatorId, setup.quorumNumbers);
-        IStakeRegistry.StakeUpdate[] memory stakeUpdatesAtIndex = _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.quorumNumbers, 0);
+        IStakeRegistry.StakeUpdate[] memory stakeUpdatesAtIndex =
+            _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.quorumNumbers, 0);
 
         /// Check results
         assertTrue(
@@ -1346,8 +1348,10 @@ contract StakeRegistryUnitTests_Register is StakeRegistryUnitTests {
                 _getLatestStakeUpdates(setup.operatorId, setup.quorumNumbers);
             uint256[] memory operatorStakeHistoryLengths =
                 _getStakeHistoryLengths(setup.operatorId, setup.quorumNumbers);
-            IStakeRegistry.StakeUpdate[][] memory newOperatorStakesHistory =
+            IStakeRegistry.StakeUpdate[][] memory operatorStakesHistory =
                 _getOperatorStakeHistories(setup.operatorId, setup.quorumNumbers);
+            IStakeRegistry.StakeUpdate[] memory stakeUpdatesAtIndex =
+                _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.quorumNumbers, 0);
 
             // Sum stakes in `_totalStakeAdded` to be checked later
             _tallyTotalStakeAdded(setup.quorumNumbers, resultingStakes);
@@ -1361,11 +1365,15 @@ contract StakeRegistryUnitTests_Register is StakeRegistryUnitTests {
                 "invalid return length for total stakes"
             );
             assertTrue(
-                newOperatorStakesHistory.length == setup.quorumNumbers.length,
+                operatorStakesHistory.length == setup.quorumNumbers.length,
                 "invalid operator stake history length"
             );
+            assertTrue(
+                stakeUpdatesAtIndex.length == setup.quorumNumbers.length,
+                "invalid return length for operator stakes at indices"
+            );
             for (uint256 j = 0; j < setup.quorumNumbers.length; j++) {
-                IStakeRegistry.StakeUpdate[] memory newOperatorStakeHistory = newOperatorStakesHistory[j];
+                IStakeRegistry.StakeUpdate[] memory operatorStakeHistory = operatorStakesHistory[j];
                 // Check result against weights and latest state read
                 assertEq(
                     resultingStakes[j],
@@ -1393,7 +1401,7 @@ contract StakeRegistryUnitTests_Register is StakeRegistryUnitTests {
                 );
                 // Check this is the first entry in the operator stake history
                 assertEq(operatorStakeHistoryLengths[j], 1, "invalid total stake history length");
-                assertEq(newOperatorStakeHistory.length, 1, "invalid operator stake history length");
+                assertEq(operatorStakeHistory.length, 1, "invalid operator stake history length");
             }
         }
 
@@ -1594,7 +1602,8 @@ contract StakeRegistryUnitTests_Deregister is StakeRegistryUnitTests {
             _getLatestTotalStakeUpdates(setup.registeredQuorumNumbers);
         IStakeRegistry.StakeUpdate[][] memory newOperatorStakesHistory =
             _getOperatorStakeHistories(setup.operatorId, setup.registeredQuorumNumbers);
-
+        IStakeRegistry.StakeUpdate[] memory newStakesAtIndex =
+            _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.registeredQuorumNumbers, 0);
         for (uint256 i = 0; i < setup.registeredQuorumNumbers.length; i++) {
             uint8 registeredQuorum = uint8(setup.registeredQuorumNumbers[i]);
 
@@ -1604,7 +1613,9 @@ contract StakeRegistryUnitTests_Deregister is StakeRegistryUnitTests {
             IStakeRegistry.StakeUpdate memory newOperatorStake = newOperatorStakes[i];
             IStakeRegistry.StakeUpdate memory newTotalStake = newTotalStakes[i];
 
-            IStakeRegistry.StakeUpdate[] memory newOperatorStakeHistory = newOperatorStakesHistory[i];
+            IStakeRegistry.StakeUpdate[] memory newOperatorStakeHistory =
+                newOperatorStakesHistory[i];
+            IStakeRegistry.StakeUpdate memory newStakeAtIndex = newStakesAtIndex[i];
 
             // Whether the operator was deregistered from this quorum
             bool deregistered = setup.quorumsToRemoveBitmap.isSet(registeredQuorum);
@@ -1640,10 +1651,15 @@ contract StakeRegistryUnitTests_Deregister is StakeRegistryUnitTests {
                     "total stake has incorrect next update block"
                 );
                 // Registration and deregistration were done in the same block
+                assertEq(newOperatorStakeHistory.length, 1, "invalid operator stake history length");
+                assertEq(newStakeAtIndex.stake, 0, "invalid stake at index");
                 assertEq(
-                    newOperatorStakeHistory.length,
-                    1,
-                    "invalid operator stake history length"
+                    newStakeAtIndex.updateBlockNumber,
+                    uint32(block.number),
+                    "invalid update block at index"
+                );
+                assertEq(
+                    newStakeAtIndex.nextUpdateBlockNumber, 0, "invalid next update block at index"
                 );
             } else {
                 // Ensure no change to operator or total stakes

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -1223,6 +1223,8 @@ contract StakeRegistryUnitTests_Register is StakeRegistryUnitTests {
             _getLatestTotalStakeUpdates(setup.quorumNumbers);
         uint256[] memory operatorStakeHistoryLengths =
             _getStakeHistoryLengths(setup.operatorId, setup.quorumNumbers);
+        IStakeRegistry.StakeUpdate[][] memory newOperatorStakesHistory =
+            _getOperatorStakeHistories(setup.operatorId, setup.quorumNumbers);
 
         /// Check results
         assertTrue(
@@ -1237,6 +1239,7 @@ contract StakeRegistryUnitTests_Register is StakeRegistryUnitTests {
         for (uint256 i = 0; i < setup.quorumNumbers.length; i++) {
             IStakeRegistry.StakeUpdate memory newOperatorStake = newOperatorStakes[i];
             IStakeRegistry.StakeUpdate memory newTotalStake = newTotalStakes[i];
+            IStakeRegistry.StakeUpdate[] memory newOperatorStakeHistory = newOperatorStakesHistory[i];
 
             // Check return value against weights, latest state read, and minimum stake
             assertEq(
@@ -1273,6 +1276,13 @@ contract StakeRegistryUnitTests_Register is StakeRegistryUnitTests {
 
             // Check this is the first entry in the operator stake history
             assertEq(operatorStakeHistoryLengths[i], 1, "invalid total stake history length");
+            assertEq(newOperatorStakeHistory.length, 1, "invalid operator stake history length");
+
+            // Index is known for newOperatorStakeHistory, as this is the first entry
+            assertEq(newOperatorStakeHistory[0].updateBlockNumber, uint32(block.number), "");
+            assertEq(newOperatorStakeHistory[0].nextUpdateBlockNumber, 0, "");
+            assertEq(newOperatorStakeHistory[0].updateBlockNumber, uint32(block.number), "");
+            assertEq(newOperatorStakeHistory[0].nextUpdateBlockNumber, 0, "");
         }
     }
 

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -83,6 +83,18 @@ contract StakeRegistryUnitTests is MockAVSDeployer, IStakeRegistryEvents {
         _initializeQuorum({minimumStake: uint96(type(uint24).max) + 1});
         _initializeQuorum({minimumStake: uint96(type(uint32).max) + 1});
         _initializeQuorum({minimumStake: uint96(type(uint64).max) + 1});
+
+        // TODO: fix this, this will make setSlashableStake pass, but everything else fail
+        // // Initialize several slashable quorums with varying minimum stakes
+        // _initializeQuorumSlashable({minimumStake: uint96(type(uint16).max)});
+        // _initializeQuorumSlashable({minimumStake: uint96(type(uint24).max)});
+        // _initializeQuorumSlashable({minimumStake: uint96(type(uint32).max)});
+        // _initializeQuorumSlashable({minimumStake: uint96(type(uint64).max)});
+
+        // _initializeQuorumSlashable({minimumStake: uint96(type(uint16).max) + 1});
+        // _initializeQuorumSlashable({minimumStake: uint96(type(uint24).max) + 1});
+        // _initializeQuorumSlashable({minimumStake: uint96(type(uint32).max) + 1});
+        // _initializeQuorumSlashable({minimumStake: uint96(type(uint64).max) + 1});
     }
 
     /**
@@ -116,6 +128,38 @@ contract StakeRegistryUnitTests is MockAVSDeployer, IStakeRegistryEvents {
         assertEq(
             uint8(stakeType),
             uint8(IStakeRegistryTypes.StakeType.TOTAL_DELEGATED),
+            "invalid stake type"
+        );
+
+        // Mark quorum initialized for other tests
+        initializedQuorumBitmap = uint192(initializedQuorumBitmap.setBit(quorumNumber));
+        initializedQuorumBytes = initializedQuorumBitmap.bitmapToBytesArray();
+    }
+
+    /**
+     * // TODO (James): dev docs
+     */
+    function _initializeQuorumSlashable(
+        uint96 minimumStake
+    ) internal {
+        uint8 quorumNumber = nextQuorum;
+
+        IStakeRegistryTypes.StrategyParams[] memory strategyParams =
+            new IStakeRegistryTypes.StrategyParams[](1);
+        strategyParams[0] = IStakeRegistryTypes.StrategyParams(
+            IStrategy(address(uint160(uint256(keccak256(abi.encodePacked(quorumNumber)))))),
+            uint96(WEIGHTING_DIVISOR)
+        );
+
+        nextQuorum++;
+
+        cheats.prank(address(registryCoordinator));
+        stakeRegistry.initializeSlashableStakeQuorum(quorumNumber, minimumStake, 1, strategyParams);
+
+        IStakeRegistryTypes.StakeType stakeType = stakeRegistry.stakeTypePerQuorum(quorumNumber);
+        assertEq(
+            uint8(stakeType),
+            uint8(IStakeRegistryTypes.StakeType.TOTAL_SLASHABLE),
             "invalid stake type"
         );
 
@@ -1141,8 +1185,7 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
         uint32 lookAheadBlocks
     ) public {
         cheats.assume(quorumNumber < nextQuorum);
-        // Only consider quorums that are slashable
-        // TODO: this test is failing as not enough quorums are total slashable
+
         cheats.assume(
             stakeRegistry.stakeTypePerQuorum(quorumNumber)
                 == IStakeRegistryTypes.StakeType.TOTAL_SLASHABLE
@@ -1155,6 +1198,95 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
             "invalid slashable stake lookahead"
         );
     }
+
+    /**
+     *
+     *                        getStakeHistory
+     *
+     */
+    function testFuzz_getStakeHistory(uint192 quorumBitmap, uint16 additionalStake) public {
+        // Setup - select a new operator and set their weight to each quorum's minimum plus some additional
+        RegisterSetup memory setup = _fuzz_setupRegisterOperator(quorumBitmap, additionalStake);
+
+        // State history should be empty
+        IStakeRegistry.StakeUpdate[][] memory operatorStakeHistories =
+            _getOperatorStakeHistories(setup.operatorId, setup.quorumNumbers);
+        for (uint256 i = 0; i < setup.quorumNumbers.length; i++) {
+            assertTrue(
+                operatorStakeHistories[i].length == 0,
+                "invalid operator stake history length"
+            );
+        }
+
+        // Register the Operator
+        cheats.prank(address(registryCoordinator));
+        (uint96[] memory resultingStakes, uint96[] memory totalStakes) =
+            stakeRegistry.registerOperator(setup.operator, setup.operatorId, setup.quorumNumbers);
+
+
+        // Check state history after registration
+        IStakeRegistry.StakeUpdate[][] memory operatorStakeHistoriesPost =
+            _getOperatorStakeHistories(setup.operatorId, setup.quorumNumbers);
+        for (uint256 i = 0; i < setup.quorumNumbers.length; i++) {
+            IStakeRegistry.StakeUpdate[] memory operatorStakeHistory = operatorStakeHistoriesPost[i];
+            assertTrue(
+                operatorStakeHistory.length == 1,
+                "invalid operator stake history length"
+            );
+            IStakeRegistry.StakeUpdate memory operatorStake = operatorStakeHistory[0];
+            assertEq(
+                operatorStake.stake,
+                resultingStakes[i],
+                "invalid operator stake in history"
+            );
+            assertEq(
+                operatorStake.updateBlockNumber,
+                uint32(block.number),
+                "invalid operator stake update block number"
+            );
+            assertEq(
+                operatorStake.nextUpdateBlockNumber,
+                0,
+                "invalid operator stake next update block number"
+            );
+        }
+    }
+
+    function testFuzz_getStakeHistory_SingleBlock(uint192 quorumsToRemove, uint16 additionalStake) public {
+        DeregisterSetup memory setup = _fuzz_setupDeregisterOperator({
+            registeredFor: initializedQuorumBitmap,
+            fuzzy_toRemove: quorumsToRemove,
+            fuzzy_addtlStake: additionalStake
+        });
+
+        // Check stake history
+        IStakeRegistry.StakeUpdate[][] memory operatorStakeHistories =
+            _getOperatorStakeHistories(setup.operatorId, setup.registeredQuorumNumbers);
+        for (uint256 i = 0; i < setup.registeredQuorumNumbers.length; i++) {
+            assertTrue(
+                operatorStakeHistories[i].length == 1,
+                "invalid operator stake history length"
+            );
+            IStakeRegistry.StakeUpdate memory operatorStake = operatorStakeHistories[i][0];
+        }
+
+        // deregisterOperator
+        cheats.prank(address(registryCoordinator));
+        stakeRegistry.deregisterOperator(setup.operatorId, setup.quorumsToRemove);
+
+        // Check stake history after deregistration in the same block
+        IStakeRegistry.StakeUpdate[][] memory operatorStakeHistoriesPost =
+            _getOperatorStakeHistories(setup.operatorId, setup.registeredQuorumNumbers);
+        for (uint256 i = 0; i < setup.registeredQuorumNumbers.length; i++) {
+            IStakeRegistry.StakeUpdate[] memory operatorStakeHistory = operatorStakeHistoriesPost[i];
+            assertTrue(
+                operatorStakeHistory.length == 1,
+                "invalid operator stake history length"
+            );
+        }
+    }
+    // TODO:
+    // - add invariant based tests for getStakeUpdateAtIndex
 }
 
 /// @notice Tests for StakeRegistry.registerOperator

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -529,6 +529,24 @@ contract StakeRegistryUnitTests is MockAVSDeployer, IStakeRegistryEvents {
         return operatorStakeHistories;
     }
 
+    /// @dev Return the stake history at a given index for each quorum
+    function _getOperatorStakeUpdatesAtIndex(
+        bytes32 operatorId,
+        bytes memory quorumNumbers,
+        uint256 index
+    ) internal view returns (IStakeRegistry.StakeUpdate[] memory) {
+        IStakeRegistry.StakeUpdate[] memory operatorStakeUpdates =
+            new IStakeRegistry.StakeUpdate[](quorumNumbers.length);
+
+        for (uint256 i = 0; i < quorumNumbers.length; i++) {
+            uint8 quorumNumber = uint8(quorumNumbers[i]);
+
+            operatorStakeUpdates[i] = stakeRegistry.getStakeUpdateAtIndex(quorumNumber, operatorId, index);
+        }
+
+        return operatorStakeUpdates;
+    }
+
     /// @dev Return the lengths of the total stake update history
     function _getTotalStakeHistoryLengths(
         bytes memory quorumNumbers
@@ -1225,6 +1243,7 @@ contract StakeRegistryUnitTests_Register is StakeRegistryUnitTests {
             _getStakeHistoryLengths(setup.operatorId, setup.quorumNumbers);
         IStakeRegistry.StakeUpdate[][] memory newOperatorStakesHistory =
             _getOperatorStakeHistories(setup.operatorId, setup.quorumNumbers);
+        IStakeRegistry.StakeUpdate[] memory stakeUpdatesAtIndex = _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.quorumNumbers, 0);
 
         /// Check results
         assertTrue(
@@ -1234,6 +1253,14 @@ contract StakeRegistryUnitTests_Register is StakeRegistryUnitTests {
         assertTrue(
             totalStakes.length == setup.quorumNumbers.length,
             "invalid return length for total stakes"
+        );
+        assertTrue(
+            newOperatorStakesHistory.length == setup.quorumNumbers.length,
+            "invalid operator stake history length"
+        );
+        assertTrue(
+            stakeUpdatesAtIndex.length == setup.quorumNumbers.length,
+            "invalid return length for operator stakes at indices"
         );
 
         for (uint256 i = 0; i < setup.quorumNumbers.length; i++) {

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -1088,21 +1088,29 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
         uint8 quorumNumber,
         uint32 lookAheadBlocks
     ) public {
+        cheats.assume(quorumNumber < nextQuorum);
+        cheats.assume(
+            stakeRegistry.stakeTypePerQuorum(quorumNumber)
+                == IStakeRegistryTypes.StakeType.TOTAL_DELEGATED
+        );
         cheats.expectRevert(IStakeRegistryErrors.QuorumNotSlashable.selector);
         cheats.prank(registryCoordinatorOwner);
         stakeRegistry.setSlashableStakeLookahead(quorumNumber, lookAheadBlocks);
     }
 
-    /// @dev Fuzzes initialized quorum numbers and stake look aheads
+    /// @dev Fuzzes initialized quorum numbers and sets stake look ahead
     function testFuzz_setSlashableStakeLookahead(
         uint8 quorumNumber,
         uint32 lookAheadBlocks
     ) public {
+        cheats.assume(quorumNumber < nextQuorum);
+        // Only consider quorums that are slashable
+        // TODO: this test is failing as not enough quorums are total slashable
+        cheats.assume(
+            stakeRegistry.stakeTypePerQuorum(quorumNumber)
+                == IStakeRegistryTypes.StakeType.TOTAL_SLASHABLE
+        );
         cheats.prank(registryCoordinatorOwner);
-        // quorums [0,nextQuorum) are initialized, so use an invalid quorumNumber
-        // cheats.assume(quorumNumber >= nextQuorum);
-        // assume all quorums are slashable
-        cheats.assume(stakeRegistry.stakeTypePerQuorum(quorumNumber) == IStakeRegistryTypes.StakeType.TOTAL_SLASHABLE);
         stakeRegistry.setSlashableStakeLookahead(quorumNumber, lookAheadBlocks);
         assertEq(
             stakeRegistry.slashableStakeLookAheadPerQuorum(quorumNumber),

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -1197,11 +1197,12 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
                 _getLatestStakeUpdates(setup.operatorId, setup.quorumNumbers);
             IStakeRegistry.StakeUpdate[][] memory stakeHistories =
                 _getOperatorStakeHistories(setup.operatorId, setup.quorumNumbers);
+            assertEq(
+                stakeHistories.length, setup.quorumNumbers.length, "invalid stake histories length"
+            );
             for (uint256 i = 0; i < setup.quorumNumbers.length; i++) {
                 IStakeRegistry.StakeUpdate[] memory stakeHistory = stakeHistories[i];
-                assertTrue(
-                    stakeHistory.length == 1, "invalid operator stake history length"
-                );
+                assertTrue(stakeHistory.length == 1, "invalid operator stake history length");
                 assertEq(
                     stakeHistory[0].stake,
                     stakeUpdates[i].stake,
@@ -1237,6 +1238,11 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
                 _getLatestStakeUpdates(setup.operatorId, setup.registeredQuorumNumbers);
             IStakeRegistry.StakeUpdate[][] memory stakeHistories =
                 _getOperatorStakeHistories(setup.operatorId, setup.registeredQuorumNumbers);
+            assertEq(
+                stakeHistories.length,
+                setup.registeredQuorumNumbers.length,
+                "invalid stake histories length"
+            );
             for (uint256 i = 0; i < setup.registeredQuorumNumbers.length; i++) {
                 assertTrue(stakeHistories[i].length == 1, "invalid operator stake history length");
                 IStakeRegistry.StakeUpdate memory stakeHistory = stakeHistories[i][0];
@@ -1268,6 +1274,11 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
                 _getLatestStakeUpdates(setup.operatorId, setup.registeredQuorumNumbers);
             IStakeRegistry.StakeUpdate[][] memory stakeHistories =
                 _getOperatorStakeHistories(setup.operatorId, setup.registeredQuorumNumbers);
+            assertEq(
+                stakeHistories.length,
+                setup.registeredQuorumNumbers.length,
+                "invalid stake histories length"
+            );
             for (uint256 i = 0; i < setup.registeredQuorumNumbers.length; i++) {
                 assertTrue(stakeHistories[i].length == 1, "invalid operator stake history length");
                 IStakeRegistry.StakeUpdate memory stakeHistory = stakeHistories[i][0];
@@ -1310,6 +1321,11 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
                 _getLatestStakeUpdates(setup.operatorId, setup.registeredQuorumNumbers);
             IStakeRegistry.StakeUpdate[] memory indexStakeUpdate =
                 _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.registeredQuorumNumbers, 0);
+            assertEq(
+                indexStakeUpdate.length,
+                setup.registeredQuorumNumbers.length,
+                "invalid operator stake history length"
+            );
             for (uint256 i = 0; i < setup.registeredQuorumNumbers.length; i++) {
                 assertEq(indexStakeUpdate[i].stake, stakeUpdates[i].stake, "invalid operator stake");
                 assertEq(
@@ -1337,6 +1353,11 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
                 _getLatestStakeUpdates(setup.operatorId, setup.quorumsToRemove);
             IStakeRegistry.StakeUpdate[] memory indexStakeUpdate =
                 _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.quorumsToRemove, 1);
+            assertEq(
+                indexStakeUpdate.length,
+                setup.quorumsToRemove.length,
+                "invalid operator stake history length"
+            );
             for (uint256 i = 0; i < setup.quorumsToRemove.length; i++) {
                 assertEq(indexStakeUpdate[i].stake, stakeUpdates[i].stake, "invalid operator stake");
                 assertEq(
@@ -1369,6 +1390,11 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
                 _getLatestStakeUpdates(setup.operatorId, setup.registeredQuorumNumbers);
             IStakeRegistry.StakeUpdate[] memory indexStakeUpdate =
                 _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.registeredQuorumNumbers, 0);
+            assertEq(
+                indexStakeUpdate.length,
+                setup.registeredQuorumNumbers.length,
+                "invalid operator stake history length"
+            );
             for (uint256 i = 0; i < setup.registeredQuorumNumbers.length; i++) {
                 assertEq(indexStakeUpdate[i].stake, stakeUpdates[i].stake, "invalid operator stake");
                 assertEq(
@@ -1393,6 +1419,11 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
                 _getLatestStakeUpdates(setup.operatorId, setup.quorumsToRemove);
             IStakeRegistry.StakeUpdate[] memory operatorStakeUpdatesPost =
                 _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.quorumsToRemove, 0);
+            assertEq(
+                operatorStakeUpdatesPost.length,
+                setup.quorumsToRemove.length,
+                "invalid operator stake history length"
+            );
             for (uint256 i = 0; i < setup.quorumsToRemove.length; i++) {
                 assertEq(
                     operatorStakeUpdatesPost[i].stake,
@@ -1501,7 +1532,7 @@ contract StakeRegistryUnitTests_Register is StakeRegistryUnitTests {
             _getStakeHistoryLengths(setup.operatorId, setup.quorumNumbers);
         IStakeRegistry.StakeUpdate[][] memory newOperatorStakesHistory =
             _getOperatorStakeHistories(setup.operatorId, setup.quorumNumbers);
-        IStakeRegistry.StakeUpdate[] memory stakeUpdatesAtIndex =
+        IStakeRegistry.StakeUpdate[] memory newStakeUpdatesAtIndex =
             _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.quorumNumbers, 0);
 
         /// Check results
@@ -1518,7 +1549,7 @@ contract StakeRegistryUnitTests_Register is StakeRegistryUnitTests {
             "invalid operator stake history length"
         );
         assertTrue(
-            stakeUpdatesAtIndex.length == setup.quorumNumbers.length,
+            newStakeUpdatesAtIndex.length == setup.quorumNumbers.length,
             "invalid return length for operator stakes at indices"
         );
 
@@ -1566,10 +1597,14 @@ contract StakeRegistryUnitTests_Register is StakeRegistryUnitTests {
             assertEq(newOperatorStakeHistory.length, 1, "invalid operator stake history length");
 
             // Index is known for newOperatorStakeHistory, as this is the first entry
+            assertEq(newOperatorStakeHistory[0].stake, newOperatorStake.stake, "");
             assertEq(newOperatorStakeHistory[0].updateBlockNumber, uint32(block.number), "");
             assertEq(newOperatorStakeHistory[0].nextUpdateBlockNumber, 0, "");
-            assertEq(newOperatorStakeHistory[0].updateBlockNumber, uint32(block.number), "");
-            assertEq(newOperatorStakeHistory[0].nextUpdateBlockNumber, 0, "");
+
+            // Check this first historical update at index 0
+            assertEq(newStakeUpdatesAtIndex[i].stake, newOperatorStake.stake, "");
+            assertEq(newStakeUpdatesAtIndex[i].updateBlockNumber, uint32(block.number), "");
+            assertEq(newStakeUpdatesAtIndex[i].nextUpdateBlockNumber, newOperatorStake.nextUpdateBlockNumber, "");
         }
     }
 
@@ -1631,6 +1666,7 @@ contract StakeRegistryUnitTests_Register is StakeRegistryUnitTests {
             );
             for (uint256 j = 0; j < setup.quorumNumbers.length; j++) {
                 IStakeRegistry.StakeUpdate[] memory operatorStakeHistory = operatorStakesHistory[j];
+                IStakeRegistry.StakeUpdate memory stakeUpdateAtIndex = stakeUpdatesAtIndex[j];
                 // Check result against weights and latest state read
                 assertEq(
                     resultingStakes[j],
@@ -1659,6 +1695,40 @@ contract StakeRegistryUnitTests_Register is StakeRegistryUnitTests {
                 // Check this is the first entry in the operator stake history
                 assertEq(operatorStakeHistoryLengths[j], 1, "invalid total stake history length");
                 assertEq(operatorStakeHistory.length, 1, "invalid operator stake history length");
+
+                // Check the first history entry
+                assertEq(
+                    operatorStakeHistory[0].stake,
+                    newOperatorStakes[j].stake,
+                    "invalid operator stake"
+                );
+                assertEq(
+                    operatorStakeHistory[0].updateBlockNumber,
+                    uint32(block.number),
+                    "invalid operator stake update block number"
+                );
+                assertEq(
+                    operatorStakeHistory[0].nextUpdateBlockNumber,
+                    0,
+                    "invalid operator stake next update block number"
+                );
+
+                // Check the update at the first index
+                assertEq(
+                    stakeUpdateAtIndex.stake,
+                    newOperatorStakes[j].stake,
+                    "invalid operator stake"
+                );
+                assertEq(
+                    stakeUpdateAtIndex.updateBlockNumber,
+                    uint32(block.number),
+                    "invalid operator stake update block number"
+                );
+                assertEq(
+                    stakeUpdateAtIndex.nextUpdateBlockNumber,
+                    0,
+                    "invalid operator stake next update block number"
+                );
             }
         }
 
@@ -1907,8 +1977,22 @@ contract StakeRegistryUnitTests_Deregister is StakeRegistryUnitTests {
                     0,
                     "total stake has incorrect next update block"
                 );
-                // Registration and deregistration were done in the same block
+                
+                // Registration and deregistration is done in the same block
                 assertEq(newOperatorStakeHistory.length, 1, "invalid operator stake history length");
+                assertEq(newOperatorStakeHistory[0].stake, 0, "invalid operator stake history stake");
+                assertEq(
+                    newOperatorStakeHistory[0].updateBlockNumber,
+                    uint32(block.number),
+                    "invalid operator stake history update block number"
+                );
+                assertEq(
+                    newOperatorStakeHistory[0].nextUpdateBlockNumber,
+                    0,
+                    "invalid operator stake history next update block number"
+                );
+
+                // Check the update at the first index
                 assertEq(newStakeAtIndex.stake, 0, "invalid stake at index");
                 assertEq(
                     newStakeAtIndex.updateBlockNumber,

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -1135,7 +1135,6 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
         stakeRegistry.setSlashableStakeLookahead(quorumNumber, lookAheadBlocks);
     }
 
-    /// @dev Fuzzes slashable quorum numbers and sets stake look ahead
     function testFuzz_setSlashableStakeLookahead(
         uint8 quorumNumber,
         uint32 lookAheadBlocks

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -1213,8 +1213,7 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
             _getOperatorStakeHistories(setup.operatorId, setup.quorumNumbers);
         for (uint256 i = 0; i < setup.quorumNumbers.length; i++) {
             assertTrue(
-                operatorStakeHistories[i].length == 0,
-                "invalid operator stake history length"
+                operatorStakeHistories[i].length == 0, "invalid operator stake history length"
             );
         }
 
@@ -1223,36 +1222,19 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
         (uint96[] memory resultingStakes, uint96[] memory totalStakes) =
             stakeRegistry.registerOperator(setup.operator, setup.operatorId, setup.quorumNumbers);
 
-
         // Check state history after registration
         IStakeRegistry.StakeUpdate[][] memory operatorStakeHistoriesPost =
             _getOperatorStakeHistories(setup.operatorId, setup.quorumNumbers);
         for (uint256 i = 0; i < setup.quorumNumbers.length; i++) {
             IStakeRegistry.StakeUpdate[] memory operatorStakeHistory = operatorStakeHistoriesPost[i];
-            assertTrue(
-                operatorStakeHistory.length == 1,
-                "invalid operator stake history length"
-            );
-            IStakeRegistry.StakeUpdate memory operatorStake = operatorStakeHistory[0];
-            assertEq(
-                operatorStake.stake,
-                resultingStakes[i],
-                "invalid operator stake in history"
-            );
-            assertEq(
-                operatorStake.updateBlockNumber,
-                uint32(block.number),
-                "invalid operator stake update block number"
-            );
-            assertEq(
-                operatorStake.nextUpdateBlockNumber,
-                0,
-                "invalid operator stake next update block number"
-            );
+            assertTrue(operatorStakeHistory.length == 1, "invalid operator stake history length");
         }
     }
 
-    function testFuzz_getStakeHistory_SingleBlock(uint192 quorumsToRemove, uint16 additionalStake) public {
+    function testFuzz_getStakeHistory_SingleBlock(
+        uint192 quorumsToRemove,
+        uint16 additionalStake
+    ) public {
         DeregisterSetup memory setup = _fuzz_setupDeregisterOperator({
             registeredFor: initializedQuorumBitmap,
             fuzzy_toRemove: quorumsToRemove,
@@ -1264,8 +1246,7 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
             _getOperatorStakeHistories(setup.operatorId, setup.registeredQuorumNumbers);
         for (uint256 i = 0; i < setup.registeredQuorumNumbers.length; i++) {
             assertTrue(
-                operatorStakeHistories[i].length == 1,
-                "invalid operator stake history length"
+                operatorStakeHistories[i].length == 1, "invalid operator stake history length"
             );
             IStakeRegistry.StakeUpdate memory operatorStake = operatorStakeHistories[i][0];
         }
@@ -1279,12 +1260,72 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
             _getOperatorStakeHistories(setup.operatorId, setup.registeredQuorumNumbers);
         for (uint256 i = 0; i < setup.registeredQuorumNumbers.length; i++) {
             IStakeRegistry.StakeUpdate[] memory operatorStakeHistory = operatorStakeHistoriesPost[i];
-            assertTrue(
-                operatorStakeHistory.length == 1,
-                "invalid operator stake history length"
+            assertTrue(operatorStakeHistory.length == 1, "invalid operator stake history length");
+        }
+    }
+
+    /**
+     *
+     *                        getStakeUpdateAtIndex
+     *
+     */
+    function testFuzz_getStakeUpdateAtIndex(uint192 quorumsToRemove, uint16 additionalStake) public {
+        DeregisterSetup memory setup = _fuzz_setupDeregisterOperator({
+            registeredFor: initializedQuorumBitmap,
+            fuzzy_toRemove: quorumsToRemove,
+            fuzzy_addtlStake: additionalStake
+        });
+
+        emit log_uint(block.number);
+        IStakeRegistry.StakeUpdate[] memory regOperatorStakes =
+            _getLatestStakeUpdates(setup.operatorId, setup.registeredQuorumNumbers);
+        IStakeRegistry.StakeUpdate[] memory operatorStakeUpdates =
+            _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.registeredQuorumNumbers, 0);
+        for (uint256 i = 0; i < setup.registeredQuorumNumbers.length; i++) {
+            assertEq(
+                operatorStakeUpdates[i].stake, regOperatorStakes[i].stake, "invalid operator stake"
+            );
+            assertEq(
+                operatorStakeUpdates[i].updateBlockNumber,
+                regOperatorStakes[i].updateBlockNumber,
+                "invalid operator stake update block number"
+            );
+            assertEq(
+                operatorStakeUpdates[i].nextUpdateBlockNumber,
+                regOperatorStakes[i].nextUpdateBlockNumber,
+                "invalid operator stake next update block number"
+            );
+        }
+
+        // Force block to be mined to ensure new stake update is registered
+        cheats.roll(3);
+
+        // deregisterOperator
+        cheats.prank(address(registryCoordinator));
+        stakeRegistry.deregisterOperator(setup.operatorId, setup.quorumsToRemove);
+        emit log_uint(block.number);
+
+        IStakeRegistry.StakeUpdate[] memory deregOperatorStakes =
+            _getLatestStakeUpdates(setup.operatorId, setup.quorumsToRemove);
+        IStakeRegistry.StakeUpdate[] memory operatorStakeUpdatesPost =
+            _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.quorumsToRemove, 1);
+        for (uint256 i = 0; i < setup.quorumsToRemove.length; i++) {
+            assertEq(
+                operatorStakeUpdatesPost[i].stake, deregOperatorStakes[i].stake, "invalid operator stake"
+            );
+            assertEq(
+                operatorStakeUpdatesPost[i].updateBlockNumber,
+                deregOperatorStakes[i].updateBlockNumber,
+                "invalid operator stake update block number"
+            );
+            assertEq(
+                operatorStakeUpdatesPost[i].nextUpdateBlockNumber,
+                deregOperatorStakes[i].nextUpdateBlockNumber,
+                "invalid operator stake next update block number"
             );
         }
     }
+
     // TODO:
     // - add invariant based tests for getStakeUpdateAtIndex
 }

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -1604,7 +1604,11 @@ contract StakeRegistryUnitTests_Register is StakeRegistryUnitTests {
             // Check this first historical update at index 0
             assertEq(newStakeUpdatesAtIndex[i].stake, newOperatorStake.stake, "");
             assertEq(newStakeUpdatesAtIndex[i].updateBlockNumber, uint32(block.number), "");
-            assertEq(newStakeUpdatesAtIndex[i].nextUpdateBlockNumber, newOperatorStake.nextUpdateBlockNumber, "");
+            assertEq(
+                newStakeUpdatesAtIndex[i].nextUpdateBlockNumber,
+                newOperatorStake.nextUpdateBlockNumber,
+                ""
+            );
         }
     }
 
@@ -1715,9 +1719,7 @@ contract StakeRegistryUnitTests_Register is StakeRegistryUnitTests {
 
                 // Check the update at the first index
                 assertEq(
-                    stakeUpdateAtIndex.stake,
-                    newOperatorStakes[j].stake,
-                    "invalid operator stake"
+                    stakeUpdateAtIndex.stake, newOperatorStakes[j].stake, "invalid operator stake"
                 );
                 assertEq(
                     stakeUpdateAtIndex.updateBlockNumber,
@@ -1977,10 +1979,12 @@ contract StakeRegistryUnitTests_Deregister is StakeRegistryUnitTests {
                     0,
                     "total stake has incorrect next update block"
                 );
-                
+
                 // Registration and deregistration is done in the same block
                 assertEq(newOperatorStakeHistory.length, 1, "invalid operator stake history length");
-                assertEq(newOperatorStakeHistory[0].stake, 0, "invalid operator stake history stake");
+                assertEq(
+                    newOperatorStakeHistory[0].stake, 0, "invalid operator stake history stake"
+                );
                 assertEq(
                     newOperatorStakeHistory[0].updateBlockNumber,
                     uint32(block.number),

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -1150,16 +1150,14 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
             IStrategy(address(uint160(uint256(keccak256(abi.encodePacked(quorumNumber)))))),
             uint96(WEIGHTING_DIVISOR)
         );
+        cheats.prank(address(registryCoordinator));
+        stakeRegistry.initializeSlashableStakeQuorum(quorumNumber, 1, 7 days, strategyParams);
         IStakeRegistryTypes.StakeType stakeType = stakeRegistry.stakeTypePerQuorum(quorumNumber);
         assertEq(
             uint8(stakeType),
             uint8(IStakeRegistryTypes.StakeType.TOTAL_SLASHABLE),
             "invalid stake type"
         );
-
-        // Create the quorum
-        cheats.prank(address(registryCoordinator));
-        stakeRegistry.initializeSlashableStakeQuorum(quorumNumber, 1, 7 days, strategyParams);
 
         cheats.prank(registryCoordinatorOwner);
         stakeRegistry.setSlashableStakeLookahead(quorumNumber, lookAheadBlocks);

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -1167,6 +1167,34 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
         );
     }
 
+    function test_SetSlashableLookAhead_EmitsEvent() public {
+        uint8 quorumNumber = nextQuorum;
+        uint32 lookAheadBlocks = 10;
+
+        // Create a new slashable quorum
+        IStakeRegistryTypes.StrategyParams[] memory strategyParams =
+            new IStakeRegistryTypes.StrategyParams[](1);
+        strategyParams[0] = IStakeRegistryTypes.StrategyParams(
+            IStrategy(address(uint160(uint256(keccak256(abi.encodePacked(quorumNumber)))))),
+            uint96(WEIGHTING_DIVISOR)
+        );
+        cheats.prank(address(registryCoordinator));
+        stakeRegistry.initializeSlashableStakeQuorum(quorumNumber, 1, 7 days, strategyParams);
+        IStakeRegistryTypes.StakeType stakeType = stakeRegistry.stakeTypePerQuorum(quorumNumber);
+        assertEq(
+            uint8(stakeType),
+            uint8(IStakeRegistryTypes.StakeType.TOTAL_SLASHABLE),
+            "invalid stake type"
+        );
+
+        uint32 oldLookahead = stakeRegistry.slashableStakeLookAheadPerQuorum(quorumNumber);
+
+        cheats.prank(registryCoordinatorOwner);
+        cheats.expectEmit(true, true, true, true);
+        emit IStakeRegistryEvents.LookAheadPeriodChanged(oldLookahead, lookAheadBlocks);
+        stakeRegistry.setSlashableStakeLookahead(quorumNumber, lookAheadBlocks);
+    }
+
     /**
      *
      *                        getStakeHistory

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -1124,7 +1124,7 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
         uint8 quorumNumber,
         uint32 lookAheadBlocks
     ) public {
-        // Only consider existing quorums and quorums which have delegated stake
+        // Only consider existing quorums and quorums which use delegated stake
         cheats.assume(quorumNumber < nextQuorum);
         cheats.assume(
             stakeRegistry.stakeTypePerQuorum(quorumNumber)
@@ -1135,7 +1135,7 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
         stakeRegistry.setSlashableStakeLookahead(quorumNumber, lookAheadBlocks);
     }
 
-    /// @dev Fuzzes initialized quorum numbers and sets stake look ahead
+    /// @dev Fuzzes slashable quorum numbers and sets stake look ahead
     function testFuzz_setSlashableStakeLookahead(
         uint8 quorumNumber,
         uint32 lookAheadBlocks
@@ -1178,12 +1178,12 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
         RegisterSetup memory setup = _fuzz_setupRegisterOperator(quorumBitmap, additionalStake);
 
         // State history should be empty
-        IStakeRegistry.StakeUpdate[][] memory operatorStakeHistories =
-            _getOperatorStakeHistories(setup.operatorId, setup.quorumNumbers);
-        for (uint256 i = 0; i < setup.quorumNumbers.length; i++) {
-            assertTrue(
-                operatorStakeHistories[i].length == 0, "invalid operator stake history length"
-            );
+        {
+            IStakeRegistry.StakeUpdate[][] memory stakeHistories =
+                _getOperatorStakeHistories(setup.operatorId, setup.quorumNumbers);
+            for (uint256 i = 0; i < setup.quorumNumbers.length; i++) {
+                assertTrue(stakeHistories[i].length == 0, "invalid operator stake history length");
+            }
         }
 
         // Register the Operator
@@ -1192,11 +1192,32 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
             stakeRegistry.registerOperator(setup.operator, setup.operatorId, setup.quorumNumbers);
 
         // Check state history after registration
-        IStakeRegistry.StakeUpdate[][] memory operatorStakeHistoriesPost =
-            _getOperatorStakeHistories(setup.operatorId, setup.quorumNumbers);
-        for (uint256 i = 0; i < setup.quorumNumbers.length; i++) {
-            IStakeRegistry.StakeUpdate[] memory operatorStakeHistory = operatorStakeHistoriesPost[i];
-            assertTrue(operatorStakeHistory.length == 1, "invalid operator stake history length");
+        {
+            IStakeRegistry.StakeUpdate[] memory stakeUpdates =
+                _getLatestStakeUpdates(setup.operatorId, setup.quorumNumbers);
+            IStakeRegistry.StakeUpdate[][] memory stakeHistories =
+                _getOperatorStakeHistories(setup.operatorId, setup.quorumNumbers);
+            for (uint256 i = 0; i < setup.quorumNumbers.length; i++) {
+                IStakeRegistry.StakeUpdate[] memory stakeHistory = stakeHistories[i];
+                assertTrue(
+                    stakeHistory.length == 1, "invalid operator stake history length"
+                );
+                assertEq(
+                    stakeHistory[0].stake,
+                    stakeUpdates[i].stake,
+                    "invalid operator stake history stake"
+                );
+                assertEq(
+                    stakeHistory[0].updateBlockNumber,
+                    stakeUpdates[i].updateBlockNumber,
+                    "invalid operator stake history update block number"
+                );
+                assertEq(
+                    stakeHistory[0].nextUpdateBlockNumber,
+                    stakeUpdates[i].nextUpdateBlockNumber,
+                    "invalid operator stake history next update block number"
+                );
+            }
         }
     }
 
@@ -1209,15 +1230,32 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
             fuzzy_toRemove: quorumsToRemove,
             fuzzy_addtlStake: additionalStake
         });
+        uint32 blockNum = uint32(block.number);
 
-        // Check stake history
-        IStakeRegistry.StakeUpdate[][] memory operatorStakeHistories =
-            _getOperatorStakeHistories(setup.operatorId, setup.registeredQuorumNumbers);
-        for (uint256 i = 0; i < setup.registeredQuorumNumbers.length; i++) {
-            assertTrue(
-                operatorStakeHistories[i].length == 1, "invalid operator stake history length"
-            );
-            IStakeRegistry.StakeUpdate memory operatorStake = operatorStakeHistories[i][0];
+        {
+            IStakeRegistry.StakeUpdate[] memory stakeUpdates =
+                _getLatestStakeUpdates(setup.operatorId, setup.registeredQuorumNumbers);
+            IStakeRegistry.StakeUpdate[][] memory stakeHistories =
+                _getOperatorStakeHistories(setup.operatorId, setup.registeredQuorumNumbers);
+            for (uint256 i = 0; i < setup.registeredQuorumNumbers.length; i++) {
+                assertTrue(stakeHistories[i].length == 1, "invalid operator stake history length");
+                IStakeRegistry.StakeUpdate memory stakeHistory = stakeHistories[i][0];
+                assertEq(
+                    stakeHistory.stake,
+                    stakeUpdates[i].stake,
+                    "invalid operator stake history stake2"
+                );
+                assertEq(
+                    stakeHistory.updateBlockNumber,
+                    blockNum,
+                    "invalid operator stake history update block number"
+                );
+                assertEq(
+                    stakeHistory.nextUpdateBlockNumber,
+                    stakeUpdates[i].nextUpdateBlockNumber,
+                    "invalid operator stake history next update block number"
+                );
+            }
         }
 
         // deregisterOperator
@@ -1225,11 +1263,30 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
         stakeRegistry.deregisterOperator(setup.operatorId, setup.quorumsToRemove);
 
         // Check stake history after deregistration in the same block
-        IStakeRegistry.StakeUpdate[][] memory operatorStakeHistoriesPost =
-            _getOperatorStakeHistories(setup.operatorId, setup.registeredQuorumNumbers);
-        for (uint256 i = 0; i < setup.registeredQuorumNumbers.length; i++) {
-            IStakeRegistry.StakeUpdate[] memory operatorStakeHistory = operatorStakeHistoriesPost[i];
-            assertTrue(operatorStakeHistory.length == 1, "invalid operator stake history length");
+        {
+            IStakeRegistry.StakeUpdate[] memory stakeUpdates =
+                _getLatestStakeUpdates(setup.operatorId, setup.registeredQuorumNumbers);
+            IStakeRegistry.StakeUpdate[][] memory stakeHistories =
+                _getOperatorStakeHistories(setup.operatorId, setup.registeredQuorumNumbers);
+            for (uint256 i = 0; i < setup.registeredQuorumNumbers.length; i++) {
+                assertTrue(stakeHistories[i].length == 1, "invalid operator stake history length");
+                IStakeRegistry.StakeUpdate memory stakeHistory = stakeHistories[i][0];
+                assertEq(
+                    stakeHistory.stake,
+                    stakeUpdates[i].stake,
+                    "invalid operator stake history stake2"
+                );
+                assertEq(
+                    stakeHistory.updateBlockNumber,
+                    blockNum,
+                    "invalid operator stake history update block number"
+                );
+                assertEq(
+                    stakeHistory.nextUpdateBlockNumber,
+                    stakeUpdates[i].nextUpdateBlockNumber,
+                    "invalid operator stake history next update block number"
+                );
+            }
         }
     }
 
@@ -1248,25 +1305,24 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
             fuzzy_addtlStake: additionalStake
         });
 
-        emit log_uint(block.number);
-        IStakeRegistry.StakeUpdate[] memory regOperatorStakes =
-            _getLatestStakeUpdates(setup.operatorId, setup.registeredQuorumNumbers);
-        IStakeRegistry.StakeUpdate[] memory operatorStakeUpdates =
-            _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.registeredQuorumNumbers, 0);
-        for (uint256 i = 0; i < setup.registeredQuorumNumbers.length; i++) {
-            assertEq(
-                operatorStakeUpdates[i].stake, regOperatorStakes[i].stake, "invalid operator stake"
-            );
-            assertEq(
-                operatorStakeUpdates[i].updateBlockNumber,
-                regOperatorStakes[i].updateBlockNumber,
-                "invalid operator stake update block number"
-            );
-            assertEq(
-                operatorStakeUpdates[i].nextUpdateBlockNumber,
-                regOperatorStakes[i].nextUpdateBlockNumber,
-                "invalid operator stake next update block number"
-            );
+        {
+            IStakeRegistry.StakeUpdate[] memory stakeUpdates =
+                _getLatestStakeUpdates(setup.operatorId, setup.registeredQuorumNumbers);
+            IStakeRegistry.StakeUpdate[] memory indexStakeUpdate =
+                _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.registeredQuorumNumbers, 0);
+            for (uint256 i = 0; i < setup.registeredQuorumNumbers.length; i++) {
+                assertEq(indexStakeUpdate[i].stake, stakeUpdates[i].stake, "invalid operator stake");
+                assertEq(
+                    indexStakeUpdate[i].updateBlockNumber,
+                    uint32(block.number),
+                    "invalid operator stake update block number"
+                );
+                assertEq(
+                    indexStakeUpdate[i].nextUpdateBlockNumber,
+                    stakeUpdates[i].nextUpdateBlockNumber,
+                    "invalid operator stake next update block number"
+                );
+            }
         }
 
         // Force block to be mined to ensure new stake update is registered
@@ -1275,28 +1331,25 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
         // deregisterOperator
         cheats.prank(address(registryCoordinator));
         stakeRegistry.deregisterOperator(setup.operatorId, setup.quorumsToRemove);
-        emit log_uint(block.number);
 
-        IStakeRegistry.StakeUpdate[] memory deregOperatorStakes =
-            _getLatestStakeUpdates(setup.operatorId, setup.quorumsToRemove);
-        IStakeRegistry.StakeUpdate[] memory operatorStakeUpdatesPost =
-            _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.quorumsToRemove, 1);
-        for (uint256 i = 0; i < setup.quorumsToRemove.length; i++) {
-            assertEq(
-                operatorStakeUpdatesPost[i].stake,
-                deregOperatorStakes[i].stake,
-                "invalid operator stake"
-            );
-            assertEq(
-                operatorStakeUpdatesPost[i].updateBlockNumber,
-                deregOperatorStakes[i].updateBlockNumber,
-                "invalid operator stake update block number"
-            );
-            assertEq(
-                operatorStakeUpdatesPost[i].nextUpdateBlockNumber,
-                deregOperatorStakes[i].nextUpdateBlockNumber,
-                "invalid operator stake next update block number"
-            );
+        {
+            IStakeRegistry.StakeUpdate[] memory stakeUpdates =
+                _getLatestStakeUpdates(setup.operatorId, setup.quorumsToRemove);
+            IStakeRegistry.StakeUpdate[] memory indexStakeUpdate =
+                _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.quorumsToRemove, 1);
+            for (uint256 i = 0; i < setup.quorumsToRemove.length; i++) {
+                assertEq(indexStakeUpdate[i].stake, stakeUpdates[i].stake, "invalid operator stake");
+                assertEq(
+                    indexStakeUpdate[i].updateBlockNumber,
+                    uint32(block.number),
+                    "invalid operator stake update block number"
+                );
+                assertEq(
+                    indexStakeUpdate[i].nextUpdateBlockNumber,
+                    stakeUpdates[i].nextUpdateBlockNumber,
+                    "invalid operator stake next update block number"
+                );
+            }
         }
     }
 
@@ -1309,53 +1362,54 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
             fuzzy_toRemove: quorumsToRemove,
             fuzzy_addtlStake: additionalStake
         });
+        uint32 blockNum = uint32(block.number);
 
-        emit log_uint(block.number);
-        IStakeRegistry.StakeUpdate[] memory regOperatorStakes =
-            _getLatestStakeUpdates(setup.operatorId, setup.registeredQuorumNumbers);
-        IStakeRegistry.StakeUpdate[] memory operatorStakeUpdates =
-            _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.registeredQuorumNumbers, 0);
-        for (uint256 i = 0; i < setup.registeredQuorumNumbers.length; i++) {
-            assertEq(
-                operatorStakeUpdates[i].stake, regOperatorStakes[i].stake, "invalid operator stake"
-            );
-            assertEq(
-                operatorStakeUpdates[i].updateBlockNumber,
-                regOperatorStakes[i].updateBlockNumber,
-                "invalid operator stake update block number"
-            );
-            assertEq(
-                operatorStakeUpdates[i].nextUpdateBlockNumber,
-                regOperatorStakes[i].nextUpdateBlockNumber,
-                "invalid operator stake next update block number"
-            );
+        {
+            IStakeRegistry.StakeUpdate[] memory stakeUpdates =
+                _getLatestStakeUpdates(setup.operatorId, setup.registeredQuorumNumbers);
+            IStakeRegistry.StakeUpdate[] memory indexStakeUpdate =
+                _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.registeredQuorumNumbers, 0);
+            for (uint256 i = 0; i < setup.registeredQuorumNumbers.length; i++) {
+                assertEq(indexStakeUpdate[i].stake, stakeUpdates[i].stake, "invalid operator stake");
+                assertEq(
+                    indexStakeUpdate[i].updateBlockNumber,
+                    blockNum,
+                    "invalid operator stake update block number"
+                );
+                assertEq(
+                    indexStakeUpdate[i].nextUpdateBlockNumber,
+                    stakeUpdates[i].nextUpdateBlockNumber,
+                    "invalid operator stake next update block number"
+                );
+            }
         }
 
         // deregisterOperator
         cheats.prank(address(registryCoordinator));
         stakeRegistry.deregisterOperator(setup.operatorId, setup.quorumsToRemove);
-        emit log_uint(block.number);
 
-        IStakeRegistry.StakeUpdate[] memory deregOperatorStakes =
-            _getLatestStakeUpdates(setup.operatorId, setup.quorumsToRemove);
-        IStakeRegistry.StakeUpdate[] memory operatorStakeUpdatesPost =
-            _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.quorumsToRemove, 0);
-        for (uint256 i = 0; i < setup.quorumsToRemove.length; i++) {
-            assertEq(
-                operatorStakeUpdatesPost[i].stake,
-                deregOperatorStakes[i].stake,
-                "invalid operator stake"
-            );
-            assertEq(
-                operatorStakeUpdatesPost[i].updateBlockNumber,
-                deregOperatorStakes[i].updateBlockNumber,
-                "invalid operator stake update block number"
-            );
-            assertEq(
-                operatorStakeUpdatesPost[i].nextUpdateBlockNumber,
-                deregOperatorStakes[i].nextUpdateBlockNumber,
-                "invalid operator stake next update block number"
-            );
+        {
+            IStakeRegistry.StakeUpdate[] memory stakeUpdates =
+                _getLatestStakeUpdates(setup.operatorId, setup.quorumsToRemove);
+            IStakeRegistry.StakeUpdate[] memory operatorStakeUpdatesPost =
+                _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.quorumsToRemove, 0);
+            for (uint256 i = 0; i < setup.quorumsToRemove.length; i++) {
+                assertEq(
+                    operatorStakeUpdatesPost[i].stake,
+                    stakeUpdates[i].stake,
+                    "invalid operator stake"
+                );
+                assertEq(
+                    operatorStakeUpdatesPost[i].updateBlockNumber,
+                    blockNum,
+                    "invalid operator stake update block number"
+                );
+                assertEq(
+                    operatorStakeUpdatesPost[i].nextUpdateBlockNumber,
+                    stakeUpdates[i].nextUpdateBlockNumber,
+                    "invalid operator stake next update block number"
+                );
+            }
         }
     }
 }

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -83,18 +83,6 @@ contract StakeRegistryUnitTests is MockAVSDeployer, IStakeRegistryEvents {
         _initializeQuorum({minimumStake: uint96(type(uint24).max) + 1});
         _initializeQuorum({minimumStake: uint96(type(uint32).max) + 1});
         _initializeQuorum({minimumStake: uint96(type(uint64).max) + 1});
-
-        // TODO: fix this, this will make setSlashableStake pass, but everything else fail
-        // // Initialize several slashable quorums with varying minimum stakes
-        // _initializeQuorumSlashable({minimumStake: uint96(type(uint16).max)});
-        // _initializeQuorumSlashable({minimumStake: uint96(type(uint24).max)});
-        // _initializeQuorumSlashable({minimumStake: uint96(type(uint32).max)});
-        // _initializeQuorumSlashable({minimumStake: uint96(type(uint64).max)});
-
-        // _initializeQuorumSlashable({minimumStake: uint96(type(uint16).max) + 1});
-        // _initializeQuorumSlashable({minimumStake: uint96(type(uint24).max) + 1});
-        // _initializeQuorumSlashable({minimumStake: uint96(type(uint32).max) + 1});
-        // _initializeQuorumSlashable({minimumStake: uint96(type(uint64).max) + 1});
     }
 
     /**
@@ -128,38 +116,6 @@ contract StakeRegistryUnitTests is MockAVSDeployer, IStakeRegistryEvents {
         assertEq(
             uint8(stakeType),
             uint8(IStakeRegistryTypes.StakeType.TOTAL_DELEGATED),
-            "invalid stake type"
-        );
-
-        // Mark quorum initialized for other tests
-        initializedQuorumBitmap = uint192(initializedQuorumBitmap.setBit(quorumNumber));
-        initializedQuorumBytes = initializedQuorumBitmap.bitmapToBytesArray();
-    }
-
-    /**
-     * // TODO (James): dev docs
-     */
-    function _initializeQuorumSlashable(
-        uint96 minimumStake
-    ) internal {
-        uint8 quorumNumber = nextQuorum;
-
-        IStakeRegistryTypes.StrategyParams[] memory strategyParams =
-            new IStakeRegistryTypes.StrategyParams[](1);
-        strategyParams[0] = IStakeRegistryTypes.StrategyParams(
-            IStrategy(address(uint160(uint256(keccak256(abi.encodePacked(quorumNumber)))))),
-            uint96(WEIGHTING_DIVISOR)
-        );
-
-        nextQuorum++;
-
-        cheats.prank(address(registryCoordinator));
-        stakeRegistry.initializeSlashableStakeQuorum(quorumNumber, minimumStake, 1, strategyParams);
-
-        IStakeRegistryTypes.StakeType stakeType = stakeRegistry.stakeTypePerQuorum(quorumNumber);
-        assertEq(
-            uint8(stakeType),
-            uint8(IStakeRegistryTypes.StakeType.TOTAL_SLASHABLE),
             "invalid stake type"
         );
 
@@ -1184,12 +1140,27 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
         uint8 quorumNumber,
         uint32 lookAheadBlocks
     ) public {
-        cheats.assume(quorumNumber < nextQuorum);
+        // Only consider non-existing quorums
+        cheats.assume(quorumNumber >= nextQuorum);
 
-        cheats.assume(
-            stakeRegistry.stakeTypePerQuorum(quorumNumber)
-                == IStakeRegistryTypes.StakeType.TOTAL_SLASHABLE
+        // Create a new slashable quorum
+        IStakeRegistryTypes.StrategyParams[] memory strategyParams =
+            new IStakeRegistryTypes.StrategyParams[](1);
+        strategyParams[0] = IStakeRegistryTypes.StrategyParams(
+            IStrategy(address(uint160(uint256(keccak256(abi.encodePacked(quorumNumber)))))),
+            uint96(WEIGHTING_DIVISOR)
         );
+        IStakeRegistryTypes.StakeType stakeType = stakeRegistry.stakeTypePerQuorum(quorumNumber);
+        assertEq(
+            uint8(stakeType),
+            uint8(IStakeRegistryTypes.StakeType.TOTAL_SLASHABLE),
+            "invalid stake type"
+        );
+
+        // Create the quorum
+        cheats.prank(address(registryCoordinator));
+        stakeRegistry.initializeSlashableStakeQuorum(quorumNumber, 1, 7 days, strategyParams);
+
         cheats.prank(registryCoordinatorOwner);
         stakeRegistry.setSlashableStakeLookahead(quorumNumber, lookAheadBlocks);
         assertEq(
@@ -1269,7 +1240,10 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
      *                        getStakeUpdateAtIndex
      *
      */
-    function testFuzz_getStakeUpdateAtIndex(uint192 quorumsToRemove, uint16 additionalStake) public {
+    function testFuzz_getStakeUpdateAtIndex(
+        uint192 quorumsToRemove,
+        uint16 additionalStake
+    ) public {
         DeregisterSetup memory setup = _fuzz_setupDeregisterOperator({
             registeredFor: initializedQuorumBitmap,
             fuzzy_toRemove: quorumsToRemove,
@@ -1311,7 +1285,9 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
             _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.quorumsToRemove, 1);
         for (uint256 i = 0; i < setup.quorumsToRemove.length; i++) {
             assertEq(
-                operatorStakeUpdatesPost[i].stake, deregOperatorStakes[i].stake, "invalid operator stake"
+                operatorStakeUpdatesPost[i].stake,
+                deregOperatorStakes[i].stake,
+                "invalid operator stake"
             );
             assertEq(
                 operatorStakeUpdatesPost[i].updateBlockNumber,
@@ -1326,7 +1302,10 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
         }
     }
 
-    function testFuzz_getStakeUpdateAtIndex_SingleBlock(uint192 quorumsToRemove, uint16 additionalStake) public {
+    function testFuzz_getStakeUpdateAtIndex_SingleBlock(
+        uint192 quorumsToRemove,
+        uint16 additionalStake
+    ) public {
         DeregisterSetup memory setup = _fuzz_setupDeregisterOperator({
             registeredFor: initializedQuorumBitmap,
             fuzzy_toRemove: quorumsToRemove,
@@ -1365,7 +1344,9 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
             _getOperatorStakeUpdatesAtIndex(setup.operatorId, setup.quorumsToRemove, 0);
         for (uint256 i = 0; i < setup.quorumsToRemove.length; i++) {
             assertEq(
-                operatorStakeUpdatesPost[i].stake, deregOperatorStakes[i].stake, "invalid operator stake"
+                operatorStakeUpdatesPost[i].stake,
+                deregOperatorStakes[i].stake,
+                "invalid operator stake"
             );
             assertEq(
                 operatorStakeUpdatesPost[i].updateBlockNumber,

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -512,6 +512,23 @@ contract StakeRegistryUnitTests is MockAVSDeployer, IStakeRegistryEvents {
         return operatorStakeHistoryLengths;
     }
 
+    /// @dev Return the stake histories for an operator for each quorum
+    function _getOperatorStakeHistories(
+        bytes32 operatorId,
+        bytes memory quorumNumbers
+    ) internal view returns (IStakeRegistry.StakeUpdate[][] memory) {
+        IStakeRegistry.StakeUpdate[][] memory operatorStakeHistories =
+            new IStakeRegistry.StakeUpdate[][](quorumNumbers.length);
+
+        for (uint256 i = 0; i < quorumNumbers.length; i++) {
+            uint8 quorumNumber = uint8(quorumNumbers[i]);
+
+            operatorStakeHistories[i] = stakeRegistry.getStakeHistory(operatorId, quorumNumber);
+        }
+
+        return operatorStakeHistories;
+    }
+
     /// @dev Return the lengths of the total stake update history
     function _getTotalStakeHistoryLengths(
         bytes memory quorumNumbers
@@ -1088,6 +1105,7 @@ contract StakeRegistryUnitTests_Config is StakeRegistryUnitTests {
         uint8 quorumNumber,
         uint32 lookAheadBlocks
     ) public {
+        // Only consider existing quorums and quorums which have delegated stake
         cheats.assume(quorumNumber < nextQuorum);
         cheats.assume(
             stakeRegistry.stakeTypePerQuorum(quorumNumber)

--- a/test/unit/VetoableSlasher.t.sol
+++ b/test/unit/VetoableSlasher.t.sol
@@ -1,0 +1,532 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+import {VetoableSlasher} from "../../src/slashers/VetoableSlasher.sol";
+import {
+    IAllocationManager,
+    IAllocationManagerTypes
+} from "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IAVSRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IAVSRegistrar.sol";
+import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
+import {IRegistryCoordinator} from "../../src/interfaces/IRegistryCoordinator.sol";
+import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
+import {ISlasher, ISlasherTypes, ISlasherErrors} from "../../src/interfaces/ISlasher.sol";
+import {ISlashingRegistryCoordinator} from "../../src/interfaces/ISlashingRegistryCoordinator.sol";
+import {IStakeRegistry, IStakeRegistryTypes} from "../../src/interfaces/IStakeRegistry.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {TransparentUpgradeableProxy} from
+    "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {EmptyContract} from "eigenlayer-contracts/src/test/mocks/EmptyContract.sol";
+import {AllocationManager} from "eigenlayer-contracts/src/contracts/core/AllocationManager.sol";
+import {PermissionController} from
+    "eigenlayer-contracts/src/contracts/permissions/PermissionController.sol";
+import {PauserRegistry} from "eigenlayer-contracts/src/contracts/permissions/PauserRegistry.sol";
+import {IPauserRegistry} from "eigenlayer-contracts/src/contracts/interfaces/IPauserRegistry.sol";
+import {IDelegationManager} from
+    "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
+import {IStrategyManager} from "eigenlayer-contracts/src/contracts/interfaces/IStrategyManager.sol";
+import {DelegationMock} from "../mocks/DelegationMock.sol";
+import {SlashingRegistryCoordinator} from "../../src/SlashingRegistryCoordinator.sol";
+import {ISlashingRegistryCoordinatorTypes} from
+    "../../src/interfaces/ISlashingRegistryCoordinator.sol";
+import {IBLSApkRegistry, IBLSApkRegistryTypes} from "../../src/interfaces/IBLSApkRegistry.sol";
+import {IIndexRegistry} from "../../src/interfaces/IIndexRegistry.sol";
+import {ISocketRegistry} from "../../src/interfaces/ISocketRegistry.sol";
+import {CoreDeploymentLib} from "../utils/CoreDeployLib.sol";
+import {
+    OperatorWalletLib,
+    Operator,
+    Wallet,
+    BLSWallet,
+    SigningKeyOperationsLib
+} from "../utils/OperatorWalletLib.sol";
+import {OperatorSet} from "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/ERC20Mock.sol";
+import {StrategyFactory} from "eigenlayer-contracts/src/contracts/strategies/StrategyFactory.sol";
+import {StakeRegistry} from "../../src/StakeRegistry.sol";
+import {BLSApkRegistry} from "../../src/BLSApkRegistry.sol";
+import {IndexRegistry} from "../../src/IndexRegistry.sol";
+import {IVetoableSlasherTypes} from "../../src/interfaces/IVetoableSlasher.sol";
+import {SocketRegistry} from "../../src/SocketRegistry.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IVetoableSlasherErrors} from "../../src/interfaces/IVetoableSlasher.sol";
+
+contract VetoableSlasherTest is Test {
+    VetoableSlasher public vetoableSlasher;
+    VetoableSlasher public vetoableSlasherImplementation;
+    ProxyAdmin public proxyAdmin;
+    EmptyContract public emptyContract;
+    CoreDeploymentLib.DeploymentData public coreDeployment;
+    PauserRegistry public pauserRegistry;
+    ERC20Mock public mockToken;
+    StrategyFactory public strategyFactory;
+    StakeRegistry public stakeRegistry;
+    BLSApkRegistry public blsApkRegistry;
+    IndexRegistry public indexRegistry;
+    SocketRegistry public socketRegistry;
+    SlashingRegistryCoordinator public slashingRegistryCoordinator;
+    SlashingRegistryCoordinator public slashingRegistryCoordinatorImplementation;
+
+    address public vetoCommittee;
+    address public slasher;
+    address public serviceManager;
+    Operator public operatorWallet;
+    IStrategy public mockStrategy;
+    address public proxyAdminOwner = address(uint160(uint256(keccak256("proxyAdminOwner"))));
+    address public pauser = address(uint160(uint256(keccak256("pauser"))));
+    address public unpauser = address(uint160(uint256(keccak256("unpauser"))));
+    address public churnApprover = address(uint160(uint256(keccak256("churnApprover"))));
+    address public ejector = address(uint160(uint256(keccak256("ejector"))));
+
+    uint256 constant VETO_PERIOD = 3 days;
+    uint32 constant DEALLOCATION_DELAY = 7 days;
+    uint32 constant ALLOCATION_CONFIGURATION_DELAY = 1 days;
+
+    function setUp() public {
+        serviceManager = address(0x2);
+        vetoCommittee = address(0x3);
+        slasher = address(0x4);
+        operatorWallet = OperatorWalletLib.createOperator("operator");
+
+        mockToken = new ERC20Mock("Mock Token", "MOCK", address(this), 0);
+
+        vm.startPrank(proxyAdminOwner);
+        proxyAdmin = new ProxyAdmin();
+        emptyContract = new EmptyContract();
+
+        address[] memory pausers = new address[](1);
+        pausers[0] = pauser;
+        pauserRegistry = new PauserRegistry(pausers, unpauser);
+
+        CoreDeploymentLib.DeploymentConfigData memory configData;
+        configData.strategyManager.initialOwner = proxyAdminOwner;
+        configData.strategyManager.initialStrategyWhitelister = proxyAdminOwner;
+        configData.strategyManager.initPausedStatus = 0;
+
+        configData.delegationManager.initialOwner = proxyAdminOwner;
+        configData.delegationManager.minWithdrawalDelayBlocks = 50400;
+        configData.delegationManager.initPausedStatus = 0;
+
+        configData.eigenPodManager.initialOwner = proxyAdminOwner;
+        configData.eigenPodManager.initPausedStatus = 0;
+
+        configData.allocationManager.initialOwner = proxyAdminOwner;
+        configData.allocationManager.deallocationDelay = DEALLOCATION_DELAY;
+        configData.allocationManager.allocationConfigurationDelay = ALLOCATION_CONFIGURATION_DELAY;
+        configData.allocationManager.initPausedStatus = 0;
+
+        configData.strategyFactory.initialOwner = proxyAdminOwner;
+        configData.strategyFactory.initPausedStatus = 0;
+
+        configData.avsDirectory.initialOwner = proxyAdminOwner;
+        configData.avsDirectory.initPausedStatus = 0;
+
+        configData.rewardsCoordinator.initialOwner = proxyAdminOwner;
+        configData.rewardsCoordinator.rewardsUpdater =
+            address(0x14dC79964da2C08b23698B3D3cc7Ca32193d9955);
+        configData.rewardsCoordinator.initPausedStatus = 0;
+        configData.rewardsCoordinator.activationDelay = 0;
+        configData.rewardsCoordinator.defaultSplitBips = 1000;
+        configData.rewardsCoordinator.calculationIntervalSeconds = 86400;
+        configData.rewardsCoordinator.maxRewardsDuration = 864000;
+        configData.rewardsCoordinator.maxRetroactiveLength = 86400;
+        configData.rewardsCoordinator.maxFutureLength = 86400;
+        configData.rewardsCoordinator.genesisRewardsTimestamp = 1672531200;
+
+        configData.ethPOSDeposit.ethPOSDepositAddress = address(0x123);
+
+        coreDeployment = CoreDeploymentLib.deployContracts(address(proxyAdmin), configData);
+
+        address strategyManagerOwner = Ownable(coreDeployment.strategyManager).owner();
+        vm.stopPrank();
+
+        vm.startPrank(strategyManagerOwner);
+        IStrategyManager(coreDeployment.strategyManager).setStrategyWhitelister(
+            coreDeployment.strategyFactory
+        );
+        vm.stopPrank();
+
+        vm.startPrank(proxyAdminOwner);
+        mockStrategy = IStrategy(
+            StrategyFactory(coreDeployment.strategyFactory).deployNewStrategy(
+                IERC20(address(mockToken))
+            )
+        );
+
+        // Deploy empty proxies for all registries
+        stakeRegistry = StakeRegistry(
+            address(
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
+            )
+        );
+
+        blsApkRegistry = BLSApkRegistry(
+            address(
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
+            )
+        );
+
+        indexRegistry = IndexRegistry(
+            address(
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
+            )
+        );
+
+        socketRegistry = SocketRegistry(
+            address(
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
+            )
+        );
+
+        slashingRegistryCoordinatorImplementation = new SlashingRegistryCoordinator(
+            IStakeRegistry(address(stakeRegistry)),
+            IBLSApkRegistry(address(blsApkRegistry)),
+            IIndexRegistry(address(indexRegistry)),
+            ISocketRegistry(address(socketRegistry)),
+            IAllocationManager(coreDeployment.allocationManager),
+            IPauserRegistry(address(pauserRegistry))
+        );
+
+        slashingRegistryCoordinator = SlashingRegistryCoordinator(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(slashingRegistryCoordinatorImplementation), address(proxyAdmin), ""
+                )
+            )
+        );
+
+        // Deploy registry implementations pointing to the coordinator
+        StakeRegistry stakeRegistryImplementation = new StakeRegistry(
+            ISlashingRegistryCoordinator(address(slashingRegistryCoordinator)),
+            IDelegationManager(coreDeployment.delegationManager),
+            IAVSDirectory(coreDeployment.avsDirectory),
+            IAllocationManager(coreDeployment.allocationManager)
+        );
+        BLSApkRegistry blsApkRegistryImplementation =
+            new BLSApkRegistry(ISlashingRegistryCoordinator(address(slashingRegistryCoordinator)));
+        IndexRegistry indexRegistryImplementation =
+            new IndexRegistry(ISlashingRegistryCoordinator(address(slashingRegistryCoordinator)));
+        SocketRegistry socketRegistryImplementation =
+            new SocketRegistry(IRegistryCoordinator(address(slashingRegistryCoordinator)));
+
+        // Upgrade all registry proxies
+        proxyAdmin.upgrade(
+            TransparentUpgradeableProxy(payable(address(stakeRegistry))),
+            address(stakeRegistryImplementation)
+        );
+        proxyAdmin.upgrade(
+            TransparentUpgradeableProxy(payable(address(blsApkRegistry))),
+            address(blsApkRegistryImplementation)
+        );
+        proxyAdmin.upgrade(
+            TransparentUpgradeableProxy(payable(address(indexRegistry))),
+            address(indexRegistryImplementation)
+        );
+        proxyAdmin.upgrade(
+            TransparentUpgradeableProxy(payable(address(socketRegistry))),
+            address(socketRegistryImplementation)
+        );
+
+        // Initialize the SlashingRegistryCoordinator first
+        slashingRegistryCoordinator.initialize(
+            proxyAdminOwner, churnApprover, ejector, 0, serviceManager
+        );
+
+        vm.stopPrank();
+
+        vetoableSlasherImplementation = new VetoableSlasher(
+            IAllocationManager(coreDeployment.allocationManager),
+            ISlashingRegistryCoordinator(slashingRegistryCoordinator)
+        );
+
+        vm.startPrank(proxyAdminOwner);
+        vetoableSlasher = VetoableSlasher(
+            address(
+                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
+            )
+        );
+
+        proxyAdmin.upgrade(
+            TransparentUpgradeableProxy(payable(address(vetoableSlasher))),
+            address(vetoableSlasherImplementation)
+        );
+        vm.stopPrank();
+
+        vetoableSlasher.initialize(vetoCommittee, slasher);
+
+        vm.startPrank(serviceManager);
+        PermissionController(coreDeployment.permissionController).setAppointee(
+            address(serviceManager),
+            address(vetoableSlasher),
+            coreDeployment.allocationManager,
+            AllocationManager.slashOperator.selector
+        );
+
+        PermissionController(coreDeployment.permissionController).setAppointee(
+            address(serviceManager),
+            address(slashingRegistryCoordinator),
+            coreDeployment.allocationManager,
+            AllocationManager.createOperatorSets.selector
+        );
+
+        vm.stopPrank();
+
+        uint8 quorumNumber = 0;
+        IStrategy[] memory strategies = new IStrategy[](1);
+        strategies[0] = mockStrategy;
+
+        uint96[] memory minimumStakes = new uint96[](1);
+        minimumStakes[0] = 1 ether;
+
+        IStakeRegistryTypes.StrategyParams[] memory strategyParams =
+            new IStakeRegistryTypes.StrategyParams[](1);
+        strategyParams[0] =
+            IStakeRegistryTypes.StrategyParams({strategy: mockStrategy, multiplier: 1 ether});
+
+        ISlashingRegistryCoordinatorTypes.OperatorSetParam memory operatorSetParams =
+        ISlashingRegistryCoordinatorTypes.OperatorSetParam({
+            maxOperatorCount: 10,
+            kickBIPsOfOperatorStake: 0,
+            kickBIPsOfTotalStake: 0
+        });
+
+        vm.startPrank(proxyAdminOwner);
+        slashingRegistryCoordinator.createSlashableStakeQuorum(
+            operatorSetParams, 1 ether, strategyParams, 0
+        );
+        vm.stopPrank();
+
+        vm.label(address(vetoableSlasher), "VetoableSlasher Proxy");
+        vm.label(address(vetoableSlasherImplementation), "VetoableSlasher Implementation");
+        vm.label(address(slashingRegistryCoordinator), "SlashingRegistryCoordinator Proxy");
+        vm.label(
+            address(slashingRegistryCoordinatorImplementation),
+            "SlashingRegistryCoordinator Implementation"
+        );
+        vm.label(address(proxyAdmin), "ProxyAdmin");
+        vm.label(coreDeployment.allocationManager, "AllocationManager Proxy");
+    }
+
+    function test_initialization() public {
+        assertEq(vetoableSlasher.vetoCommittee(), vetoCommittee);
+        assertEq(vetoableSlasher.VETO_PERIOD(), VETO_PERIOD);
+    }
+
+    function _createMockSlashingParams()
+        internal
+        view
+        returns (IAllocationManagerTypes.SlashingParams memory)
+    {
+        IStrategy[] memory strategies = new IStrategy[](1);
+        strategies[0] = mockStrategy;
+
+        uint256[] memory wadsToSlash = new uint256[](1);
+        wadsToSlash[0] = 0.5e18; // 50% slash
+
+        return IAllocationManagerTypes.SlashingParams({
+            operator: operatorWallet.key.addr,
+            operatorSetId: 1,
+            strategies: strategies,
+            wadsToSlash: wadsToSlash,
+            description: "Test slashing"
+        });
+    }
+
+    function test_queueSlashingRequest_revert_notSlasher() public {
+        IAllocationManagerTypes.SlashingParams memory params = _createMockSlashingParams();
+        vm.expectRevert(ISlasherErrors.OnlySlasher.selector);
+        vetoableSlasher.queueSlashingRequest(params);
+    }
+
+    function test_queueSlashingRequest() public {
+        IAllocationManagerTypes.SlashingParams memory params = _createMockSlashingParams();
+
+        vm.prank(slasher);
+        vetoableSlasher.queueSlashingRequest(params);
+
+        (
+            IAllocationManagerTypes.SlashingParams memory resultParams,
+            uint256 requestTimestamp,
+            IVetoableSlasherTypes.SlashingStatus status
+        ) = vetoableSlasher.slashingRequests(0);
+        IVetoableSlasherTypes.VetoableSlashingRequest memory request =
+            IVetoableSlasherTypes.VetoableSlashingRequest(params, requestTimestamp, status);
+        assertEq(resultParams.operator, operatorWallet.key.addr);
+        assertEq(resultParams.operatorSetId, 1);
+        assertEq(resultParams.wadsToSlash[0], 0.5e18);
+        assertEq(resultParams.description, "Test slashing");
+        assertEq(uint8(status), uint8(IVetoableSlasherTypes.SlashingStatus.Requested));
+        assertEq(requestTimestamp, block.timestamp);
+    }
+
+    function test_cancelSlashingRequest_revert_notVetoCommittee() public {
+        IAllocationManagerTypes.SlashingParams memory params = _createMockSlashingParams();
+
+        vm.prank(slasher);
+        vetoableSlasher.queueSlashingRequest(params);
+
+        vm.expectRevert(IVetoableSlasherErrors.OnlyVetoCommittee.selector);
+        vetoableSlasher.cancelSlashingRequest(0);
+    }
+
+    function test_cancelSlashingRequest_revert_afterVetoPeriod() public {
+        IAllocationManagerTypes.SlashingParams memory params = _createMockSlashingParams();
+
+        vm.prank(slasher);
+        vetoableSlasher.queueSlashingRequest(params);
+
+        vm.warp(block.timestamp + VETO_PERIOD + 1);
+
+        vm.prank(vetoCommittee);
+        vm.expectRevert(IVetoableSlasherErrors.VetoPeriodPassed.selector);
+        vetoableSlasher.cancelSlashingRequest(0);
+    }
+
+    function test_cancelSlashingRequest() public {
+        IAllocationManagerTypes.SlashingParams memory params = _createMockSlashingParams();
+
+        vm.prank(slasher);
+        vetoableSlasher.queueSlashingRequest(params);
+
+        vm.prank(vetoCommittee);
+        vetoableSlasher.cancelSlashingRequest(0);
+
+        (
+            IAllocationManagerTypes.SlashingParams memory resultParams,
+            uint256 requestTimestamp,
+            IVetoableSlasherTypes.SlashingStatus status
+        ) = vetoableSlasher.slashingRequests(0);
+        assertEq(uint8(status), uint8(IVetoableSlasherTypes.SlashingStatus.Cancelled));
+    }
+
+    function test_fulfillSlashingRequest_revert_beforeVetoPeriod() public {
+        IAllocationManagerTypes.SlashingParams memory params = _createMockSlashingParams();
+
+        vm.prank(slasher);
+        vetoableSlasher.queueSlashingRequest(params);
+
+        vm.prank(slasher);
+        vm.expectRevert(IVetoableSlasherErrors.VetoPeriodNotPassed.selector);
+        vetoableSlasher.fulfillSlashingRequest(0);
+    }
+
+    function test_fulfillSlashingRequest() public {
+        vm.skip(false);
+        vm.startPrank(operatorWallet.key.addr);
+        IDelegationManager(coreDeployment.delegationManager).registerAsOperator(
+            address(0), 1, "metadata"
+        );
+
+        uint256 depositAmount = 1 ether;
+        mockToken.mint(operatorWallet.key.addr, depositAmount);
+        mockToken.approve(address(coreDeployment.strategyManager), depositAmount);
+        IStrategyManager(coreDeployment.strategyManager).depositIntoStrategy(
+            mockStrategy, mockToken, depositAmount
+        );
+
+        uint32 minDelay = 1;
+        IAllocationManager(coreDeployment.allocationManager).setAllocationDelay(
+            operatorWallet.key.addr, minDelay
+        );
+        vm.stopPrank();
+
+        vm.roll(block.number + ALLOCATION_CONFIGURATION_DELAY + 1);
+
+        IStrategy[] memory allocStrategies = new IStrategy[](1);
+        allocStrategies[0] = mockStrategy;
+
+        uint64[] memory magnitudes = new uint64[](1);
+        magnitudes[0] = uint64(1 ether); // Allocate full magnitude
+
+        OperatorSet memory operatorSet = OperatorSet({avs: address(serviceManager), id: 0});
+
+        vm.startPrank(serviceManager);
+        IAllocationManagerTypes.CreateSetParams[] memory createParams =
+            new IAllocationManagerTypes.CreateSetParams[](1);
+        createParams[0] =
+            IAllocationManagerTypes.CreateSetParams({operatorSetId: 0, strategies: allocStrategies});
+        IAllocationManager(coreDeployment.allocationManager).setAVSRegistrar(
+            address(serviceManager), IAVSRegistrar(address(slashingRegistryCoordinator))
+        );
+        vm.stopPrank();
+
+        vm.startPrank(operatorWallet.key.addr);
+
+        IAllocationManagerTypes.AllocateParams[] memory allocParams =
+            new IAllocationManagerTypes.AllocateParams[](1);
+        allocParams[0] = IAllocationManagerTypes.AllocateParams({
+            operatorSet: operatorSet,
+            strategies: allocStrategies,
+            newMagnitudes: magnitudes
+        });
+
+        IAllocationManager(coreDeployment.allocationManager).modifyAllocations(
+            operatorWallet.key.addr, allocParams
+        );
+        vm.roll(block.number + 100);
+
+        uint32[] memory operatorSetIds = new uint32[](1);
+        operatorSetIds[0] = 0;
+        bytes32 messageHash = slashingRegistryCoordinator.calculatePubkeyRegistrationMessageHash(
+            operatorWallet.key.addr
+        );
+        IBLSApkRegistryTypes.PubkeyRegistrationParams memory pubkeyParams = IBLSApkRegistryTypes
+            .PubkeyRegistrationParams({
+            pubkeyRegistrationSignature: SigningKeyOperationsLib.sign(
+                operatorWallet.signingKey, messageHash
+            ),
+            pubkeyG1: operatorWallet.signingKey.publicKeyG1,
+            pubkeyG2: operatorWallet.signingKey.publicKeyG2
+        });
+
+        bytes memory registrationData = abi.encode(
+            ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, "socket", pubkeyParams
+        );
+
+        IAllocationManagerTypes.RegisterParams memory registerParams = IAllocationManagerTypes
+            .RegisterParams({
+            avs: address(serviceManager),
+            operatorSetIds: operatorSetIds,
+            data: registrationData
+        });
+        IAllocationManager(coreDeployment.allocationManager).registerForOperatorSets(
+            operatorWallet.key.addr, registerParams
+        );
+        vm.stopPrank();
+
+        vm.roll(block.number + 100);
+
+        // Create slashing params
+        IAllocationManagerTypes.SlashingParams memory params = IAllocationManagerTypes
+            .SlashingParams({
+            operator: operatorWallet.key.addr,
+            operatorSetId: 0,
+            strategies: allocStrategies,
+            wadsToSlash: new uint256[](allocStrategies.length),
+            description: "Test slashing"
+        });
+
+        // Set each wad to slash to 1e18 (100% slash)
+        for (uint256 i = 0; i < params.wadsToSlash.length; i++) {
+            params.wadsToSlash[i] = 1e18;
+        }
+
+        vm.prank(slasher);
+        vetoableSlasher.queueSlashingRequest(params);
+
+        // Wait for veto period to pass
+        vm.warp(block.timestamp + VETO_PERIOD + 1);
+
+        vm.prank(slasher);
+        vetoableSlasher.fulfillSlashingRequest(0);
+
+        (
+            IAllocationManagerTypes.SlashingParams memory resultParams,
+            uint256 requestTimestamp,
+            IVetoableSlasherTypes.SlashingStatus status
+        ) = vetoableSlasher.slashingRequests(0);
+        assertEq(uint8(status), uint8(IVetoableSlasherTypes.SlashingStatus.Completed));
+    }
+}

--- a/test/unit/VetoableSlasher.t.sol
+++ b/test/unit/VetoableSlasher.t.sol
@@ -52,6 +52,7 @@ import {IVetoableSlasherTypes} from "../../src/interfaces/IVetoableSlasher.sol";
 import {SocketRegistry} from "../../src/SocketRegistry.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IVetoableSlasherErrors} from "../../src/interfaces/IVetoableSlasher.sol";
+import {MiddlewareDeployLib} from "../utils/MiddlewareDeployLib.sol";
 
 contract VetoableSlasherTest is Test {
     VetoableSlasher public vetoableSlasher;
@@ -155,86 +156,48 @@ contract VetoableSlasherTest is Test {
             )
         );
 
-        // Deploy empty proxies for all registries
-        stakeRegistry = StakeRegistry(
-            address(
-                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
-            )
-        );
+        MiddlewareDeployLib.MiddlewareDeployConfig memory middlewareConfig;
+        middlewareConfig.instantSlasher.initialOwner = proxyAdminOwner;
+        middlewareConfig.instantSlasher.slasher = slasher;
+        middlewareConfig.slashingRegistryCoordinator.initialOwner = proxyAdminOwner;
+        middlewareConfig.slashingRegistryCoordinator.churnApprover = churnApprover;
+        middlewareConfig.slashingRegistryCoordinator.ejector = ejector;
+        middlewareConfig.slashingRegistryCoordinator.initPausedStatus = 0;
+        middlewareConfig.slashingRegistryCoordinator.serviceManager = serviceManager;
+        middlewareConfig.socketRegistry.initialOwner = proxyAdminOwner;
+        middlewareConfig.indexRegistry.initialOwner = proxyAdminOwner;
+        middlewareConfig.stakeRegistry.initialOwner = proxyAdminOwner;
+        middlewareConfig.stakeRegistry.minimumStake = 1 ether;
+        middlewareConfig.stakeRegistry.strategyParams = 0;
+        middlewareConfig.stakeRegistry.delegationManager = coreDeployment.delegationManager;
+        middlewareConfig.stakeRegistry.avsDirectory = coreDeployment.avsDirectory;
+        {
+            IStakeRegistryTypes.StrategyParams[] memory stratParams =
+                new IStakeRegistryTypes.StrategyParams[](1);
+            stratParams[0] =
+                IStakeRegistryTypes.StrategyParams({strategy: mockStrategy, multiplier: 1 ether});
+            middlewareConfig.stakeRegistry.strategyParamsArray = stratParams;
+        }
+        middlewareConfig.stakeRegistry.lookAheadPeriod = 0;
+        middlewareConfig.stakeRegistry.stakeType = IStakeRegistryTypes.StakeType(1);
+        middlewareConfig.blsApkRegistry.initialOwner = proxyAdminOwner;
 
-        blsApkRegistry = BLSApkRegistry(
-            address(
-                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
-            )
+        MiddlewareDeployLib.MiddlewareDeployData memory middlewareDeployments = MiddlewareDeployLib
+            .deployMiddleware(
+            address(proxyAdmin),
+            coreDeployment.allocationManager,
+            address(pauserRegistry),
+            middlewareConfig
         );
-
-        indexRegistry = IndexRegistry(
-            address(
-                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
-            )
-        );
-
-        socketRegistry = SocketRegistry(
-            address(
-                new TransparentUpgradeableProxy(address(emptyContract), address(proxyAdmin), "")
-            )
-        );
-
-        slashingRegistryCoordinatorImplementation = new SlashingRegistryCoordinator(
-            IStakeRegistry(address(stakeRegistry)),
-            IBLSApkRegistry(address(blsApkRegistry)),
-            IIndexRegistry(address(indexRegistry)),
-            ISocketRegistry(address(socketRegistry)),
-            IAllocationManager(coreDeployment.allocationManager),
-            IPauserRegistry(address(pauserRegistry))
-        );
-
-        slashingRegistryCoordinator = SlashingRegistryCoordinator(
-            address(
-                new TransparentUpgradeableProxy(
-                    address(slashingRegistryCoordinatorImplementation), address(proxyAdmin), ""
-                )
-            )
-        );
-
-        // Deploy registry implementations pointing to the coordinator
-        StakeRegistry stakeRegistryImplementation = new StakeRegistry(
-            ISlashingRegistryCoordinator(address(slashingRegistryCoordinator)),
-            IDelegationManager(coreDeployment.delegationManager),
-            IAVSDirectory(coreDeployment.avsDirectory),
-            IAllocationManager(coreDeployment.allocationManager)
-        );
-        BLSApkRegistry blsApkRegistryImplementation =
-            new BLSApkRegistry(ISlashingRegistryCoordinator(address(slashingRegistryCoordinator)));
-        IndexRegistry indexRegistryImplementation =
-            new IndexRegistry(ISlashingRegistryCoordinator(address(slashingRegistryCoordinator)));
-        SocketRegistry socketRegistryImplementation =
-            new SocketRegistry(IRegistryCoordinator(address(slashingRegistryCoordinator)));
-
-        // Upgrade all registry proxies
-        proxyAdmin.upgrade(
-            TransparentUpgradeableProxy(payable(address(stakeRegistry))),
-            address(stakeRegistryImplementation)
-        );
-        proxyAdmin.upgrade(
-            TransparentUpgradeableProxy(payable(address(blsApkRegistry))),
-            address(blsApkRegistryImplementation)
-        );
-        proxyAdmin.upgrade(
-            TransparentUpgradeableProxy(payable(address(indexRegistry))),
-            address(indexRegistryImplementation)
-        );
-        proxyAdmin.upgrade(
-            TransparentUpgradeableProxy(payable(address(socketRegistry))),
-            address(socketRegistryImplementation)
-        );
-
-        // Initialize the SlashingRegistryCoordinator first
-        slashingRegistryCoordinator.initialize(
-            proxyAdminOwner, churnApprover, ejector, 0, serviceManager
-        );
-
         vm.stopPrank();
+
+        vetoableSlasher = VetoableSlasher(middlewareDeployments.instantSlasher);
+        slashingRegistryCoordinator =
+            SlashingRegistryCoordinator(middlewareDeployments.slashingRegistryCoordinator);
+        stakeRegistry = StakeRegistry(middlewareDeployments.stakeRegistry);
+        blsApkRegistry = BLSApkRegistry(middlewareDeployments.blsApkRegistry);
+        indexRegistry = IndexRegistry(middlewareDeployments.indexRegistry);
+        socketRegistry = SocketRegistry(middlewareDeployments.socketRegistry);
 
         vetoableSlasherImplementation = new VetoableSlasher(
             IAllocationManager(coreDeployment.allocationManager),
@@ -413,7 +376,6 @@ contract VetoableSlasherTest is Test {
     }
 
     function test_fulfillSlashingRequest() public {
-        vm.skip(false);
         vm.startPrank(operatorWallet.key.addr);
         IDelegationManager(coreDeployment.delegationManager).registerAsOperator(
             address(0), 1, "metadata"

--- a/test/unit/VetoableSlasher.t.sol
+++ b/test/unit/VetoableSlasher.t.sol
@@ -81,7 +81,7 @@ contract VetoableSlasherTest is Test {
     address public churnApprover = address(uint160(uint256(keccak256("churnApprover"))));
     address public ejector = address(uint160(uint256(keccak256("ejector"))));
 
-    uint256 constant VETO_PERIOD = 3 days;
+    uint32 constant vetoWindowBlocks = 3 days / 12 seconds;
     uint32 constant DEALLOCATION_DELAY = 7 days;
     uint32 constant ALLOCATION_CONFIGURATION_DELAY = 1 days;
 
@@ -201,7 +201,10 @@ contract VetoableSlasherTest is Test {
 
         vetoableSlasherImplementation = new VetoableSlasher(
             IAllocationManager(coreDeployment.allocationManager),
-            ISlashingRegistryCoordinator(slashingRegistryCoordinator)
+            ISlashingRegistryCoordinator(slashingRegistryCoordinator),
+            slasher,
+            vetoCommittee,
+            vetoWindowBlocks
         );
 
         vm.startPrank(proxyAdminOwner);
@@ -216,8 +219,6 @@ contract VetoableSlasherTest is Test {
             address(vetoableSlasherImplementation)
         );
         vm.stopPrank();
-
-        vetoableSlasher.initialize(vetoCommittee, slasher);
 
         vm.startPrank(serviceManager);
         PermissionController(coreDeployment.permissionController).setAppointee(
@@ -274,7 +275,7 @@ contract VetoableSlasherTest is Test {
 
     function test_initialization() public {
         assertEq(vetoableSlasher.vetoCommittee(), vetoCommittee);
-        assertEq(vetoableSlasher.VETO_PERIOD(), VETO_PERIOD);
+        assertEq(vetoableSlasher.vetoWindowBlocks(), vetoWindowBlocks);
     }
 
     function _createMockSlashingParams()
@@ -340,7 +341,7 @@ contract VetoableSlasherTest is Test {
         vm.prank(slasher);
         vetoableSlasher.queueSlashingRequest(params);
 
-        vm.warp(block.timestamp + VETO_PERIOD + 1);
+        vm.roll(block.number + vetoWindowBlocks + 1);
 
         vm.prank(vetoCommittee);
         vm.expectRevert(IVetoableSlasherErrors.VetoPeriodPassed.selector);
@@ -479,7 +480,7 @@ contract VetoableSlasherTest is Test {
         vetoableSlasher.queueSlashingRequest(params);
 
         // Wait for veto period to pass
-        vm.warp(block.timestamp + VETO_PERIOD + 1);
+        vm.roll(block.number + vetoWindowBlocks + 1);
 
         vm.prank(slasher);
         vetoableSlasher.fulfillSlashingRequest(0);

--- a/test/utils/BN256G2.sol
+++ b/test/utils/BN256G2.sol
@@ -1,0 +1,337 @@
+pragma solidity ^0.8.0;
+
+/**
+ * @title Elliptic curve operations on twist points for alt_bn128
+ * @author Mustafa Al-Bassam (mus@musalbas.com)
+ * @dev Homepage: https://github.com/musalbas/solidity-BN256G2
+ */
+library BN256G2 {
+    uint256 internal constant FIELD_MODULUS =
+        0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47;
+    uint256 internal constant TWISTBX =
+        0x2b149d40ceb8aaae81be18991be06ac3b5b4c5e559dbefa33267e6dc24a138e5;
+    uint256 internal constant TWISTBY =
+        0x9713b03af0fed4cd2cafadeed8fdf4a74fa084e52d1852e4a2bd0685c315d2;
+    uint256 internal constant PTXX = 0;
+    uint256 internal constant PTXY = 1;
+    uint256 internal constant PTYX = 2;
+    uint256 internal constant PTYY = 3;
+    uint256 internal constant PTZX = 4;
+    uint256 internal constant PTZY = 5;
+
+    /**
+     * @notice Add two twist points
+     * @param pt1xx Coefficient 1 of x on point 1
+     * @param pt1xy Coefficient 2 of x on point 1
+     * @param pt1yx Coefficient 1 of y on point 1
+     * @param pt1yy Coefficient 2 of y on point 1
+     * @param pt2xx Coefficient 1 of x on point 2
+     * @param pt2xy Coefficient 2 of x on point 2
+     * @param pt2yx Coefficient 1 of y on point 2
+     * @param pt2yy Coefficient 2 of y on point 2
+     * @return (pt3xx, pt3xy, pt3yx, pt3yy)
+     */
+    function ECTwistAdd(
+        uint256 pt1xx,
+        uint256 pt1xy,
+        uint256 pt1yx,
+        uint256 pt1yy,
+        uint256 pt2xx,
+        uint256 pt2xy,
+        uint256 pt2yx,
+        uint256 pt2yy
+    ) public view returns (uint256, uint256, uint256, uint256) {
+        if (pt1xx == 0 && pt1xy == 0 && pt1yx == 0 && pt1yy == 0) {
+            if (!(pt2xx == 0 && pt2xy == 0 && pt2yx == 0 && pt2yy == 0)) {
+                assert(_isOnCurve(pt2xx, pt2xy, pt2yx, pt2yy));
+            }
+            return (pt2xx, pt2xy, pt2yx, pt2yy);
+        } else if (pt2xx == 0 && pt2xy == 0 && pt2yx == 0 && pt2yy == 0) {
+            assert(_isOnCurve(pt1xx, pt1xy, pt1yx, pt1yy));
+            return (pt1xx, pt1xy, pt1yx, pt1yy);
+        }
+
+        assert(_isOnCurve(pt1xx, pt1xy, pt1yx, pt1yy));
+        assert(_isOnCurve(pt2xx, pt2xy, pt2yx, pt2yy));
+
+        uint256[6] memory pt3 =
+            _ECTwistAddJacobian(pt1xx, pt1xy, pt1yx, pt1yy, 1, 0, pt2xx, pt2xy, pt2yx, pt2yy, 1, 0);
+
+        return _fromJacobian(pt3[PTXX], pt3[PTXY], pt3[PTYX], pt3[PTYY], pt3[PTZX], pt3[PTZY]);
+    }
+
+    /**
+     * @notice Multiply a twist point by a scalar
+     * @param s     Scalar to multiply by
+     * @param pt1xx Coefficient 1 of x
+     * @param pt1xy Coefficient 2 of x
+     * @param pt1yx Coefficient 1 of y
+     * @param pt1yy Coefficient 2 of y
+     * @return (pt2xx, pt2xy, pt2yx, pt2yy)
+     */
+    function ECTwistMul(
+        uint256 s,
+        uint256 pt1xx,
+        uint256 pt1xy,
+        uint256 pt1yx,
+        uint256 pt1yy
+    ) public view returns (uint256, uint256, uint256, uint256) {
+        uint256 pt1zx = 1;
+        if (pt1xx == 0 && pt1xy == 0 && pt1yx == 0 && pt1yy == 0) {
+            pt1xx = 1;
+            pt1yx = 1;
+            pt1zx = 0;
+        } else {
+            assert(_isOnCurve(pt1xx, pt1xy, pt1yx, pt1yy));
+        }
+
+        uint256[6] memory pt2 = _ECTwistMulJacobian(s, pt1xx, pt1xy, pt1yx, pt1yy, pt1zx, 0);
+
+        return _fromJacobian(pt2[PTXX], pt2[PTXY], pt2[PTYX], pt2[PTYY], pt2[PTZX], pt2[PTZY]);
+    }
+
+    /**
+     * @notice Get the field modulus
+     * @return The field modulus
+     */
+    function GetFieldModulus() public pure returns (uint256) {
+        return FIELD_MODULUS;
+    }
+
+    function submod(uint256 a, uint256 b, uint256 n) internal pure returns (uint256) {
+        return addmod(a, n - b, n);
+    }
+
+    function _FQ2Mul(
+        uint256 xx,
+        uint256 xy,
+        uint256 yx,
+        uint256 yy
+    ) internal pure returns (uint256, uint256) {
+        return (
+            submod(mulmod(xx, yx, FIELD_MODULUS), mulmod(xy, yy, FIELD_MODULUS), FIELD_MODULUS),
+            addmod(mulmod(xx, yy, FIELD_MODULUS), mulmod(xy, yx, FIELD_MODULUS), FIELD_MODULUS)
+        );
+    }
+
+    function _FQ2Muc(uint256 xx, uint256 xy, uint256 c) internal pure returns (uint256, uint256) {
+        return (mulmod(xx, c, FIELD_MODULUS), mulmod(xy, c, FIELD_MODULUS));
+    }
+
+    function _FQ2Add(
+        uint256 xx,
+        uint256 xy,
+        uint256 yx,
+        uint256 yy
+    ) internal pure returns (uint256, uint256) {
+        return (addmod(xx, yx, FIELD_MODULUS), addmod(xy, yy, FIELD_MODULUS));
+    }
+
+    function _FQ2Sub(
+        uint256 xx,
+        uint256 xy,
+        uint256 yx,
+        uint256 yy
+    ) internal pure returns (uint256 rx, uint256 ry) {
+        return (submod(xx, yx, FIELD_MODULUS), submod(xy, yy, FIELD_MODULUS));
+    }
+
+    function _FQ2Div(
+        uint256 xx,
+        uint256 xy,
+        uint256 yx,
+        uint256 yy
+    ) internal view returns (uint256, uint256) {
+        (yx, yy) = _FQ2Inv(yx, yy);
+        return _FQ2Mul(xx, xy, yx, yy);
+    }
+
+    function _FQ2Inv(uint256 x, uint256 y) internal view returns (uint256, uint256) {
+        uint256 inv = _modInv(
+            addmod(mulmod(y, y, FIELD_MODULUS), mulmod(x, x, FIELD_MODULUS), FIELD_MODULUS),
+            FIELD_MODULUS
+        );
+        return (mulmod(x, inv, FIELD_MODULUS), FIELD_MODULUS - mulmod(y, inv, FIELD_MODULUS));
+    }
+
+    function _isOnCurve(
+        uint256 xx,
+        uint256 xy,
+        uint256 yx,
+        uint256 yy
+    ) internal pure returns (bool) {
+        uint256 yyx;
+        uint256 yyy;
+        uint256 xxxx;
+        uint256 xxxy;
+        (yyx, yyy) = _FQ2Mul(yx, yy, yx, yy);
+        (xxxx, xxxy) = _FQ2Mul(xx, xy, xx, xy);
+        (xxxx, xxxy) = _FQ2Mul(xxxx, xxxy, xx, xy);
+        (yyx, yyy) = _FQ2Sub(yyx, yyy, xxxx, xxxy);
+        (yyx, yyy) = _FQ2Sub(yyx, yyy, TWISTBX, TWISTBY);
+        return yyx == 0 && yyy == 0;
+    }
+
+    function _modInv(uint256 a, uint256 n) internal view returns (uint256 result) {
+        bool success;
+        assembly ("memory-safe") {
+            let freemem := mload(0x40)
+            mstore(freemem, 0x20)
+            mstore(add(freemem, 0x20), 0x20)
+            mstore(add(freemem, 0x40), 0x20)
+            mstore(add(freemem, 0x60), a)
+            mstore(add(freemem, 0x80), sub(n, 2))
+            mstore(add(freemem, 0xA0), n)
+            success := staticcall(sub(gas(), 2000), 5, freemem, 0xC0, freemem, 0x20)
+            result := mload(freemem)
+        }
+        require(success);
+    }
+
+    function _fromJacobian(
+        uint256 pt1xx,
+        uint256 pt1xy,
+        uint256 pt1yx,
+        uint256 pt1yy,
+        uint256 pt1zx,
+        uint256 pt1zy
+    ) internal view returns (uint256 pt2xx, uint256 pt2xy, uint256 pt2yx, uint256 pt2yy) {
+        uint256 invzx;
+        uint256 invzy;
+        (invzx, invzy) = _FQ2Inv(pt1zx, pt1zy);
+        (pt2xx, pt2xy) = _FQ2Mul(pt1xx, pt1xy, invzx, invzy);
+        (pt2yx, pt2yy) = _FQ2Mul(pt1yx, pt1yy, invzx, invzy);
+    }
+
+    function _ECTwistAddJacobian(
+        uint256 pt1xx,
+        uint256 pt1xy,
+        uint256 pt1yx,
+        uint256 pt1yy,
+        uint256 pt1zx,
+        uint256 pt1zy,
+        uint256 pt2xx,
+        uint256 pt2xy,
+        uint256 pt2yx,
+        uint256 pt2yy,
+        uint256 pt2zx,
+        uint256 pt2zy
+    ) internal pure returns (uint256[6] memory pt3) {
+        if (pt1zx == 0 && pt1zy == 0) {
+            (pt3[PTXX], pt3[PTXY], pt3[PTYX], pt3[PTYY], pt3[PTZX], pt3[PTZY]) =
+                (pt2xx, pt2xy, pt2yx, pt2yy, pt2zx, pt2zy);
+            return pt3;
+        } else if (pt2zx == 0 && pt2zy == 0) {
+            (pt3[PTXX], pt3[PTXY], pt3[PTYX], pt3[PTYY], pt3[PTZX], pt3[PTZY]) =
+                (pt1xx, pt1xy, pt1yx, pt1yy, pt1zx, pt1zy);
+            return pt3;
+        }
+
+        (pt2yx, pt2yy) = _FQ2Mul(pt2yx, pt2yy, pt1zx, pt1zy); // U1 = y2 * z1
+        (pt3[PTYX], pt3[PTYY]) = _FQ2Mul(pt1yx, pt1yy, pt2zx, pt2zy); // U2 = y1 * z2
+        (pt2xx, pt2xy) = _FQ2Mul(pt2xx, pt2xy, pt1zx, pt1zy); // V1 = x2 * z1
+        (pt3[PTZX], pt3[PTZY]) = _FQ2Mul(pt1xx, pt1xy, pt2zx, pt2zy); // V2 = x1 * z2
+
+        if (pt2xx == pt3[PTZX] && pt2xy == pt3[PTZY]) {
+            if (pt2yx == pt3[PTYX] && pt2yy == pt3[PTYY]) {
+                (pt3[PTXX], pt3[PTXY], pt3[PTYX], pt3[PTYY], pt3[PTZX], pt3[PTZY]) =
+                    _ECTwistDoubleJacobian(pt1xx, pt1xy, pt1yx, pt1yy, pt1zx, pt1zy);
+                return pt3;
+            }
+            (pt3[PTXX], pt3[PTXY], pt3[PTYX], pt3[PTYY], pt3[PTZX], pt3[PTZY]) = (1, 0, 1, 0, 0, 0);
+            return pt3;
+        }
+
+        (pt2zx, pt2zy) = _FQ2Mul(pt1zx, pt1zy, pt2zx, pt2zy); // W = z1 * z2
+        (pt1xx, pt1xy) = _FQ2Sub(pt2yx, pt2yy, pt3[PTYX], pt3[PTYY]); // U = U1 - U2
+        (pt1yx, pt1yy) = _FQ2Sub(pt2xx, pt2xy, pt3[PTZX], pt3[PTZY]); // V = V1 - V2
+        (pt1zx, pt1zy) = _FQ2Mul(pt1yx, pt1yy, pt1yx, pt1yy); // V_squared = V * V
+        (pt2yx, pt2yy) = _FQ2Mul(pt1zx, pt1zy, pt3[PTZX], pt3[PTZY]); // V_squared_times_V2 = V_squared * V2
+        (pt1zx, pt1zy) = _FQ2Mul(pt1zx, pt1zy, pt1yx, pt1yy); // V_cubed = V * V_squared
+        (pt3[PTZX], pt3[PTZY]) = _FQ2Mul(pt1zx, pt1zy, pt2zx, pt2zy); // newz = V_cubed * W
+        (pt2xx, pt2xy) = _FQ2Mul(pt1xx, pt1xy, pt1xx, pt1xy); // U * U
+        (pt2xx, pt2xy) = _FQ2Mul(pt2xx, pt2xy, pt2zx, pt2zy); // U * U * W
+        (pt2xx, pt2xy) = _FQ2Sub(pt2xx, pt2xy, pt1zx, pt1zy); // U * U * W - V_cubed
+        (pt2zx, pt2zy) = _FQ2Muc(pt2yx, pt2yy, 2); // 2 * V_squared_times_V2
+        (pt2xx, pt2xy) = _FQ2Sub(pt2xx, pt2xy, pt2zx, pt2zy); // A = U * U * W - V_cubed - 2 * V_squared_times_V2
+        (pt3[PTXX], pt3[PTXY]) = _FQ2Mul(pt1yx, pt1yy, pt2xx, pt2xy); // newx = V * A
+        (pt1yx, pt1yy) = _FQ2Sub(pt2yx, pt2yy, pt2xx, pt2xy); // V_squared_times_V2 - A
+        (pt1yx, pt1yy) = _FQ2Mul(pt1xx, pt1xy, pt1yx, pt1yy); // U * (V_squared_times_V2 - A)
+        (pt1xx, pt1xy) = _FQ2Mul(pt1zx, pt1zy, pt3[PTYX], pt3[PTYY]); // V_cubed * U2
+        (pt3[PTYX], pt3[PTYY]) = _FQ2Sub(pt1yx, pt1yy, pt1xx, pt1xy); // newy = U * (V_squared_times_V2 - A) - V_cubed * U2
+    }
+
+    function _ECTwistDoubleJacobian(
+        uint256 pt1xx,
+        uint256 pt1xy,
+        uint256 pt1yx,
+        uint256 pt1yy,
+        uint256 pt1zx,
+        uint256 pt1zy
+    )
+        internal
+        pure
+        returns (
+            uint256 pt2xx,
+            uint256 pt2xy,
+            uint256 pt2yx,
+            uint256 pt2yy,
+            uint256 pt2zx,
+            uint256 pt2zy
+        )
+    {
+        (pt2xx, pt2xy) = _FQ2Muc(pt1xx, pt1xy, 3); // 3 * x
+        (pt2xx, pt2xy) = _FQ2Mul(pt2xx, pt2xy, pt1xx, pt1xy); // W = 3 * x * x
+        (pt1zx, pt1zy) = _FQ2Mul(pt1yx, pt1yy, pt1zx, pt1zy); // S = y * z
+        (pt2yx, pt2yy) = _FQ2Mul(pt1xx, pt1xy, pt1yx, pt1yy); // x * y
+        (pt2yx, pt2yy) = _FQ2Mul(pt2yx, pt2yy, pt1zx, pt1zy); // B = x * y * S
+        (pt1xx, pt1xy) = _FQ2Mul(pt2xx, pt2xy, pt2xx, pt2xy); // W * W
+        (pt2zx, pt2zy) = _FQ2Muc(pt2yx, pt2yy, 8); // 8 * B
+        (pt1xx, pt1xy) = _FQ2Sub(pt1xx, pt1xy, pt2zx, pt2zy); // H = W * W - 8 * B
+        (pt2zx, pt2zy) = _FQ2Mul(pt1zx, pt1zy, pt1zx, pt1zy); // S_squared = S * S
+        (pt2yx, pt2yy) = _FQ2Muc(pt2yx, pt2yy, 4); // 4 * B
+        (pt2yx, pt2yy) = _FQ2Sub(pt2yx, pt2yy, pt1xx, pt1xy); // 4 * B - H
+        (pt2yx, pt2yy) = _FQ2Mul(pt2yx, pt2yy, pt2xx, pt2xy); // W * (4 * B - H)
+        (pt2xx, pt2xy) = _FQ2Muc(pt1yx, pt1yy, 8); // 8 * y
+        (pt2xx, pt2xy) = _FQ2Mul(pt2xx, pt2xy, pt1yx, pt1yy); // 8 * y * y
+        (pt2xx, pt2xy) = _FQ2Mul(pt2xx, pt2xy, pt2zx, pt2zy); // 8 * y * y * S_squared
+        (pt2yx, pt2yy) = _FQ2Sub(pt2yx, pt2yy, pt2xx, pt2xy); // newy = W * (4 * B - H) - 8 * y * y * S_squared
+        (pt2xx, pt2xy) = _FQ2Muc(pt1xx, pt1xy, 2); // 2 * H
+        (pt2xx, pt2xy) = _FQ2Mul(pt2xx, pt2xy, pt1zx, pt1zy); // newx = 2 * H * S
+        (pt2zx, pt2zy) = _FQ2Mul(pt1zx, pt1zy, pt2zx, pt2zy); // S * S_squared
+        (pt2zx, pt2zy) = _FQ2Muc(pt2zx, pt2zy, 8); // newz = 8 * S * S_squared
+    }
+
+    function _ECTwistMulJacobian(
+        uint256 d,
+        uint256 pt1xx,
+        uint256 pt1xy,
+        uint256 pt1yx,
+        uint256 pt1yy,
+        uint256 pt1zx,
+        uint256 pt1zy
+    ) internal pure returns (uint256[6] memory pt2) {
+        while (d != 0) {
+            if ((d & 1) != 0) {
+                pt2 = _ECTwistAddJacobian(
+                    pt2[PTXX],
+                    pt2[PTXY],
+                    pt2[PTYX],
+                    pt2[PTYY],
+                    pt2[PTZX],
+                    pt2[PTZY],
+                    pt1xx,
+                    pt1xy,
+                    pt1yx,
+                    pt1yy,
+                    pt1zx,
+                    pt1zy
+                );
+            }
+            (pt1xx, pt1xy, pt1yx, pt1yy, pt1zx, pt1zy) =
+                _ECTwistDoubleJacobian(pt1xx, pt1xy, pt1yx, pt1yy, pt1zx, pt1zy);
+
+            d = d / 2;
+        }
+    }
+}

--- a/test/utils/CoreDeployLib.sol
+++ b/test/utils/CoreDeployLib.sol
@@ -1,271 +1,345 @@
-// // SPDX-License-Identifier: UNLICENSED
-// pragma solidity ^0.8.0;
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
 
-// import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
-// import {TransparentUpgradeableProxy} from
-//     "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-// import {UpgradeableBeacon} from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
-// import {DelegationManager} from "eigenlayer-contracts/src/contracts/core/DelegationManager.sol";
-// import {StrategyManager} from "eigenlayer-contracts/src/contracts/core/StrategyManager.sol";
-// import {AVSDirectory} from "eigenlayer-contracts/src/contracts/core/AVSDirectory.sol";
-// import {EigenPodManager} from "eigenlayer-contracts/src/contracts/pods/EigenPodManager.sol";
-// import {RewardsCoordinator} from "eigenlayer-contracts/src/contracts/core/RewardsCoordinator.sol";
-// import {StrategyBase} from "eigenlayer-contracts/src/contracts/strategies/StrategyBase.sol";
-// import {EigenPod} from "eigenlayer-contracts/src/contracts/pods/EigenPod.sol";
-// import {IETHPOSDeposit} from "eigenlayer-contracts/src/contracts/interfaces/IETHPOSDeposit.sol";
-// import {StrategyBaseTVLLimits} from "eigenlayer-contracts/src/contracts/strategies/StrategyBaseTVLLimits.sol";
-// import {PauserRegistry} from "eigenlayer-contracts/src/contracts/permissions/PauserRegistry.sol";
-// import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
-// import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-// import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
-// import {IDelegationManager} from "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
-// import {IBeacon} from "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
-// import {IStrategyManager} from "eigenlayer-contracts/src/contracts/interfaces/IStrategyManager.sol";
-// import {IEigenPodManager} from "eigenlayer-contracts/src/contracts/interfaces/IEigenPodManager.sol";
-// import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
-// import {IPauserRegistry} from "eigenlayer-contracts/src/contracts/interfaces/IPauserRegistry.sol";
-// import {StrategyFactory} from "eigenlayer-contracts/src/contracts/strategies/StrategyFactory.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {TransparentUpgradeableProxy} from
+    "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {UpgradeableBeacon} from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import {DelegationManager} from "eigenlayer-contracts/src/contracts/core/DelegationManager.sol";
+import {StrategyManager} from "eigenlayer-contracts/src/contracts/core/StrategyManager.sol";
+import {AVSDirectory} from "eigenlayer-contracts/src/contracts/core/AVSDirectory.sol";
+import {EigenPodManager} from "eigenlayer-contracts/src/contracts/pods/EigenPodManager.sol";
+import {RewardsCoordinator} from "eigenlayer-contracts/src/contracts/core/RewardsCoordinator.sol";
+import {StrategyBase} from "eigenlayer-contracts/src/contracts/strategies/StrategyBase.sol";
+import {EigenPod} from "eigenlayer-contracts/src/contracts/pods/EigenPod.sol";
+import {IETHPOSDeposit} from "eigenlayer-contracts/src/contracts/interfaces/IETHPOSDeposit.sol";
+import {StrategyBaseTVLLimits} from
+    "eigenlayer-contracts/src/contracts/strategies/StrategyBaseTVLLimits.sol";
+import {PauserRegistry} from "eigenlayer-contracts/src/contracts/permissions/PauserRegistry.sol";
+import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISignatureUtils.sol";
+import {IDelegationManager} from
+    "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
+import {IBeacon} from "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
+import {IStrategyManager} from "eigenlayer-contracts/src/contracts/interfaces/IStrategyManager.sol";
+import {IEigenPodManager} from "eigenlayer-contracts/src/contracts/interfaces/IEigenPodManager.sol";
+import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
+import {IPauserRegistry} from "eigenlayer-contracts/src/contracts/interfaces/IPauserRegistry.sol";
+import {StrategyFactory} from "eigenlayer-contracts/src/contracts/strategies/StrategyFactory.sol";
+import {IPermissionController} from
+    "eigenlayer-contracts/src/contracts/interfaces/IPermissionController.sol";
+import {IAllocationManager} from
+    "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {AllocationManager} from "eigenlayer-contracts/src/contracts/core/AllocationManager.sol";
+import {PermissionController} from
+    "eigenlayer-contracts/src/contracts/permissions/PermissionController.sol";
 
-// import {UpgradeableProxyLib} from "../unit/UpgradeableProxyLib.sol";
+import {UpgradeableProxyLib} from "../unit/UpgradeableProxyLib.sol";
 
-// library CoreDeploymentLib {
-//     using UpgradeableProxyLib for address;
+library CoreDeploymentLib {
+    using UpgradeableProxyLib for address;
 
-//     struct StrategyManagerConfig {
-//         uint256 initPausedStatus;
-//         uint256 initWithdrawalDelayBlocks;
-//     }
+    struct StrategyManagerConfig {
+        uint256 initPausedStatus;
+        address initialOwner;
+        address initialStrategyWhitelister;
+    }
 
-//     struct DelegationManagerConfig {
-//         uint256 initPausedStatus;
-//         IStrategy[] strategies;
-//         uint256 minWithdrawalDelayBlocks;
-//         uint256[] withdrawalDelayBlocks;
+    struct DelegationManagerConfig {
+        uint256 initPausedStatus;
+        address initialOwner;
+        uint32 minWithdrawalDelayBlocks;
+    }
 
-//     }
+    struct EigenPodManagerConfig {
+        uint256 initPausedStatus;
+        address initialOwner;
+    }
 
-//     struct EigenPodManagerConfig {
-//         uint256 initPausedStatus;
-//     }
+    struct AllocationManagerConfig {
+        uint256 initPausedStatus;
+        address initialOwner;
+        uint32 deallocationDelay;
+        uint32 allocationConfigurationDelay;
+    }
 
-//     struct RewardsCoordinatorConfig {
-//         uint256 initPausedStatus;
-//         uint256 maxRewardsDuration;
-//         uint256 maxRetroactiveLength;
-//         uint256 maxFutureLength;
-//         uint256 genesisRewardsTimestamp;
-//         address updater;
-//         uint256 activationDelay;
-//         uint256 calculationIntervalSeconds;
-//         uint256 globalOperatorCommissionBips;
-//     }
+    struct StrategyFactoryConfig {
+        uint256 initPausedStatus;
+        address initialOwner;
+    }
 
-//     struct StrategyFactoryConfig {
-//         uint256 initPausedStatus;
-//     }
+    struct AVSDirectoryConfig {
+        uint256 initPausedStatus;
+        address initialOwner;
+    }
 
-//     struct DeploymentConfigData {
-//         StrategyManagerConfig strategyManager;
-//         DelegationManagerConfig delegationManager;
-//         EigenPodManagerConfig eigenPodManager;
-//         RewardsCoordinatorConfig rewardsCoordinator;
-//         StrategyFactoryConfig strategyFactory;
-//     }
+    struct RewardsCoordinatorConfig {
+        uint256 initPausedStatus;
+        address initialOwner;
+        address rewardsUpdater;
+        uint32 activationDelay;
+        uint16 defaultSplitBips;
+        uint32 calculationIntervalSeconds;
+        uint32 maxRewardsDuration;
+        uint32 maxRetroactiveLength;
+        uint32 maxFutureLength;
+        uint32 genesisRewardsTimestamp;
+    }
 
-//     struct DeploymentData {
-//         address delegationManager;
-//         address avsDirectory;
-//         address strategyManager;
-//         address eigenPodManager;
-//         address rewardsCoordinator;
-//         address eigenPodBeacon;
-//         address pauserRegistry;
-//         address strategyFactory;
-//         address strategyBeacon;
-//     }
+    struct ETHPOSDepositConfig {
+        address ethPOSDepositAddress;
+    }
 
-//     function deployContracts(
-//         address proxyAdmin,
-//         DeploymentConfigData memory configData
-//     ) internal returns (DeploymentData memory) {
-//         DeploymentData memory result;
+    struct EigenPodConfig {
+        uint64 genesisTimestamp;
+    }
 
-//         result.delegationManager = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
-//         result.avsDirectory = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
-//         result.strategyManager = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
-//         result.eigenPodManager = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
-//         result.rewardsCoordinator = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
-//         result.eigenPodBeacon = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
-//         result.pauserRegistry = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
-//         result.strategyFactory = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+    struct DeploymentConfigData {
+        StrategyManagerConfig strategyManager;
+        DelegationManagerConfig delegationManager;
+        EigenPodManagerConfig eigenPodManager;
+        AllocationManagerConfig allocationManager;
+        StrategyFactoryConfig strategyFactory;
+        RewardsCoordinatorConfig rewardsCoordinator;
+        AVSDirectoryConfig avsDirectory;
+        ETHPOSDepositConfig ethPOSDeposit;
+        EigenPodConfig eigenPod;
+    }
 
-//         // Deploy the implementation contracts, using the proxy contracts as inputs
-//         address delegationManagerImpl = address(
-//             new DelegationManager(
-//                 IStrategyManager(result.strategyManager),
-//                 IEigenPodManager(result.eigenPodManager)
-//             )
-//         );
-//         address avsDirectoryImpl =
-//             address(new AVSDirectory(IDelegationManager(result.delegationManager)));
+    struct DeploymentData {
+        address delegationManager;
+        address avsDirectory;
+        address strategyManager;
+        address eigenPodManager;
+        address allocationManager;
+        address eigenPodBeacon;
+        address pauserRegistry;
+        address strategyFactory;
+        address strategyBeacon;
+        address rewardsCoordinator;
+        address permissionController;
+    }
 
-//         address strategyManagerImpl = address(
-//             new StrategyManager(
-//                 IDelegationManager(result.delegationManager),
-//                 IEigenPodManager(result.eigenPodManager)
-//             )
-//         );
+    function deployContracts(
+        address proxyAdmin,
+        DeploymentConfigData memory configData
+    ) internal returns (DeploymentData memory result) {
+        result = deployEmptyProxies(proxyAdmin);
 
-//         address strategyFactoryImpl =
-//             address(new StrategyFactory(IStrategyManager(result.strategyManager)));
+        deployAndConfigureCore(result, configData);
+        deployAndConfigurePods(result, configData);
+        deployAndConfigureStrategies(result, configData);
+        deployAndConfigureRewards(result, configData);
 
-//         address ethPOSDeposit;
-//         if (block.chainid == 1) {
-//             ethPOSDeposit = 0x00000000219ab540356cBB839Cbe05303d7705Fa;
-//         } else {
-//             // For non-mainnet chains, you might want to deploy a mock or read from a config
-//             // This assumes you have a similar config setup as in M2_Deploy_From_Scratch.s.sol
-//             /// TODO: Handle Eth pos
-//         }
+        return result;
+    }
 
-//         address eigenPodManagerImpl = address(
-//             new EigenPodManager(
-//                 IETHPOSDeposit(ethPOSDeposit),
-//                 IBeacon(result.eigenPodBeacon),
-//                 IStrategyManager(result.strategyManager),
-//                 IDelegationManager(result.delegationManager)
-//             )
-//         );
+    function deployEmptyProxies(
+        address proxyAdmin
+    ) internal returns (DeploymentData memory proxies) {
+        proxies.delegationManager = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        proxies.avsDirectory = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        proxies.strategyManager = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        proxies.eigenPodManager = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        proxies.allocationManager = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        proxies.eigenPodBeacon = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        proxies.pauserRegistry = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        proxies.strategyFactory = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        proxies.rewardsCoordinator = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        proxies.permissionController = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        return proxies;
+    }
 
-//         /// TODO: Get actual values
-//         uint32 CALCULATION_INTERVAL_SECONDS = 1 days;
-//         uint32 MAX_REWARDS_DURATION = 1 days;
-//         uint32 MAX_RETROACTIVE_LENGTH = 1;
-//         uint32 MAX_FUTURE_LENGTH = 1;
-//         uint32 GENESIS_REWARDS_TIMESTAMP = 10 days;
-//         address rewardsCoordinatorImpl = address(
-//             new RewardsCoordinator(
-//                 IDelegationManager(result.delegationManager),
-//                 IStrategyManager(result.strategyManager),
-//                 CALCULATION_INTERVAL_SECONDS,
-//                 MAX_REWARDS_DURATION,
-//                 MAX_RETROACTIVE_LENGTH,
-//                 MAX_FUTURE_LENGTH,
-//                 GENESIS_REWARDS_TIMESTAMP
-//             )
-//         );
+    function deployAndConfigureCore(
+        DeploymentData memory deployments,
+        DeploymentConfigData memory config
+    ) internal {
+        // Deploy core implementations
+        address permissionControllerImpl = address(new PermissionController());
 
-//         /// TODO: Get actual genesis time
-//         uint64 GENESIS_TIME = 1_564_000;
+        address strategyManagerImpl = address(
+            new StrategyManager(
+                IDelegationManager(deployments.delegationManager),
+                IPauserRegistry(deployments.pauserRegistry)
+            )
+        );
 
-//         address eigenPodImpl = address(
-//             new EigenPod(
-//                 IETHPOSDeposit(ethPOSDeposit),
-//                 IEigenPodManager(result.eigenPodManager),
-//                 GENESIS_TIME
-//             )
-//         );
-//         address eigenPodBeaconImpl = address(new UpgradeableBeacon(eigenPodImpl));
-//         address baseStrategyImpl =
-//             address(new StrategyBase(IStrategyManager(result.strategyManager)));
-//         /// TODO: PauserRegistry isn't upgradeable
-//         address pauserRegistryImpl = address(
-//             new PauserRegistry(
-//                 new address[](0), // Empty array for pausers
-//                 proxyAdmin // ProxyAdmin as the unpauser
-//             )
-//         );
+        address allocationManagerImpl = address(
+            new AllocationManager(
+                IDelegationManager(deployments.delegationManager),
+                IPauserRegistry(deployments.pauserRegistry),
+                IPermissionController(deployments.permissionController),
+                config.allocationManager.deallocationDelay,
+                config.allocationManager.allocationConfigurationDelay
+            )
+        );
 
-//         // Deploy and configure the strategy beacon
-//         result.strategyBeacon = address(new UpgradeableBeacon(baseStrategyImpl));
+        address delegationManagerImpl = address(
+            new DelegationManager(
+                IStrategyManager(deployments.strategyManager),
+                IEigenPodManager(deployments.eigenPodManager),
+                IAllocationManager(deployments.allocationManager),
+                IPauserRegistry(deployments.pauserRegistry),
+                IPermissionController(deployments.permissionController),
+                config.delegationManager.minWithdrawalDelayBlocks
+            )
+        );
 
-//         // Upgrade contracts
-//         /// TODO: Get from config
-//         bytes memory upgradeCall = abi.encodeWithSelector( /// TODO: Fix abi.encodeCall was failing Cannot implicitly convert component at position 4 from "IStrategy[]" to "IStrategy[]"
-//             DelegationManager.initialize.selector,
-//                 proxyAdmin, // initialOwner
-//                 IPauserRegistry(result.pauserRegistry), // _pauserRegistry
-//                 configData.delegationManager.initPausedStatus, // initialPausedStatus
-//                 configData.delegationManager.minWithdrawalDelayBlocks, // _minWithdrawalDelayBlocks
-//                 configData.delegationManager.strategies, // _strategies
-//                 configData.delegationManager.withdrawalDelayBlocks // _withdrawalDelayBlocks
-//         );
-//         UpgradeableProxyLib.upgradeAndCall(
-//             result.delegationManager, delegationManagerImpl, upgradeCall
-//         );
+        address avsDirectoryImpl = address(
+            new AVSDirectory(
+                IDelegationManager(deployments.delegationManager),
+                IPauserRegistry(deployments.pauserRegistry)
+            )
+        );
 
-//         // Upgrade StrategyManager contract
-//         upgradeCall = abi.encodeCall(
-//             StrategyManager.initialize,
-//             (
-//                 proxyAdmin, // initialOwner
-//                 result.strategyFactory, // initialStrategyWhitelister
-//                 IPauserRegistry(result.pauserRegistry), // _pauserRegistry
-//                 configData.strategyManager.initPausedStatus // initialPausedStatus
-//             )
-//         );
-//         UpgradeableProxyLib.upgradeAndCall(result.strategyManager, strategyManagerImpl, upgradeCall);
+        // Initialize core contracts
+        UpgradeableProxyLib.upgrade(deployments.permissionController, permissionControllerImpl);
 
-//         // Upgrade StrategyFactory contract
-//         upgradeCall = abi.encodeCall(
-//             StrategyFactory.initialize,
-//             (
-//                 proxyAdmin, // initialOwner
-//                 IPauserRegistry(result.pauserRegistry), // _pauserRegistry
-//                 configData.strategyFactory.initPausedStatus, // initialPausedStatus
-//                 IBeacon(result.strategyBeacon)
-//             )
-//         );
-//         UpgradeableProxyLib.upgradeAndCall(result.strategyFactory, strategyFactoryImpl, upgradeCall);
+        bytes memory upgradeCall = abi.encodeCall(
+            StrategyManager.initialize,
+            (
+                config.strategyManager.initialOwner,
+                config.strategyManager.initialStrategyWhitelister,
+                config.strategyManager.initPausedStatus
+            )
+        );
+        UpgradeableProxyLib.upgradeAndCall(
+            deployments.strategyManager, strategyManagerImpl, upgradeCall
+        );
 
-//         // Upgrade EigenPodManager contract
-//         upgradeCall = abi.encodeCall(
-//             EigenPodManager.initialize,
-//             (
-//                 proxyAdmin, // initialOwner
-//                 IPauserRegistry(result.pauserRegistry), // _pauserRegistry
-//                 configData.eigenPodManager.initPausedStatus // initialPausedStatus
-//             )
-//         );
-//         UpgradeableProxyLib.upgradeAndCall(result.eigenPodManager, eigenPodManagerImpl, upgradeCall);
+        upgradeCall = abi.encodeCall(
+            DelegationManager.initialize,
+            (config.delegationManager.initialOwner, config.delegationManager.initPausedStatus)
+        );
+        UpgradeableProxyLib.upgradeAndCall(
+            deployments.delegationManager, delegationManagerImpl, upgradeCall
+        );
 
-//         // Upgrade AVSDirectory contract
-//         upgradeCall = abi.encodeCall(
-//             AVSDirectory.initialize,
-//             (
-//                 proxyAdmin, // initialOwner
-//                 IPauserRegistry(result.pauserRegistry), // _pauserRegistry
-//                 0 // TODO: AVS Missing configinitialPausedStatus
-//             )
-//         );
-//         UpgradeableProxyLib.upgradeAndCall(result.avsDirectory, avsDirectoryImpl, upgradeCall);
+        upgradeCall = abi.encodeCall(
+            AllocationManager.initialize,
+            (config.allocationManager.initialOwner, config.allocationManager.initPausedStatus)
+        );
+        UpgradeableProxyLib.upgradeAndCall(
+            deployments.allocationManager, allocationManagerImpl, upgradeCall
+        );
 
-//         // Upgrade RewardsCoordinator contract
-//         upgradeCall = abi.encodeCall(
-//             RewardsCoordinator.initialize,
-//             (
-//                 proxyAdmin, // initialOwner
-//                 IPauserRegistry(result.pauserRegistry), // _pauserRegistry
-//                 configData.rewardsCoordinator.initPausedStatus, // initialPausedStatus
-//                 /// TODO: is there a setter and is this expected?
-//                 address(0), // rewards updater
-//                 uint32(configData.rewardsCoordinator.activationDelay), // _activationDelay
-//                 uint16(configData.rewardsCoordinator.globalOperatorCommissionBips) // _globalCommissionBips
-//             )
-//         );
-//         UpgradeableProxyLib.upgradeAndCall(
-//             result.rewardsCoordinator, rewardsCoordinatorImpl, upgradeCall
-//         );
+        upgradeCall = abi.encodeCall(
+            AVSDirectory.initialize,
+            (config.avsDirectory.initialOwner, config.avsDirectory.initPausedStatus)
+        );
+        UpgradeableProxyLib.upgradeAndCall(deployments.avsDirectory, avsDirectoryImpl, upgradeCall);
+    }
 
-//         // Upgrade EigenPod contract
-//         upgradeCall = abi.encodeCall(
-//             EigenPod.initialize,
-//             // TODO: Double check this
-//             (address(result.eigenPodManager)) // _podOwner
-//         );
-//         UpgradeableProxyLib.upgradeAndCall(result.eigenPodBeacon, eigenPodImpl, upgradeCall);
+    function deployAndConfigurePods(
+        DeploymentData memory deployments,
+        DeploymentConfigData memory config
+    ) internal {
+        address ethPOSDeposit = config.ethPOSDeposit.ethPOSDepositAddress;
+        if (ethPOSDeposit == address(0)) {
+            if (block.chainid == 1) {
+                ethPOSDeposit = 0x00000000219ab540356cBB839Cbe05303d7705Fa;
+            } else {
+                revert("DEPLOY_MOCK_ETHPOS_CONTRACT");
+            }
+        }
 
-//         return result;
-//     }
+        address eigenPodImpl = address(
+            new EigenPod(
+                IETHPOSDeposit(ethPOSDeposit),
+                IEigenPodManager(deployments.eigenPodManager),
+                config.eigenPod.genesisTimestamp == 0
+                    ? uint64(block.timestamp)
+                    : config.eigenPod.genesisTimestamp
+            )
+        );
 
-// }
+        address eigenPodBeaconImpl = address(new UpgradeableBeacon(eigenPodImpl));
+        UpgradeableProxyLib.upgrade(deployments.eigenPodBeacon, eigenPodBeaconImpl);
+
+        address eigenPodManagerImpl = address(
+            new EigenPodManager(
+                IETHPOSDeposit(ethPOSDeposit),
+                IBeacon(deployments.eigenPodBeacon),
+                IDelegationManager(deployments.delegationManager),
+                IPauserRegistry(deployments.pauserRegistry)
+            )
+        );
+
+        bytes memory upgradeCall = abi.encodeCall(
+            EigenPodManager.initialize,
+            (config.eigenPodManager.initialOwner, config.eigenPodManager.initPausedStatus)
+        );
+        UpgradeableProxyLib.upgradeAndCall(
+            deployments.eigenPodManager, eigenPodManagerImpl, upgradeCall
+        );
+    }
+
+    function deployAndConfigureStrategies(
+        DeploymentData memory deployments,
+        DeploymentConfigData memory config
+    ) internal {
+        address baseStrategyImpl = address(
+            new StrategyBase(
+                IStrategyManager(deployments.strategyManager),
+                IPauserRegistry(deployments.pauserRegistry)
+            )
+        );
+
+        deployments.strategyBeacon = address(new UpgradeableBeacon(baseStrategyImpl));
+
+        address strategyFactoryImpl = address(
+            new StrategyFactory(
+                IStrategyManager(deployments.strategyManager),
+                IPauserRegistry(deployments.pauserRegistry)
+            )
+        );
+
+        bytes memory upgradeCall = abi.encodeCall(
+            StrategyFactory.initialize,
+            (
+                config.strategyFactory.initialOwner,
+                config.strategyFactory.initPausedStatus,
+                IBeacon(deployments.strategyBeacon)
+            )
+        );
+        UpgradeableProxyLib.upgradeAndCall(
+            deployments.strategyFactory, strategyFactoryImpl, upgradeCall
+        );
+    }
+
+    function deployAndConfigureRewards(
+        DeploymentData memory deployments,
+        DeploymentConfigData memory config
+    ) internal {
+        address rewardsCoordinatorImpl = address(
+            new RewardsCoordinator(
+                IDelegationManager(deployments.delegationManager),
+                IStrategyManager(deployments.strategyManager),
+                IAllocationManager(deployments.allocationManager),
+                IPauserRegistry(deployments.pauserRegistry),
+                IPermissionController(deployments.permissionController),
+                config.rewardsCoordinator.calculationIntervalSeconds,
+                config.rewardsCoordinator.maxRewardsDuration,
+                config.rewardsCoordinator.maxRetroactiveLength,
+                config.rewardsCoordinator.maxFutureLength,
+                config.rewardsCoordinator.genesisRewardsTimestamp
+            )
+        );
+
+        bytes memory upgradeCall = abi.encodeCall(
+            RewardsCoordinator.initialize,
+            (
+                config.rewardsCoordinator.initialOwner,
+                config.rewardsCoordinator.initPausedStatus,
+                config.rewardsCoordinator.rewardsUpdater,
+                config.rewardsCoordinator.activationDelay,
+                config.rewardsCoordinator.defaultSplitBips
+            )
+        );
+
+        UpgradeableProxyLib.upgradeAndCall(
+            deployments.rewardsCoordinator, rewardsCoordinatorImpl, upgradeCall
+        );
+    }
+}

--- a/test/utils/MiddlewareDeployLib.sol
+++ b/test/utils/MiddlewareDeployLib.sol
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {TransparentUpgradeableProxy} from
+    "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {UpgradeableBeacon} from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import {IAllocationManager} from
+    "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IPauserRegistry} from "eigenlayer-contracts/src/contracts/interfaces/IPauserRegistry.sol";
+import {IDelegationManager} from
+    "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
+import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
+
+import {InstantSlasher} from "../../src/slashers/InstantSlasher.sol";
+import {SlashingRegistryCoordinator} from "../../src/SlashingRegistryCoordinator.sol";
+import {SocketRegistry} from "../../src/SocketRegistry.sol";
+import {IndexRegistry} from "../../src/IndexRegistry.sol";
+import {StakeRegistry} from "../../src/StakeRegistry.sol";
+import {BLSApkRegistry} from "../../src/BLSApkRegistry.sol";
+import {IStakeRegistry, IStakeRegistryTypes} from "../../src/interfaces/IStakeRegistry.sol";
+import {IBLSApkRegistry} from "../../src/interfaces/IBLSApkRegistry.sol";
+import {IIndexRegistry} from "../../src/interfaces/IIndexRegistry.sol";
+import {ISocketRegistry} from "../../src/interfaces/ISocketRegistry.sol";
+import {ISlashingRegistryCoordinator} from "../../src/interfaces/ISlashingRegistryCoordinator.sol";
+
+import {UpgradeableProxyLib} from "../unit/UpgradeableProxyLib.sol";
+
+library MiddlewareDeployLib {
+    using UpgradeableProxyLib for address;
+
+    struct InstantSlasherConfig {
+        address initialOwner;
+        address slasher;
+    }
+
+    struct SlashingRegistryCoordinatorConfig {
+        address initialOwner;
+        address churnApprover;
+        address ejector;
+        uint256 initPausedStatus;
+        address serviceManager;
+    }
+
+    struct SocketRegistryConfig {
+        address initialOwner;
+    }
+
+    struct IndexRegistryConfig {
+        address initialOwner;
+    }
+
+    struct StakeRegistryConfig {
+        address initialOwner;
+        uint256 minimumStake;
+        uint32 strategyParams;
+        address delegationManager;
+        address avsDirectory;
+        IStakeRegistryTypes.StrategyParams[] strategyParamsArray;
+        uint32 lookAheadPeriod;
+        IStakeRegistryTypes.StakeType stakeType;
+    }
+
+    struct BLSApkRegistryConfig {
+        address initialOwner;
+    }
+
+    struct MiddlewareDeployConfig {
+        InstantSlasherConfig instantSlasher;
+        SlashingRegistryCoordinatorConfig slashingRegistryCoordinator;
+        SocketRegistryConfig socketRegistry;
+        IndexRegistryConfig indexRegistry;
+        StakeRegistryConfig stakeRegistry;
+        BLSApkRegistryConfig blsApkRegistry;
+    }
+
+    struct MiddlewareDeployData {
+        address instantSlasher;
+        address slashingRegistryCoordinator;
+        address socketRegistry;
+        address indexRegistry;
+        address stakeRegistry;
+        address blsApkRegistry;
+    }
+
+    function deployMiddleware(
+        address proxyAdmin,
+        address allocationManager,
+        address pauserRegistry,
+        MiddlewareDeployConfig memory config
+    ) internal returns (MiddlewareDeployData memory result) {
+        result = deployEmptyProxies(proxyAdmin);
+
+        upgradeRegistries(result, allocationManager, pauserRegistry, config);
+        upgradeCoordinator(
+            result, allocationManager, pauserRegistry, config.slashingRegistryCoordinator
+        );
+        upgradeInstantSlasher(result, allocationManager, config.instantSlasher);
+
+        return result;
+    }
+
+    function deployEmptyProxies(
+        address proxyAdmin
+    ) internal returns (MiddlewareDeployData memory proxies) {
+        proxies.instantSlasher = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        proxies.slashingRegistryCoordinator = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        proxies.socketRegistry = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        proxies.indexRegistry = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        proxies.stakeRegistry = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        proxies.blsApkRegistry = UpgradeableProxyLib.setUpEmptyProxy(proxyAdmin);
+        return proxies;
+    }
+
+    function upgradeRegistries(
+        MiddlewareDeployData memory deployments,
+        address allocationManager,
+        address pauserRegistry,
+        MiddlewareDeployConfig memory config
+    ) internal {
+        address blsApkRegistryImpl = address(
+            new BLSApkRegistry(
+                ISlashingRegistryCoordinator(deployments.slashingRegistryCoordinator)
+            )
+        );
+        UpgradeableProxyLib.upgrade(deployments.blsApkRegistry, blsApkRegistryImpl);
+
+        address indexRegistryImpl = address(
+            new IndexRegistry(ISlashingRegistryCoordinator(deployments.slashingRegistryCoordinator))
+        );
+        UpgradeableProxyLib.upgrade(deployments.indexRegistry, indexRegistryImpl);
+
+        address socketRegistryImpl = address(
+            new SocketRegistry(
+                ISlashingRegistryCoordinator(deployments.slashingRegistryCoordinator)
+            )
+        );
+        UpgradeableProxyLib.upgrade(deployments.socketRegistry, socketRegistryImpl);
+
+        // StakeRegistry upgrade
+        address stakeRegistryImpl = address(
+            new StakeRegistry(
+                ISlashingRegistryCoordinator(deployments.slashingRegistryCoordinator),
+                IDelegationManager(config.stakeRegistry.delegationManager),
+                IAVSDirectory(config.stakeRegistry.avsDirectory),
+                IAllocationManager(allocationManager)
+            )
+        );
+        UpgradeableProxyLib.upgrade(deployments.stakeRegistry, stakeRegistryImpl);
+    }
+
+    function upgradeCoordinator(
+        MiddlewareDeployData memory deployments,
+        address allocationManager,
+        address pauserRegistry,
+        SlashingRegistryCoordinatorConfig memory coordinatorConfig
+    ) internal {
+        address coordinatorImpl = address(
+            new SlashingRegistryCoordinator(
+                IStakeRegistry(deployments.stakeRegistry),
+                IBLSApkRegistry(deployments.blsApkRegistry),
+                IIndexRegistry(deployments.indexRegistry),
+                ISocketRegistry(deployments.socketRegistry),
+                IAllocationManager(allocationManager),
+                IPauserRegistry(pauserRegistry)
+            )
+        );
+        bytes memory upgradeCall = abi.encodeCall(
+            SlashingRegistryCoordinator.initialize,
+            (
+                coordinatorConfig.initialOwner,
+                coordinatorConfig.churnApprover,
+                coordinatorConfig.ejector,
+                coordinatorConfig.initPausedStatus,
+                coordinatorConfig.serviceManager
+            )
+        );
+        UpgradeableProxyLib.upgradeAndCall(
+            deployments.slashingRegistryCoordinator, coordinatorImpl, upgradeCall
+        );
+    }
+
+    // Upgrade and initialize InstantSlasher with its config data
+    function upgradeInstantSlasher(
+        MiddlewareDeployData memory deployments,
+        address allocationManager,
+        InstantSlasherConfig memory slasherConfig
+    ) internal {
+        address instantSlasherImpl = address(
+            new InstantSlasher(
+                IAllocationManager(allocationManager),
+                ISlashingRegistryCoordinator(deployments.slashingRegistryCoordinator),
+                slasherConfig.slasher
+            )
+        );
+        bytes memory upgradeCall =
+            abi.encodeCall(InstantSlasher.initialize, (slasherConfig.slasher));
+        UpgradeableProxyLib.upgradeAndCall(
+            deployments.instantSlasher, instantSlasherImpl, upgradeCall
+        );
+    }
+}

--- a/test/utils/MiddlewareDeployLib.sol
+++ b/test/utils/MiddlewareDeployLib.sol
@@ -193,10 +193,6 @@ library MiddlewareDeployLib {
                 slasherConfig.slasher
             )
         );
-        bytes memory upgradeCall =
-            abi.encodeCall(InstantSlasher.initialize, (slasherConfig.slasher));
-        UpgradeableProxyLib.upgradeAndCall(
-            deployments.instantSlasher, instantSlasherImpl, upgradeCall
-        );
+        UpgradeableProxyLib.upgrade(deployments.instantSlasher, instantSlasherImpl);
     }
 }

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -357,8 +357,10 @@ contract MockAVSDeployer is Test {
 
         operatorStateRetriever = new OperatorStateRetriever();
 
+        // Set RegistryCoordinator as M2 state with existing quorums
+        registryCoordinator.setM2QuorumBitmap(0);
         registryCoordinator.setOperatorSetsEnabled(false);
-        registryCoordinator.setM2QuorumsDisabled(false);
+        registryCoordinator.setM2QuorumRegistrationDisabled(false);
     }
 
     function _labelContracts() internal {

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -53,6 +53,7 @@ import {BLSApkRegistryHarness} from "../harnesses/BLSApkRegistryHarness.sol";
 import {EmptyContract} from "eigenlayer-contracts/src/test/mocks/EmptyContract.sol";
 
 import {StakeRegistryHarness} from "../harnesses/StakeRegistryHarness.sol";
+import {OperatorWalletLib, Operator} from "../utils/OperatorWalletLib.sol";
 
 import "forge-std/Test.sol";
 
@@ -546,5 +547,18 @@ contract MockAVSDeployer is Test {
             expiry: expiry,
             salt: salt
         });
+    }
+
+    function _createOperators(
+        uint256 numOperators,
+        uint256 startIndex
+    ) internal returns (Operator[] memory) {
+        Operator[] memory operators = new Operator[](numOperators);
+        for (uint256 i = 0; i < numOperators; i++) {
+            operators[i] = OperatorWalletLib.createOperator(
+                string(abi.encodePacked("operator-", i + startIndex))
+            );
+        }
+        return operators;
     }
 }

--- a/test/utils/OperatorWalletLib.sol
+++ b/test/utils/OperatorWalletLib.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Vm} from "forge-std/Vm.sol";
+import {BN254} from "src/libraries/BN254.sol";
+import {BN256G2} from "./BN256G2.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+
+struct Wallet {
+    uint256 privateKey;
+    address addr;
+}
+
+struct BLSWallet {
+    uint256 privateKey;
+    BN254.G2Point publicKeyG2;
+    BN254.G1Point publicKeyG1;
+}
+
+struct Operator {
+    Wallet key;
+    BLSWallet signingKey;
+}
+
+library OperatorKeyOperationsLib {
+    Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function sign(Wallet memory wallet, bytes32 digest) internal pure returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wallet.privateKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+}
+
+library SigningKeyOperationsLib {
+    using BN254 for BN254.G1Point;
+
+    function sign(
+        BLSWallet memory blsWallet,
+        bytes32 messageHash
+    ) internal view returns (BN254.G1Point memory) {
+        // Hash the message to a point on G1
+        BN254.G1Point memory messagePoint = BN254.hashToG1(messageHash);
+
+        // Sign by multiplying the hashed message point with the private key
+        return messagePoint.scalar_mul(blsWallet.privateKey);
+    }
+
+    function aggregate(
+        BN254.G2Point memory pk1,
+        BN254.G2Point memory pk2
+    ) internal view returns (BN254.G2Point memory apk) {
+        (apk.X[0], apk.X[1], apk.Y[0], apk.Y[1]) = BN256G2.ECTwistAdd(
+            pk1.X[0], pk1.X[1], pk1.Y[0], pk1.Y[1], pk2.X[0], pk2.X[1], pk2.Y[0], pk2.Y[1]
+        );
+    }
+}
+
+library OperatorWalletLib {
+    using BN254 for *;
+    using Strings for uint256;
+
+    Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function createBLSWallet(
+        uint256 salt
+    ) internal returns (BLSWallet memory) {
+        uint256 privateKey = uint256(keccak256(abi.encodePacked(salt)));
+        BN254.G1Point memory publicKeyG1 = BN254.generatorG1().scalar_mul(privateKey);
+        BN254.G2Point memory publicKeyG2 = mul(privateKey);
+
+        return
+            BLSWallet({privateKey: privateKey, publicKeyG2: publicKeyG2, publicKeyG1: publicKeyG1});
+    }
+
+    function createWallet(
+        uint256 salt
+    ) internal pure returns (Wallet memory) {
+        uint256 privateKey = uint256(keccak256(abi.encodePacked(salt)));
+        address addr = vm.addr(privateKey);
+
+        return Wallet({privateKey: privateKey, addr: addr});
+    }
+
+    function createOperator(
+        string memory name
+    ) internal returns (Operator memory) {
+        uint256 salt = uint256(keccak256(abi.encodePacked(name)));
+        Wallet memory vmWallet = createWallet(salt);
+        BLSWallet memory blsWallet = createBLSWallet(salt);
+
+        return Operator({key: vmWallet, signingKey: blsWallet});
+    }
+
+    function mul(
+        uint256 x
+    ) internal returns (BN254.G2Point memory g2Point) {
+        string[] memory inputs = new string[](5);
+        inputs[0] = "go";
+        inputs[1] = "run";
+        inputs[2] = "test/ffi/go/g2mul.go";
+        inputs[3] = x.toString();
+
+        inputs[4] = "1";
+        bytes memory res = vm.ffi(inputs);
+        g2Point.X[1] = abi.decode(res, (uint256));
+
+        inputs[4] = "2";
+        res = vm.ffi(inputs);
+        g2Point.X[0] = abi.decode(res, (uint256));
+
+        inputs[4] = "3";
+        res = vm.ffi(inputs);
+        g2Point.Y[1] = abi.decode(res, (uint256));
+
+        inputs[4] = "4";
+        res = vm.ffi(inputs);
+        g2Point.Y[0] = abi.decode(res, (uint256));
+    }
+}


### PR DESCRIPTION
This PR extends the test coverage of the `StakeRegistry`. Specifically targeting coverage over the following functions:
- `getStakeHistory`
- `getStakeHistoryAtIndex` 
- `setSlashableStakeLookAhead` 

Fuzzing unit tests have been for each of the above as well as including `getStakeHistory` and `getStakeHistoryAtIndex` into the fuzzing operator registration and deregistration tests.