### PR TITLE
fix: handle eject operators correctly for post try-catch

### DIFF
--- a/src/EjectionManager.sol
+++ b/src/EjectionManager.sol
@@ -9,8 +9,6 @@ import {
     IStakeRegistry
 } from "./EjectionManagerStorage.sol";
 
-// TODO: double check order of inheritance since we separated storage from logic...
-
 /**
  * @title Used for automated ejection of operators from the SlashingRegistryCoordinator under a ratelimit
  * @author Layr Labs, Inc.

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -160,7 +160,7 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
         override(ISlashingRegistryCoordinator, SlashingRegistryCoordinator)
         onlyEjector
     {
-        _kickOperators(operator, quorumNumbers, true);
+        _kickOperators({operator: operator, quorumNumbers: quorumNumbers, isEjection: true});
     }
 
     /**
@@ -221,7 +221,11 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
 
                 bytes memory singleQuorumNumber = new bytes(1);
                 singleQuorumNumber[0] = quorumNumbers[i];
-                _kickOperators(operatorKickParams[i].operator, singleQuorumNumber, false);
+                _kickOperators({
+                    operator: operatorKickParams[i].operator,
+                    quorumNumbers: singleQuorumNumber,
+                    isEjection: false
+                });
             }
         }
     }
@@ -237,10 +241,8 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
         }
 
         OperatorInfo storage operatorInfo = _operatorInfo[operator];
-        bytes32 operatorId = operatorInfo.operatorId;
         uint192 quorumsToRemove =
             uint192(BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers, quorumCount));
-        uint192 currentBitmap = _currentOperatorBitmap(operatorId);
         if (operatorInfo.status == OperatorStatus.REGISTERED && !quorumsToRemove.isEmpty()) {
             // For each quorum number, check if it's an M2 quorum
             for (uint256 i = 0; i < quorumNumbers.length; i++) {
@@ -329,7 +331,11 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
 
         for (uint256 i = 0; i < operators.length; ++i) {
             if (doesNotMeetStakeThreshold[i]) {
-                _kickOperators(operators[i], singleQuorumNumber, false);
+                _kickOperators({
+                    operator: operators[i],
+                    quorumNumbers: singleQuorumNumber,
+                    isEjection: false
+                });
             }
         }
     }

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -160,7 +160,7 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
         override(ISlashingRegistryCoordinator, SlashingRegistryCoordinator)
         onlyEjector
     {
-        _ejectOperators(operator, quorumNumbers, true);
+        _kickOperators(operator, quorumNumbers, true);
     }
 
     /**
@@ -221,18 +221,18 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
 
                 bytes memory singleQuorumNumber = new bytes(1);
                 singleQuorumNumber[0] = quorumNumbers[i];
-                _ejectOperators(operatorKickParams[i].operator, singleQuorumNumber, false);
+                _kickOperators(operatorKickParams[i].operator, singleQuorumNumber, false);
             }
         }
     }
 
-    /// @dev override the _ejectOperators function to handle M2 quorum ejection
-    function _ejectOperators(
+    /// @dev override the _kickOperators function to handle M2 quorum ejection
+    function _kickOperators(
         address operator,
         bytes memory quorumNumbers,
-        bool shouldRecordEjectionTimestamp
+        bool isEjection
     ) internal virtual override {
-        if (shouldRecordEjectionTimestamp) {
+        if (isEjection) {
             lastEjectionTimestamp[operator] = block.timestamp;
         }
 
@@ -329,7 +329,7 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
 
         for (uint256 i = 0; i < operators.length; ++i) {
             if (doesNotMeetStakeThreshold[i]) {
-                _ejectOperators(operators[i], singleQuorumNumber, false);
+                _kickOperators(operators[i], singleQuorumNumber, false);
             }
         }
     }

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -160,8 +160,7 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
         override(ISlashingRegistryCoordinator, SlashingRegistryCoordinator)
         onlyEjector
     {
-        // Call parent to update lastEjectionTimestamp
-        super.ejectOperator(operator, quorumNumbers);
+        lastEjectionTimestamp[operator] = block.timestamp;
 
         OperatorInfo storage operatorInfo = _operatorInfo[operator];
         bytes32 operatorId = operatorInfo.operatorId;

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -199,6 +199,74 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
      *
      */
 
+    /**
+     * @notice Internal function to handle operator registration with churn
+     * @param operator The operator to register
+     * @param operatorId The operator's ID
+     * @param quorumNumbers The quorum numbers to register for
+     * @param socket The operator's socket
+     * @param operatorKickParams The parameters needed to kick operators from quorums that have reached their caps
+     * @param churnApproverSignature The churnApprover's signature approving the registration
+     */
+    function _registerOperatorWithChurn(
+        address operator,
+        bytes32 operatorId,
+        bytes memory quorumNumbers,
+        string memory socket,
+        OperatorKickParam[] memory operatorKickParams,
+        SignatureWithSaltAndExpiry memory churnApproverSignature
+    ) internal virtual override {
+        // verify churnApprover's signature
+        _verifyChurnApproverSignature(
+            operator,
+            operatorId,
+            operatorKickParams,
+            churnApproverSignature
+        );
+
+        // quorum bitmap and registration status
+        RegisterResults memory results = _registerOperator({
+            operator: operator,
+            operatorId: operatorId,
+            quorumNumbers: quorumNumbers,
+            socket: socket,
+            checkMaxOperatorCount: false
+        });
+
+        // Check that each quorum's operator count is below the configured maximum. If the max
+        // is exceeded, use `operatorKickParams` to deregister an existing operator to make space
+        for (uint256 i = 0; i < quorumNumbers.length; i++) {
+            OperatorSetParam memory operatorSetParams = _quorumParams[uint8(quorumNumbers[i])];
+
+            /**
+             * If the new operator count for any quorum exceeds the maximum, validate
+             * that churn can be performed, then deregister the specified operator
+             */
+            if (results.numOperatorsPerQuorum[i] > operatorSetParams.maxOperatorCount) {
+                _validateChurn({
+                    quorumNumber: uint8(quorumNumbers[i]),
+                    totalQuorumStake: results.totalStakes[i],
+                    newOperator: operator,
+                    newOperatorStake: results.operatorStakes[i],
+                    kickParams: operatorKickParams[i],
+                    setParams: operatorSetParams
+                });
+
+                bytes memory singleQuorumNumber = new bytes(1);
+                singleQuorumNumber[0] = quorumNumbers[i];
+                if (_isM2Quorum(uint8(quorumNumbers[i]))) {
+                    _deregisterOperator({
+                        operator: operatorKickParams[i].operator,
+                        quorumNumbers: singleQuorumNumber,
+                        shouldForceDeregister: true
+                    });
+                } else {
+                    _ejectOperators(operatorKickParams[i].operator, singleQuorumNumber);
+                }
+            }
+        }
+    }
+
     /// @dev override the _forceDeregisterOperator function to handle M2 quorum deregistration
     function _forceDeregisterOperator(
         address operator,

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -251,14 +251,39 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
 
                 bytes memory singleQuorumNumber = new bytes(1);
                 singleQuorumNumber[0] = quorumNumbers[i];
+                _ejectOperators(operatorKickParams[i].operator, singleQuorumNumber);
+            }
+        }
+    }
+
+    /// @dev override the _ejectOperators function to handle M2 quorum ejection
+    function _ejectOperators(
+        address operator,
+        bytes memory quorumNumbers
+    ) internal virtual override {
+        lastEjectionTimestamp[operator] = block.timestamp;
+
+        OperatorInfo storage operatorInfo = _operatorInfo[operator];
+        bytes32 operatorId = operatorInfo.operatorId;
+        uint192 quorumsToRemove =
+            uint192(BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers, quorumCount));
+        uint192 currentBitmap = _currentOperatorBitmap(operatorId);
+        if (operatorInfo.status == OperatorStatus.REGISTERED && !quorumsToRemove.isEmpty()) {
+            // For each quorum number, check if it's an M2 quorum
+            for (uint256 i = 0; i < quorumNumbers.length; i++) {
+                bytes memory singleQuorumNumber = new bytes(1);
+                singleQuorumNumber[0] = quorumNumbers[i];
+
                 if (_isM2Quorum(uint8(quorumNumbers[i]))) {
+                    // For M2 quorums, use _deregisterOperator
                     _deregisterOperator({
-                        operator: operatorKickParams[i].operator,
+                        operator: operator,
                         quorumNumbers: singleQuorumNumber,
                         shouldForceDeregister: true
                     });
                 } else {
-                    _ejectOperators(operatorKickParams[i].operator, singleQuorumNumber);
+                    // For non-M2 quorums, use _forceDeregisterOperator
+                    _forceDeregisterOperator(operator, singleQuorumNumber);
                 }
             }
         }
@@ -330,31 +355,8 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
             stakeRegistry.updateOperatorsStake(operators, operatorIds, quorumNumber);
 
         for (uint256 i = 0; i < operators.length; ++i) {
-            bool isM2Quorum = _isM2Quorum(quorumNumber);
-            bool registeredInCore;
-            // If its an operatorSet quorum, its possible for registeredInCore to be true/false
-            // so check for operatorSet inclusion in the AllocationManager
-            if (!isM2Quorum) {
-                registeredInCore = allocationManager.isMemberOfOperatorSet(
-                    operators[i], OperatorSet({avs: accountIdentifier, id: uint32(quorumNumber)})
-                );
-            }
-
-            // Determine if the operator should be deregistered
-            // If the operator does not have the minimum stake, they need to be force deregistered.
-            // Additionally, it is possible for an operator to have deregistered from an OperatorSet
-            // in the core EigenLayer contract AllocationManager but not have the deregistration
-            // callback succeed here in `deregisterOperator` due to out of gas errors. If that is the case,
-            // we need to deregister the operator from the OperatorSet in this contract
-            bool shouldDeregister =
-                doesNotMeetStakeThreshold[i] || (!registeredInCore && !isM2Quorum);
-
-            if (shouldDeregister) {
-                _deregisterOperator({
-                    operator: operators[i],
-                    quorumNumbers: singleQuorumNumber,
-                    shouldForceDeregister: registeredInCore
-                });
+            if (doesNotMeetStakeThreshold[i]) {
+                _ejectOperators(operators[i], singleQuorumNumber);
             }
         }
     }

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -218,10 +218,7 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
     ) internal virtual override {
         // verify churnApprover's signature
         _verifyChurnApproverSignature(
-            operator,
-            operatorId,
-            operatorKickParams,
-            churnApproverSignature
+            operator, operatorId, operatorKickParams, churnApproverSignature
         );
 
         // quorum bitmap and registration status

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -150,6 +150,50 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
         emit M2QuorumRegistrationDisabled();
     }
 
+    /// @inheritdoc ISlashingRegistryCoordinator
+    function ejectOperator(
+        address operator,
+        bytes memory quorumNumbers
+    )
+        public
+        virtual
+        override(ISlashingRegistryCoordinator, SlashingRegistryCoordinator)
+        onlyEjector
+    {
+        // Call parent to update lastEjectionTimestamp
+        super.ejectOperator(operator, quorumNumbers);
+
+        OperatorInfo storage operatorInfo = _operatorInfo[operator];
+        bytes32 operatorId = operatorInfo.operatorId;
+        uint192 quorumsToRemove =
+            uint192(BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers, quorumCount));
+        uint192 currentBitmap = _currentOperatorBitmap(operatorId);
+
+        if (
+            operatorInfo.status == OperatorStatus.REGISTERED && !quorumsToRemove.isEmpty()
+                && quorumsToRemove.isSubsetOf(currentBitmap)
+        ) {
+            // Split quorums into M2 and non-M2
+            uint256 m2Bitmap = m2QuorumBitmap();
+            uint256 m2QuorumsToRemove = BitmapUtils.and(quorumsToRemove, m2Bitmap);
+            uint256 nonM2QuorumsToRemove = BitmapUtils.minus(quorumsToRemove, m2Bitmap);
+
+            // Handle M2 quorums with _deregisterOperator
+            if (!m2QuorumsToRemove.isEmpty()) {
+                _deregisterOperator({
+                    operator: operator,
+                    quorumNumbers: m2QuorumsToRemove.bitmapToBytesArray(),
+                    shouldForceDeregister: true
+                });
+            }
+
+            // Handle non-M2 quorums with _forceDeregisterOperator
+            if (!nonM2QuorumsToRemove.isEmpty()) {
+                _forceDeregisterOperator(operator, nonM2QuorumsToRemove.bitmapToBytesArray());
+            }
+        }
+    }
+
     /**
      *
      *                            INTERNAL FUNCTIONS

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -160,37 +160,7 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
         override(ISlashingRegistryCoordinator, SlashingRegistryCoordinator)
         onlyEjector
     {
-        lastEjectionTimestamp[operator] = block.timestamp;
-
-        OperatorInfo storage operatorInfo = _operatorInfo[operator];
-        bytes32 operatorId = operatorInfo.operatorId;
-        uint192 quorumsToRemove =
-            uint192(BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers, quorumCount));
-        uint192 currentBitmap = _currentOperatorBitmap(operatorId);
-
-        if (
-            operatorInfo.status == OperatorStatus.REGISTERED && !quorumsToRemove.isEmpty()
-                && quorumsToRemove.isSubsetOf(currentBitmap)
-        ) {
-            // Split quorums into M2 and non-M2
-            uint256 m2Bitmap = m2QuorumBitmap();
-            uint256 m2QuorumsToRemove = BitmapUtils.and(quorumsToRemove, m2Bitmap);
-            uint256 nonM2QuorumsToRemove = BitmapUtils.minus(quorumsToRemove, m2Bitmap);
-
-            // Handle M2 quorums with _deregisterOperator
-            if (!m2QuorumsToRemove.isEmpty()) {
-                _deregisterOperator({
-                    operator: operator,
-                    quorumNumbers: m2QuorumsToRemove.bitmapToBytesArray(),
-                    shouldForceDeregister: true
-                });
-            }
-
-            // Handle non-M2 quorums with _forceDeregisterOperator
-            if (!nonM2QuorumsToRemove.isEmpty()) {
-                _forceDeregisterOperator(operator, nonM2QuorumsToRemove.bitmapToBytesArray());
-            }
-        }
+        _ejectOperators(operator, quorumNumbers, true);
     }
 
     /**
@@ -251,7 +221,7 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
 
                 bytes memory singleQuorumNumber = new bytes(1);
                 singleQuorumNumber[0] = quorumNumbers[i];
-                _ejectOperators(operatorKickParams[i].operator, singleQuorumNumber);
+                _ejectOperators(operatorKickParams[i].operator, singleQuorumNumber, false);
             }
         }
     }
@@ -259,9 +229,12 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
     /// @dev override the _ejectOperators function to handle M2 quorum ejection
     function _ejectOperators(
         address operator,
-        bytes memory quorumNumbers
+        bytes memory quorumNumbers,
+        bool shouldRecordEjectionTimestamp
     ) internal virtual override {
-        lastEjectionTimestamp[operator] = block.timestamp;
+        if (shouldRecordEjectionTimestamp) {
+            lastEjectionTimestamp[operator] = block.timestamp;
+        }
 
         OperatorInfo storage operatorInfo = _operatorInfo[operator];
         bytes32 operatorId = operatorInfo.operatorId;
@@ -356,7 +329,7 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
 
         for (uint256 i = 0; i < operators.length; ++i) {
             if (doesNotMeetStakeThreshold[i]) {
-                _ejectOperators(operators[i], singleQuorumNumber);
+                _ejectOperators(operators[i], singleQuorumNumber, false);
             }
         }
     }

--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -312,14 +312,16 @@ contract RegistryCoordinator is RegistryCoordinatorStorage {
     }
 
     /**
-     * @dev Helper function to update operator stakes and deregister loiterers
-     * Loiterers are AVS registered operators who have force deregistered from the OperatorSet/quorum
-     * in the core EigenLayer contract AllocationManager but not deregistered from the OperatorSet/quorum
-     * in this contract. Potentially due to out of gas errors in the deregistration callback. This function
-     * will handle that edge case by deregistering the operator from the AVS if they are no longer registered
-     * in the AllocationManager.
+     * @dev Helper function to update operator stakes and deregister operators with insufficient stake
+     * This function handles two cases:
+     * 1. Operators who no longer meet the minimum stake requirement for a quorum
+     * 2. Operators who have been force-deregistered from the AllocationManager but not from this contract
+     * (e.g. due to out of gas errors in the deregistration callback)
+     * @param operators The list of operators to check and update
+     * @param operatorIds The corresponding operator IDs
+     * @param quorumNumber The quorum number to check stakes for
      */
-    function _updateStakesAndDeregisterLoiterers(
+    function _updateOperatorsStakes(
         address[] memory operators,
         bytes32[] memory operatorIds,
         uint8 quorumNumber

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -651,22 +651,9 @@ contract SlashingRegistryCoordinator is
         bool[] memory doesNotMeetStakeThreshold =
             stakeRegistry.updateOperatorsStake(operators, operatorIds, quorumNumber);
         for (uint256 j = 0; j < operators.length; ++j) {
-            // whether the operator is registered in the core EigenLayer contract AllocationManager
-            bool registeredInCore = allocationManager.isMemberOfOperatorSet(
-                operators[j], OperatorSet({avs: accountIdentifier, id: uint32(quorumNumber)})
-            );
-
             // If the operator does not have the minimum stake, they need to be force deregistered.
-            // Additionally, it is possible for an operator to have deregistered from an OperatorSet
-            // in the core EigenLayer contract AllocationManager but not have the deregistration
-            // callback succeed here in `deregisterOperator` due to out of gas errors. If that is the case,
-            // we need to deregister the operator from the OperatorSet in this contract
-            if (doesNotMeetStakeThreshold[j] || !registeredInCore) {
-                _deregisterOperator({
-                    operator: operators[j],
-                    quorumNumbers: singleQuorumNumber,
-                    shouldForceDeregister: registeredInCore
-                });
+            if (doesNotMeetStakeThreshold[j]) {
+                _ejectOperators(operators[j], singleQuorumNumber);
             }
         }
     }

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -323,7 +323,10 @@ contract SlashingRegistryCoordinator is
      */
 
     /// @inheritdoc ISlashingRegistryCoordinator
-    function ejectOperator(address operator, bytes memory quorumNumbers) external onlyEjector {
+    function ejectOperator(
+        address operator,
+        bytes memory quorumNumbers
+    ) public virtual onlyEjector {
         lastEjectionTimestamp[operator] = block.timestamp;
 
         OperatorInfo storage operatorInfo = _operatorInfo[operator];
@@ -335,11 +338,7 @@ contract SlashingRegistryCoordinator is
             operatorInfo.status == OperatorStatus.REGISTERED && !quorumsToRemove.isEmpty()
                 && quorumsToRemove.isSubsetOf(currentBitmap)
         ) {
-            _deregisterOperator({
-                operator: operator,
-                quorumNumbers: quorumNumbers,
-                shouldForceDeregister: true
-            });
+            _forceDeregisterOperator(operator, quorumNumbers);
         }
     }
 

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -247,9 +247,7 @@ contract SlashingRegistryCoordinator is
             bytes memory quorumNumbers = currentBitmap.bitmapToBytesArray();
             for (uint256 j = 0; j < quorumNumbers.length; j++) {
                 // update the operator's stake for each quorum
-                _updateStakesAndDeregisterLoiterers(
-                    singleOperator, singleOperatorId, uint8(quorumNumbers[j])
-                );
+                _updateOperatorsStakes(singleOperator, singleOperatorId, uint8(quorumNumbers[j]));
             }
         }
     }
@@ -300,7 +298,7 @@ contract SlashingRegistryCoordinator is
                 prevOperatorAddress = operator;
             }
 
-            _updateStakesAndDeregisterLoiterers(currQuorumOperators, operatorIds, quorumNumber);
+            _updateOperatorsStakes(currQuorumOperators, operatorIds, quorumNumber);
 
             // Update timestamp that all operators in quorum have been updated all at once
             quorumUpdateBlockNumber[quorumNumber] = block.number;
@@ -644,14 +642,16 @@ contract SlashingRegistryCoordinator is
     }
 
     /**
-     * @dev Helper function to update operator stakes and deregister loiterers
-     * Loiterers are AVS registered operators who have force deregistered from the OperatorSet/quorum
-     * in the core EigenLayer contract AllocationManager but not deregistered from the OperatorSet/quorum
-     * in this contract. Potentially due to out of gas errors in the deregistration callback. This function
-     * will handle that edge case by deregistering the operator from the AVS if they are no longer registered
-     * in the AllocationManager.
+     * @dev Helper function to update operator stakes and deregister operators with insufficient stake
+     * This function handles two cases:
+     * 1. Operators who no longer meet the minimum stake requirement for a quorum
+     * 2. Operators who have been force-deregistered from the AllocationManager but not from this contract
+     * (e.g. due to out of gas errors in the deregistration callback)
+     * @param operators The list of operators to check and update
+     * @param operatorIds The corresponding operator IDs
+     * @param quorumNumber The quorum number to check stakes for
      */
-    function _updateStakesAndDeregisterLoiterers(
+    function _updateOperatorsStakes(
         address[] memory operators,
         bytes32[] memory operatorIds,
         uint8 quorumNumber

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -388,10 +388,7 @@ contract SlashingRegistryCoordinator is
      * @param operator The operator to eject
      * @param quorumNumbers The quorum numbers to eject the operator from
      */
-    function _ejectOperators(
-        address operator,
-        bytes memory quorumNumbers
-    ) internal virtual {
+    function _ejectOperators(address operator, bytes memory quorumNumbers) internal virtual {
         lastEjectionTimestamp[operator] = block.timestamp;
 
         OperatorInfo storage operatorInfo = _operatorInfo[operator];

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -327,7 +327,7 @@ contract SlashingRegistryCoordinator is
         address operator,
         bytes memory quorumNumbers
     ) public virtual onlyEjector {
-        _ejectOperators(operator, quorumNumbers);
+        _ejectOperators(operator, quorumNumbers, true);
     }
 
     /**
@@ -388,8 +388,14 @@ contract SlashingRegistryCoordinator is
      * @param operator The operator to eject
      * @param quorumNumbers The quorum numbers to eject the operator from
      */
-    function _ejectOperators(address operator, bytes memory quorumNumbers) internal virtual {
-        lastEjectionTimestamp[operator] = block.timestamp;
+    function _ejectOperators(
+        address operator,
+        bytes memory quorumNumbers,
+        bool shouldRecordEjectionTimestamp
+    ) internal virtual {
+        if (shouldRecordEjectionTimestamp) {
+            lastEjectionTimestamp[operator] = block.timestamp;
+        }
 
         OperatorInfo storage operatorInfo = _operatorInfo[operator];
         bytes32 operatorId = operatorInfo.operatorId;
@@ -525,7 +531,7 @@ contract SlashingRegistryCoordinator is
 
                 bytes memory singleQuorumNumber = new bytes(1);
                 singleQuorumNumber[0] = quorumNumbers[i];
-                _ejectOperators(operatorKickParams[i].operator, singleQuorumNumber);
+                _ejectOperators(operatorKickParams[i].operator, singleQuorumNumber, false);
             }
         }
     }
@@ -653,7 +659,7 @@ contract SlashingRegistryCoordinator is
         for (uint256 j = 0; j < operators.length; ++j) {
             // If the operator does not have the minimum stake, they need to be force deregistered.
             if (doesNotMeetStakeThreshold[j]) {
-                _ejectOperators(operators[j], singleQuorumNumber);
+                _ejectOperators(operators[j], singleQuorumNumber, false);
             }
         }
     }

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -327,7 +327,7 @@ contract SlashingRegistryCoordinator is
         address operator,
         bytes memory quorumNumbers
     ) public virtual onlyEjector {
-        _ejectOperators(operator, quorumNumbers, true);
+        _kickOperators(operator, quorumNumbers, true);
     }
 
     /**
@@ -388,12 +388,12 @@ contract SlashingRegistryCoordinator is
      * @param operator The operator to eject
      * @param quorumNumbers The quorum numbers to eject the operator from
      */
-    function _ejectOperators(
+    function _kickOperators(
         address operator,
         bytes memory quorumNumbers,
-        bool shouldRecordEjectionTimestamp
+        bool isEjection
     ) internal virtual {
-        if (shouldRecordEjectionTimestamp) {
+        if (isEjection) {
             lastEjectionTimestamp[operator] = block.timestamp;
         }
 
@@ -531,7 +531,7 @@ contract SlashingRegistryCoordinator is
 
                 bytes memory singleQuorumNumber = new bytes(1);
                 singleQuorumNumber[0] = quorumNumbers[i];
-                _ejectOperators(operatorKickParams[i].operator, singleQuorumNumber, false);
+                _kickOperators(operatorKickParams[i].operator, singleQuorumNumber, false);
             }
         }
     }
@@ -659,7 +659,7 @@ contract SlashingRegistryCoordinator is
         for (uint256 j = 0; j < operators.length; ++j) {
             // If the operator does not have the minimum stake, they need to be force deregistered.
             if (doesNotMeetStakeThreshold[j]) {
-                _ejectOperators(operators[j], singleQuorumNumber, false);
+                _kickOperators(operators[j], singleQuorumNumber, false);
             }
         }
     }

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -327,19 +327,7 @@ contract SlashingRegistryCoordinator is
         address operator,
         bytes memory quorumNumbers
     ) public virtual onlyEjector {
-        lastEjectionTimestamp[operator] = block.timestamp;
-
-        OperatorInfo storage operatorInfo = _operatorInfo[operator];
-        bytes32 operatorId = operatorInfo.operatorId;
-        uint192 quorumsToRemove =
-            uint192(BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers, quorumCount));
-        uint192 currentBitmap = _currentOperatorBitmap(operatorId);
-        if (
-            operatorInfo.status == OperatorStatus.REGISTERED && !quorumsToRemove.isEmpty()
-                && quorumsToRemove.isSubsetOf(currentBitmap)
-        ) {
-            _forceDeregisterOperator(operator, quorumNumbers);
-        }
+        _ejectOperators(operator, quorumNumbers);
     }
 
     /**
@@ -394,6 +382,30 @@ contract SlashingRegistryCoordinator is
      *                         INTERNAL FUNCTIONS
      *
      */
+
+    /**
+     * @notice Internal function to handle operator ejection logic
+     * @param operator The operator to eject
+     * @param quorumNumbers The quorum numbers to eject the operator from
+     */
+    function _ejectOperators(
+        address operator,
+        bytes memory quorumNumbers
+    ) internal virtual {
+        lastEjectionTimestamp[operator] = block.timestamp;
+
+        OperatorInfo storage operatorInfo = _operatorInfo[operator];
+        bytes32 operatorId = operatorInfo.operatorId;
+        uint192 quorumsToRemove =
+            uint192(BitmapUtils.orderedBytesArrayToBitmap(quorumNumbers, quorumCount));
+        uint192 currentBitmap = _currentOperatorBitmap(operatorId);
+        if (
+            operatorInfo.status == OperatorStatus.REGISTERED && !quorumsToRemove.isEmpty()
+                && quorumsToRemove.isSubsetOf(currentBitmap)
+        ) {
+            _forceDeregisterOperator(operator, quorumNumbers);
+        }
+    }
 
     /**
      * @notice Register the operator for one or more quorums. This method updates the
@@ -516,11 +528,7 @@ contract SlashingRegistryCoordinator is
 
                 bytes memory singleQuorumNumber = new bytes(1);
                 singleQuorumNumber[0] = quorumNumbers[i];
-                _deregisterOperator({
-                    operator: operatorKickParams[i].operator,
-                    quorumNumbers: singleQuorumNumber,
-                    shouldForceDeregister: true
-                });
+                _ejectOperators(operatorKickParams[i].operator, singleQuorumNumber);
             }
         }
     }

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -327,7 +327,7 @@ contract SlashingRegistryCoordinator is
         address operator,
         bytes memory quorumNumbers
     ) public virtual onlyEjector {
-        _kickOperators(operator, quorumNumbers, true);
+        _kickOperators({operator: operator, quorumNumbers: quorumNumbers, isEjection: true});
     }
 
     /**
@@ -531,7 +531,11 @@ contract SlashingRegistryCoordinator is
 
                 bytes memory singleQuorumNumber = new bytes(1);
                 singleQuorumNumber[0] = quorumNumbers[i];
-                _kickOperators(operatorKickParams[i].operator, singleQuorumNumber, false);
+                _kickOperators({
+                    operator: operatorKickParams[i].operator,
+                    quorumNumbers: singleQuorumNumber,
+                    isEjection: false
+                });
             }
         }
     }
@@ -659,7 +663,11 @@ contract SlashingRegistryCoordinator is
         for (uint256 j = 0; j < operators.length; ++j) {
             // If the operator does not have the minimum stake, they need to be force deregistered.
             if (doesNotMeetStakeThreshold[j]) {
-                _kickOperators(operators[j], singleQuorumNumber, false);
+                _kickOperators({
+                    operator: operators[j],
+                    quorumNumbers: singleQuorumNumber,
+                    isEjection: false
+                });
             }
         }
     }

--- a/src/libraries/BitmapUtils.sol
+++ b/src/libraries/BitmapUtils.sol
@@ -215,4 +215,12 @@ library BitmapUtils {
     function minus(uint256 a, uint256 b) internal pure returns (uint256) {
         return a & ~b;
     }
+
+    /**
+     * @notice Returns a new bitmap that contains only bits set in both `a` and `b`
+     * @dev Result is the intersection of `a` and `b`
+     */
+    function and(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a & b;
+    }
 }


### PR DESCRIPTION
Changes:

- ejectOperator in SlashingRegistryCoordinator now only uses _forceDeregisterOperator, allowing AllocationManager to handle callbacks for deregistration

- RegistryCoordinator now handles M2 and non-M2 quorums separately:

- M2 quorums use _deregisterOperator

- Non-M2 quorums use _forceDeregisterOperator

- Added bitmap intersection support to filter quorum types properly

This change improves the ejection flow by ensuring proper deregistration handling through the AllocationManager while maintaining special handling for M2 quorums on ejection