### PR TITLE
feat: add operator set support to ECDSA contracts

### DIFF
--- a/src/interfaces/IECDSAStakeRegistry.sol
+++ b/src/interfaces/IECDSAStakeRegistry.sol
@@ -37,6 +37,12 @@ interface IECDSAStakeRegistryErrors {
     error OperatorAlreadyRegistered();
     /// @notice Thrown when de-registering or updating the stake for an unregisted operator.
     error OperatorNotRegistered();
+    /// @notice Thrown when the sender is not the AVS Registrar.
+    error InvalidSender();
+    /// @notice Thrown when the M2 quorum registration is disabled.
+    error M2QuorumRegistrationIsDisabled();
+    /// @notice Thrown when the operator set ids are invalid.
+    error InvalidOperatorSetIdsLength();
 }
 
 interface IECDSAStakeRegistryTypes {
@@ -124,6 +130,11 @@ interface IECDSAStakeRegistryEvents is IECDSAStakeRegistryTypes {
         address indexed newSigningKey,
         address oldSigningKey
     );
+
+    /*
+     * @notice Emitted when the M2 quorum registration is disabled.
+     */
+    event M2QuorumRegistrationDisabled();
 }
 
 interface IECDSAStakeRegistry is
@@ -138,7 +149,7 @@ interface IECDSAStakeRegistry is
      * @param operatorSignature Contains the operator's signature, salt, and expiry.
      * @param signingKey The signing key to add to the operator's history.
      */
-    function registerOperatorWithSignature(
+    function registerOperatorM2Quorum(
         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature,
         address signingKey
     ) external;
@@ -146,7 +157,22 @@ interface IECDSAStakeRegistry is
     /*
      * @notice Deregisters an existing operator.
      */
-    function deregisterOperator() external;
+    function deregisterOperatorM2Quorum() external;
+
+    /*
+     * @notice called by the AVS Registrar when an operator is registered on the allocation manager.
+     * @param operator The address of the operator.
+     * @param signingKey The signing key of the operator.
+     */
+    function onOperatorSetRegistered(address operator, address signingKey) external;
+
+    /*
+     * @notice called by the AVS Registrar when an operator is deregistered on the allocation manager.
+     * @param operator The address of the operator.
+     */
+    function onOperatorSetDeregistered(
+        address operator
+    ) external;
 
     /*
      * @notice Updates the signing key for an operator.
@@ -198,6 +224,12 @@ interface IECDSAStakeRegistry is
      * @return The current quorum of strategies and weights.
      */
     function quorum() external view returns (IECDSAStakeRegistryTypes.Quorum memory);
+
+    /*
+     * @notice Retrieves the current operator set id
+     * @return The current operator set id
+     */
+    function getCurrentOperatorSetIds() external view returns (uint32[] memory);
 
     /*
      * @notice Retrieves the latest signing key for a given operator.
@@ -274,6 +306,42 @@ interface IECDSAStakeRegistry is
     function getOperatorWeight(
         address operator
     ) external view returns (uint256);
+
+    /*
+     * @notice Retrieves the operator's weight in the m2 quorum.
+     * @param operator The address of the operator.
+     * @return The operator's weight in the m2 quorum.
+     */
+    function getQuorumWeight(
+        address operator
+    ) external view returns (uint256);
+
+    /*
+     * @notice Retrieves the operator's weight in the current operator set.
+     * @param operator The address of the operator.
+     * @return The operator's weight in the current operator set.
+     */
+    function getOperatorSetWeight(
+        address operator
+    ) external view returns (uint256);
+
+    /*
+     * @notice Checks if an operator is registered on the AVS Directory(M2).
+     * @param operator The address of the operator to check.
+     * @return bool True if the operator is registered on the AVS Directory, false otherwise.
+     */
+    function operatorRegisteredOnAVSDirectory(
+        address operator
+    ) external view returns (bool);
+
+    /*
+     * @notice Checks if an operator is registered on the current operator set.
+     * @param operator The address of the operator to check.
+     * @return bool True if the operator is registered on the current operator set, false otherwise.
+     */
+    function operatorRegisteredOnCurrentOperatorSets(
+        address operator
+    ) external view returns (bool);
 
     /*
      * @notice Updates operators for a specific quorum.

--- a/src/unaudited/ECDSAAVSRegistrar.sol
+++ b/src/unaudited/ECDSAAVSRegistrar.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {IAVSRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IAVSRegistrar.sol";
+import {IAllocationManager} from
+    "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IECDSAStakeRegistry} from "../interfaces/IECDSAStakeRegistry.sol";
+
+contract AVSRegistrar is IAVSRegistrar, Ownable {
+    IAllocationManager public allocationManager;
+    IECDSAStakeRegistry public immutable stakeRegistry;
+
+    error AVSRegistrar__OnlyAllocationManager();
+
+    modifier onlyAllocationManager() {
+        if (msg.sender != address(allocationManager)) {
+            revert AVSRegistrar__OnlyAllocationManager();
+        }
+        _;
+    }
+
+    constructor(address _allocationManager, address _stakeRegistry) Ownable() {
+        allocationManager = IAllocationManager(_allocationManager);
+        stakeRegistry = IECDSAStakeRegistry(_stakeRegistry);
+    }
+
+    function registerOperator(
+        address operator,
+        uint32[] calldata operatorSetIds,
+        bytes calldata data
+    ) external override onlyAllocationManager {
+        // Decode signing key
+        (address signingKey) = abi.decode(data, (address));
+
+        // Call stake registry to register operator
+        // Weight check will be done in ECDSAStakeRegistry
+        stakeRegistry.onOperatorSetRegistered(operator, signingKey);
+    }
+
+    function deregisterOperator(
+        address operator,
+        uint32[] calldata operatorSetIds
+    ) external override onlyAllocationManager {
+        stakeRegistry.onOperatorSetDeregistered(operator);
+    }
+
+    function updateAllocationManager(
+        address _allocationManager
+    ) external onlyOwner {
+        allocationManager = IAllocationManager(_allocationManager);
+    }
+}

--- a/src/unaudited/ECDSAServiceManagerBase.sol
+++ b/src/unaudited/ECDSAServiceManagerBase.sol
@@ -17,8 +17,12 @@ import {IRewardsCoordinator} from
 import {IECDSAStakeRegistryTypes} from "../interfaces/IECDSAStakeRegistry.sol";
 import {ECDSAStakeRegistry} from "../unaudited/ECDSAStakeRegistry.sol";
 import {IAVSRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IAVSRegistrar.sol";
-import {IAllocationManager} from
-    "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IPermissionController} from
+    "eigenlayer-contracts/src/contracts/interfaces/IPermissionController.sol";
+import {
+    IAllocationManager,
+    IAllocationManagerTypes
+} from "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 
 abstract contract ECDSAServiceManagerBase is IServiceManager, OwnableUpgradeable {
     using SafeERC20 for IERC20;
@@ -37,6 +41,9 @@ abstract contract ECDSAServiceManagerBase is IServiceManager, OwnableUpgradeable
 
     /// @notice Address of the delegation manager contract, which manages staker delegations to operators.
     address internal immutable delegationManager;
+
+    /// @notice Address of the permission controller contract, which manages permissions for the service manager.
+    address internal immutable permissionController;
 
     /// @notice Address of the rewards initiator, which is allowed to create AVS rewards submissions.
     address public rewardsInitiator;
@@ -74,13 +81,15 @@ abstract contract ECDSAServiceManagerBase is IServiceManager, OwnableUpgradeable
         address _stakeRegistry,
         address _rewardsCoordinator,
         address _delegationManager,
-        address _allocationManager
+        address _allocationManager,
+        address _permissionController
     ) {
         avsDirectory = _avsDirectory;
         stakeRegistry = _stakeRegistry;
         rewardsCoordinator = _rewardsCoordinator;
         delegationManager = _delegationManager;
         allocationManager = _allocationManager;
+        permissionController = _permissionController;
         _disableInitializers();
     }
 
@@ -137,6 +146,81 @@ abstract contract ECDSAServiceManagerBase is IServiceManager, OwnableUpgradeable
         address operator
     ) external virtual onlyStakeRegistry {
         _deregisterOperatorFromAVS(operator);
+    }
+
+    /// @notice Deregisters an operator from a set of operator sets.
+    /// @dev This function is used to deregister an operator from a set of operator sets.
+    /// @param operator The address of the operator to deregister.
+    /// @param operatorSetIds The set of operator set ids to deregister from.
+    function deregisterOperatorFromOperatorSets(
+        address operator,
+        uint32[] memory operatorSetIds
+    ) external virtual onlyStakeRegistry {
+        IAllocationManager.DeregisterParams memory params = IAllocationManagerTypes.DeregisterParams({
+            operator: operator,
+            avs: address(this),
+            operatorSetIds: operatorSetIds
+        });
+        IAllocationManager(allocationManager).deregisterFromOperatorSets(params);
+    }
+
+    /// @inheritdoc IServiceManager
+
+    function addPendingAdmin(
+        address admin
+    ) external virtual onlyOwner {
+        IPermissionController(permissionController).addPendingAdmin({
+            account: address(this),
+            admin: admin
+        });
+    }
+
+    /// @inheritdoc IServiceManager
+    function removePendingAdmin(
+        address pendingAdmin
+    ) external virtual onlyOwner {
+        IPermissionController(permissionController).removePendingAdmin({
+            account: address(this),
+            admin: pendingAdmin
+        });
+    }
+
+    /// @inheritdoc IServiceManager
+    function removeAdmin(
+        address admin
+    ) external virtual onlyOwner {
+        IPermissionController(permissionController).removeAdmin({
+            account: address(this),
+            admin: admin
+        });
+    }
+
+    /// @inheritdoc IServiceManager
+    function setAppointee(
+        address appointee,
+        address target,
+        bytes4 selector
+    ) external virtual onlyOwner {
+        IPermissionController(permissionController).setAppointee({
+            account: address(this),
+            appointee: appointee,
+            target: target,
+            selector: selector
+        });
+    }
+
+    /// @inheritdoc IServiceManager
+    function removeAppointee(
+        address appointee,
+        address target,
+        bytes4 selector
+    ) external virtual onlyOwner {
+        IPermissionController(permissionController).removeAppointee({
+            account: address(this),
+            appointee: appointee,
+            target: target,
+            selector: selector
+        });
     }
 
     /// @inheritdoc IServiceManagerUI

--- a/src/unaudited/ECDSAStakeRegistry.sol
+++ b/src/unaudited/ECDSAStakeRegistry.sol
@@ -19,6 +19,13 @@ import {SignatureCheckerUpgradeable} from
     "@openzeppelin-upgrades/contracts/utils/cryptography/SignatureCheckerUpgradeable.sol";
 import {IERC1271Upgradeable} from
     "@openzeppelin-upgrades/contracts/interfaces/IERC1271Upgradeable.sol";
+import {
+    IAVSDirectory,
+    IAVSDirectoryTypes
+} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
+import {IAllocationManager} from
+    "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {OperatorSet} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
 
 /// @title ECDSA Stake Registry
 /// @dev THIS CONTRACT IS NOT AUDITED
@@ -34,9 +41,22 @@ contract ECDSAStakeRegistry is
     /// @dev Constructor to create ECDSAStakeRegistry.
     /// @param _delegationManager Address of the DelegationManager contract that this registry interacts with.
     constructor(
-        IDelegationManager _delegationManager
-    ) ECDSAStakeRegistryStorage(_delegationManager) {
+        IDelegationManager _delegationManager,
+        IAllocationManager _allocationManager,
+        address _avsRegistrar,
+        IAVSDirectory _avsDirectory
+    )
+        ECDSAStakeRegistryStorage(_delegationManager, _allocationManager, _avsRegistrar, _avsDirectory)
+    {
         // _disableInitializers();
+    }
+
+    /// @notice Modifier to ensure the caller is the AVS Registrar.
+    modifier onlyAVSRegistrar() {
+        if (msg.sender != address(avsRegistrar)) {
+            revert InvalidSender();
+        }
+        _;
     }
 
     /// @notice Initializes the contract with the given parameters.
@@ -64,24 +84,70 @@ contract ECDSAStakeRegistry is
         __Ownable_init();
     }
 
-    /// @inheritdoc IECDSAStakeRegistry
-    function registerOperatorWithSignature(
-        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature,
-        address signingKey
-    ) external {
-        _registerOperatorWithSig(msg.sender, operatorSignature, signingKey);
+    function disableM2QuorumRegistration() external onlyOwner {
+        if (isM2QuorumRegistrationDisabled) {
+            revert M2QuorumRegistrationIsDisabled();
+        }
+
+        isM2QuorumRegistrationDisabled = true;
+        emit M2QuorumRegistrationDisabled();
     }
 
     /// @inheritdoc IECDSAStakeRegistry
-    function deregisterOperator() external {
-        _deregisterOperator(msg.sender);
+    function registerOperatorM2Quorum(
+        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature,
+        address signingKey
+    ) external {
+        if (isM2QuorumRegistrationDisabled) {
+            revert M2QuorumRegistrationIsDisabled();
+        }
+        if (operatorRegisteredOnAVSDirectory(msg.sender)) {
+            revert OperatorAlreadyRegistered();
+        }
+        _registerOperatorM2Quorum(msg.sender, operatorSignature, signingKey);
+    }
+
+    /// @inheritdoc IECDSAStakeRegistry
+    function deregisterOperatorM2Quorum() external {
+        if (!operatorRegisteredOnAVSDirectory(msg.sender)) {
+            revert OperatorNotRegistered();
+        }
+
+        _deregisterOperatorM2Quorum(msg.sender);
+    }
+
+    function onOperatorSetRegistered(
+        address operator,
+        address signingKey
+    ) external onlyAVSRegistrar {
+        // Update operator weight
+        _updateOperatorWeight(operator);
+
+        // Update signing key and p2p key
+        _updateOperatorSigningKey(operator, signingKey);
+
+        if (!operatorRegisteredOnAVSDirectory(operator)) {
+            emit OperatorRegistered(operator, _serviceManager);
+        }
+    }
+
+    function onOperatorSetDeregistered(
+        address operator
+    ) external onlyAVSRegistrar {
+        // Update weights
+        _updateOperatorWeight(operator);
+
+        // Emit event
+        if (!operatorRegisteredOnAVSDirectory(operator)) {
+            emit OperatorDeregistered(operator, _serviceManager);
+        }
     }
 
     /// @inheritdoc IECDSAStakeRegistry
     function updateOperatorSigningKey(
         address newSigningKey
     ) external {
-        if (!_operatorRegistered[msg.sender]) {
+        if (!operatorRegistered(msg.sender)) {
             revert OperatorNotRegistered();
         }
         _updateOperatorSigningKey(msg.sender, newSigningKey);
@@ -119,6 +185,33 @@ contract ECDSAStakeRegistry is
         _updateStakeThreshold(thresholdWeight);
     }
 
+    /// @notice Sets the current operator set ids
+    /// @param _ids The ids of the operator sets to set
+    function setCurrentOperatorSetIds(
+        uint32[] calldata _ids
+    ) external onlyOwner {
+        if (_ids.length == 0 || _ids.length > 10) {
+            revert InvalidOperatorSetIdsLength();
+        }
+        currentOperatorSetIds = _ids;
+    }
+
+    /// @notice Sets the allocation manager
+    /// @param _allocationManager The allocation manager to set
+    function setAllocationManager(
+        IAllocationManager _allocationManager
+    ) external onlyOwner {
+        allocationManager = _allocationManager;
+    }
+
+    /// @notice Sets the AVS Registrar
+    /// @param _avsRegistrar The AVS Registrar to set
+    function setAVSRegistrar(
+        address _avsRegistrar
+    ) external onlyOwner {
+        avsRegistrar = _avsRegistrar;
+    }
+
     function isValidSignature(
         bytes32 digest,
         bytes memory _signatureData
@@ -132,6 +225,12 @@ contract ECDSAStakeRegistry is
     /// @inheritdoc IECDSAStakeRegistry
     function quorum() external view returns (IECDSAStakeRegistryTypes.Quorum memory) {
         return _quorum;
+    }
+
+    /// @notice Gets the current operator set ids
+    /// @return The current operator set ids
+    function getCurrentOperatorSetIds() external view returns (uint32[] memory) {
+        return currentOperatorSetIds;
     }
 
     /// @inheritdoc IECDSAStakeRegistry
@@ -189,35 +288,119 @@ contract ECDSAStakeRegistry is
     }
 
     /// @inheritdoc IECDSAStakeRegistry
-    function operatorRegistered(
-        address operator
-    ) external view returns (bool) {
-        return _operatorRegistered[operator];
-    }
-
-    /// @inheritdoc IECDSAStakeRegistry
     function minimumWeight() external view returns (uint256) {
         return _minimumWeight;
     }
 
-    /// @inheritdoc IECDSAStakeRegistry
+    /// @notice Calculates an operator's current weight based on their delegated stake
+    /// @param _operator Address of the operator to calculate weight for
+    /// @return Current weight of the operator (0 if below minimum threshold)
+    /// @dev Queries mainnet delegation manager for current shares
     function getOperatorWeight(
+        address _operator
+    ) public view returns (uint256) {
+        uint256 quorumWeight = getQuorumWeight(_operator);
+        uint256 operatorSetWeight = getOperatorSetWeight(_operator);
+
+        return quorumWeight + operatorSetWeight;
+    }
+
+    /// @notice Calculates operator's weight in the quorum
+    /// @param operator The operator address to calculate weight for
+    /// @return The operator's weight in quorum, or 0 if below minimum
+    function getQuorumWeight(
         address operator
     ) public view returns (uint256) {
+        // Get strategy params from quorum
         StrategyParams[] memory strategyParams = _quorum.strategies;
         uint256 weight;
+
+        // Create strategy array for batch shares query
         IStrategy[] memory strategies = new IStrategy[](strategyParams.length);
         for (uint256 i; i < strategyParams.length; i++) {
             strategies[i] = strategyParams[i].strategy;
         }
+
+        // Get operator's shares for all strategies
         uint256[] memory shares = DELEGATION_MANAGER.getOperatorShares(operator, strategies);
+
+        // Calculate weighted sum of shares
         for (uint256 i; i < strategyParams.length; i++) {
             weight += shares[i] * strategyParams[i].multiplier;
         }
+        // Divide by BPS to get final weight
         weight = weight / BPS;
 
+        // Return 0 if below minimum weight
         if (weight >= _minimumWeight) {
             return weight;
+        } else {
+            return 0;
+        }
+    }
+
+    /// @notice Calculates operator's available weight in current operator set
+    /// @dev Weight calculation:
+    ///      1. Check operator set membership
+    ///      2. Get shares and allocation for each strategy
+    ///      3. Calculate available proportion (currentMagnitude/maxMagnitude)
+    ///      4. Sum up available shares weighted by proportion
+    /// @param operator The operator address to calculate weight for
+    /// @return The operator's available weight in set, or 0 if below minimum
+    function getOperatorSetWeight(
+        address operator
+    ) public view returns (uint256) {
+        // Return 0 if allocation manager not set
+        if (address(allocationManager) == address(0)) {
+            return 0;
+        }
+
+        uint256 totalWeight;
+
+        // Loop through all operator sets
+        for (uint256 setIndex = 0; setIndex < currentOperatorSetIds.length; setIndex++) {
+            // Create operator set struct for current id
+            OperatorSet memory operatorSet =
+                OperatorSet({avs: address(_serviceManager), id: currentOperatorSetIds[setIndex]});
+
+            // Check operator set membership
+            if (!allocationManager.isMemberOfOperatorSet(operator, operatorSet)) {
+                continue;
+            }
+
+            // Get strategies from operator set
+            IStrategy[] memory strategies =
+                allocationManager.getStrategiesInOperatorSet(operatorSet);
+            if (strategies.length == 0) {
+                continue;
+            }
+
+            // Get operator's shares for all strategies
+            uint256[] memory shares = DELEGATION_MANAGER.getOperatorShares(operator, strategies);
+
+            // Calculate available weight for each strategy
+            for (uint256 i = 0; i < strategies.length; i++) {
+                // Get allocation and max magnitude
+                IAllocationManager.Allocation memory allocation =
+                    allocationManager.getAllocation(operator, operatorSet, strategies[i]);
+                uint64 maxMagnitude = allocationManager.getMaxMagnitude(operator, strategies[i]);
+
+                if (maxMagnitude == 0) {
+                    continue;
+                }
+
+                // Calculate available proportion
+                uint256 slashableProportion =
+                    uint256(allocation.currentMagnitude) * WAD / maxMagnitude;
+
+                // Add weighted shares to total
+                totalWeight += shares[i] * slashableProportion / WAD;
+            }
+        }
+
+        // Return 0 if below minimum weight
+        if (totalWeight >= _minimumWeight) {
+            return totalWeight;
         } else {
             return 0;
         }
@@ -229,6 +412,47 @@ contract ECDSAStakeRegistry is
         bytes memory
     ) external {
         _updateAllOperators(operatorsPerQuorum[0]);
+    }
+
+    /// @notice Checks if an operator is registered on the AVS Directory(M2).
+    /// @param operator The address of the operator to check.
+    /// @return bool True if the operator is registered on the AVS Directory, false otherwise.
+    function operatorRegisteredOnAVSDirectory(
+        address operator
+    ) public view returns (bool) {
+        return AVS_DIRECTORY.avsOperatorStatus(_serviceManager, operator)
+            == IAVSDirectoryTypes.OperatorAVSRegistrationStatus.REGISTERED;
+    }
+
+    /// @notice Checks if an operator is registered on the current operator set.
+    /// @param operator The address of the operator to check.
+    /// @return bool True if the operator is registered on the current operator set, false otherwise.
+    function operatorRegisteredOnCurrentOperatorSets(
+        address operator
+    ) public view returns (bool) {
+        if (address(allocationManager) == address(0)) {
+            return false;
+        }
+
+        // Check if operator is registered in any current set
+        for (uint256 i = 0; i < currentOperatorSetIds.length; i++) {
+            OperatorSet memory operatorSet =
+                OperatorSet({avs: address(_serviceManager), id: currentOperatorSetIds[i]});
+            if (allocationManager.isMemberOfOperatorSet(operator, operatorSet)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// @notice Checks if an operator is registered on the AVS Directory or the current operator set.
+    /// @param operator The address of the operator to check.
+    /// @return bool True if the operator is registered on the AVS Directory or the current operator set, false otherwise.
+    function operatorRegistered(
+        address operator
+    ) public view returns (bool) {
+        return operatorRegisteredOnAVSDirectory(operator)
+            || operatorRegisteredOnCurrentOperatorSets(operator);
     }
 
     /// @dev Updates the list of operators if the provided list has the correct number of operators.
@@ -296,38 +520,53 @@ contract ECDSAStakeRegistry is
 
     /// @dev Internal function to deregister an operator
     /// @param operator The operator's address to deregister
-    function _deregisterOperator(
+    function _deregisterOperatorM2Quorum(
         address operator
     ) internal {
-        if (!_operatorRegistered[operator]) {
+        if (!operatorRegisteredOnAVSDirectory(operator)) {
             revert OperatorNotRegistered();
         }
-        _totalOperators--;
-        delete _operatorRegistered[operator];
+
         int256 delta = _updateOperatorWeight(operator);
         _updateTotalWeight(delta);
         IServiceManager(_serviceManager).deregisterOperatorFromAVS(operator);
-        emit OperatorDeregistered(operator, address(_serviceManager));
+        if (!operatorRegisteredOnCurrentOperatorSets(operator)) {
+            _totalOperators--;
+            emit OperatorDeregistered(operator, address(_serviceManager));
+        }
     }
 
     /// @dev registers an operator through a provided signature
     /// @param operatorSignature Contains the operator's signature, salt, and expiry
     /// @param signingKey The signing key to add to the operator's history
-    function _registerOperatorWithSig(
+    function _registerOperatorM2Quorum(
         address operator,
         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature,
         address signingKey
     ) internal virtual {
-        if (_operatorRegistered[operator]) {
+        if (operatorRegisteredOnAVSDirectory(operator)) {
             revert OperatorAlreadyRegistered();
         }
-        _totalOperators++;
-        _operatorRegistered[operator] = true;
+
         int256 delta = _updateOperatorWeight(operator);
         _updateTotalWeight(delta);
         _updateOperatorSigningKey(operator, signingKey);
         IServiceManager(_serviceManager).registerOperatorToAVS(operator, operatorSignature);
-        emit OperatorRegistered(operator, _serviceManager);
+        if (!operatorRegisteredOnCurrentOperatorSets(operator)) {
+            _totalOperators++;
+            emit OperatorRegistered(operator, _serviceManager);
+        }
+    }
+
+    /// @notice Deregisters an operator from a set of operator sets.
+    /// @dev This function is used to deregister an operator from a set of operator sets.
+    /// @param operator The address of the operator to deregister.
+    function _deregisterOperatorFromOperatorSets(
+        address operator
+    ) internal virtual {
+        IServiceManager(_serviceManager).deregisterOperatorFromOperatorSets(
+            operator, currentOperatorSetIds
+        );
     }
 
     /// @dev Internal function to update an operator's signing key
@@ -350,7 +589,7 @@ contract ECDSAStakeRegistry is
         int256 delta;
         uint256 newWeight;
         uint256 oldWeight = _operatorWeightHistory[operator].latest();
-        if (!_operatorRegistered[operator]) {
+        if (!operatorRegistered(operator)) {
             delta -= int256(oldWeight);
             if (delta == 0) {
                 return delta;

--- a/src/unaudited/ECDSAStakeRegistry.sol
+++ b/src/unaudited/ECDSAStakeRegistry.sol
@@ -20,12 +20,15 @@ import {SignatureCheckerUpgradeable} from
 import {IERC1271Upgradeable} from
     "@openzeppelin-upgrades/contracts/interfaces/IERC1271Upgradeable.sol";
 import {
-    IAVSDirectory,
     IAVSDirectoryTypes
 } from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
 import {IAllocationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 import {OperatorSet} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+
+interface IAVSDirectory {
+    function avsOperatorStatus(address avs, address operator) external view returns (IAVSDirectoryTypes.OperatorAVSRegistrationStatus);
+}
 
 /// @title ECDSA Stake Registry
 /// @dev THIS CONTRACT IS NOT AUDITED

--- a/src/unaudited/ECDSAStakeRegistryStorage.sol
+++ b/src/unaudited/ECDSAStakeRegistryStorage.sol
@@ -12,11 +12,7 @@ import {IAllocationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 import {IAVSRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IAVSRegistrar.sol";
 import {IAVSDirectoryTypes} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
-
-interface IAVSDirectory {
-    function avsOperatorStatus(address avs, address operator) external view returns (IAVSDirectoryTypes.OperatorAVSRegistrationStatus);
-}
-
+import {IAVSDirectory} from "./ECDSAStakeRegistry.sol";
 abstract contract ECDSAStakeRegistryStorage is IECDSAStakeRegistry {
     /// @notice Manages staking delegations through the DelegationManager interface
     IDelegationManager internal immutable DELEGATION_MANAGER;

--- a/src/unaudited/ECDSAStakeRegistryStorage.sol
+++ b/src/unaudited/ECDSAStakeRegistryStorage.sol
@@ -8,10 +8,32 @@ import {CheckpointsUpgradeable} from
 import {
     IECDSAStakeRegistry, IECDSAStakeRegistryTypes
 } from "../interfaces/IECDSAStakeRegistry.sol";
+import {IAllocationManager} from
+    "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IAVSRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IAVSRegistrar.sol";
+import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
 
 abstract contract ECDSAStakeRegistryStorage is IECDSAStakeRegistry {
     /// @notice Manages staking delegations through the DelegationManager interface
     IDelegationManager internal immutable DELEGATION_MANAGER;
+
+    /// @notice The AVS Directory contract
+    IAVSDirectory internal immutable AVS_DIRECTORY;
+
+    /// @notice Manages staking delegations through the DelegationManager interface
+    IAllocationManager internal allocationManager;
+
+    /// @notice The address of the AVS Registrar of the AVS
+    address internal avsRegistrar;
+
+    /// @notice Whether M2 quorum registration is disabled
+    bool public isM2QuorumRegistrationDisabled;
+
+    /// @notice The current operator set ids
+    uint32[] public currentOperatorSetIds;
+
+    /// @notice The total amount of multipliers to weigh stakes
+    uint256 public constant WAD = 1e18;
 
     /// @dev The total amount of multipliers to weigh stakes
     uint256 internal constant BPS = 10000;
@@ -28,9 +50,6 @@ abstract contract ECDSAStakeRegistryStorage is IECDSAStakeRegistry {
     /// @notice Holds the address of the service manager
     address internal _serviceManager;
 
-    /// @notice Defines the duration after which the stake's weight expires.
-    uint256 internal _stakeExpiry;
-
     /// @notice Maps an operator to their signing key history using checkpoints
     mapping(address => CheckpointsUpgradeable.History) internal _operatorSigningKeyHistory;
 
@@ -43,14 +62,17 @@ abstract contract ECDSAStakeRegistryStorage is IECDSAStakeRegistry {
     /// @notice Maps operator addresses to their respective stake histories using checkpoints
     mapping(address => CheckpointsUpgradeable.History) internal _operatorWeightHistory;
 
-    /// @notice Maps an operator to their registration status
-    mapping(address => bool) internal _operatorRegistered;
-
     /// @param _delegationManager Connects this registry with the DelegationManager
     constructor(
-        IDelegationManager _delegationManager
+        IDelegationManager _delegationManager,
+        IAllocationManager _allocationManager,
+        address _avsRegistrar,
+        IAVSDirectory _avsDirectory
     ) {
         DELEGATION_MANAGER = _delegationManager;
+        allocationManager = _allocationManager;
+        avsRegistrar = _avsRegistrar;
+        AVS_DIRECTORY = _avsDirectory;
     }
 
     // slither-disable-next-line shadowing-state

--- a/src/unaudited/ECDSAStakeRegistryStorage.sol
+++ b/src/unaudited/ECDSAStakeRegistryStorage.sol
@@ -11,7 +11,11 @@ import {
 import {IAllocationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 import {IAVSRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IAVSRegistrar.sol";
-import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
+import {IAVSDirectoryTypes} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
+
+interface IAVSDirectory {
+    function avsOperatorStatus(address avs, address operator) external view returns (IAVSDirectoryTypes.OperatorAVSRegistrationStatus);
+}
 
 abstract contract ECDSAStakeRegistryStorage is IECDSAStakeRegistry {
     /// @notice Manages staking delegations through the DelegationManager interface

--- a/src/unaudited/examples/ECDSAStakeRegistryEqualWeight.sol
+++ b/src/unaudited/examples/ECDSAStakeRegistryEqualWeight.sol
@@ -7,6 +7,9 @@ import {IDelegationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
 import {CheckpointsUpgradeable} from
     "@openzeppelin-upgrades/contracts/utils/CheckpointsUpgradeable.sol";
+import {IAllocationManager} from
+    "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
 
 /// @title ECDSA Stake Registry with Equal Weight
 /// @dev THIS CONTRACT IS NOT AUDITED
@@ -18,8 +21,18 @@ contract ECDSAStakeRegistryEqualWeight is ECDSAStakeRegistryPermissioned {
     /// @dev Passes the delegation manager to the parent constructor.
     /// @param _delegationManager The address of the delegation manager contract.
     constructor(
-        IDelegationManager _delegationManager
-    ) ECDSAStakeRegistryPermissioned(_delegationManager) {
+        IDelegationManager _delegationManager,
+        IAllocationManager _allocationManager,
+        address _avsRegistrar,
+        IAVSDirectory _avsDirectory
+    )
+        ECDSAStakeRegistryPermissioned(
+            _delegationManager,
+            _allocationManager,
+            _avsRegistrar,
+            _avsDirectory
+        )
+    {
         // _disableInitializers();
     }
 
@@ -33,7 +46,7 @@ contract ECDSAStakeRegistryEqualWeight is ECDSAStakeRegistryPermissioned {
         uint256 oldWeight;
         uint256 newWeight;
         int256 delta;
-        if (_operatorRegistered[_operator]) {
+        if (operatorRegistered(_operator)) {
             (oldWeight,) = _operatorWeightHistory[_operator].push(1);
             delta = int256(1) - int256(oldWeight); // handles if they were already registered
         } else {

--- a/src/unaudited/examples/ECDSAStakeRegistryEqualWeight.sol
+++ b/src/unaudited/examples/ECDSAStakeRegistryEqualWeight.sol
@@ -9,7 +9,7 @@ import {CheckpointsUpgradeable} from
     "@openzeppelin-upgrades/contracts/utils/CheckpointsUpgradeable.sol";
 import {IAllocationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
-import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
+import {IAVSDirectory} from "../ECDSAStakeRegistry.sol";
 
 /// @title ECDSA Stake Registry with Equal Weight
 /// @dev THIS CONTRACT IS NOT AUDITED

--- a/src/unaudited/examples/ECDSAStakeRegistryPermissioned.sol
+++ b/src/unaudited/examples/ECDSAStakeRegistryPermissioned.sol
@@ -7,7 +7,7 @@ import {IDelegationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
 import {IAllocationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
-import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
+import {IAVSDirectory} from "../ECDSAStakeRegistry.sol";
 
 /// @title ECDSA Stake Registry with an Operator Allowlist
 /// @dev THIS CONTRACT IS NOT AUDITED

--- a/src/unaudited/examples/ECDSAStakeRegistryPermissioned.sol
+++ b/src/unaudited/examples/ECDSAStakeRegistryPermissioned.sol
@@ -5,6 +5,9 @@ import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/ISi
 import {ECDSAStakeRegistry} from "../ECDSAStakeRegistry.sol";
 import {IDelegationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
+import {IAllocationManager} from
+    "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IAVSDirectory} from "eigenlayer-contracts/src/contracts/interfaces/IAVSDirectory.sol";
 
 /// @title ECDSA Stake Registry with an Operator Allowlist
 /// @dev THIS CONTRACT IS NOT AUDITED
@@ -29,8 +32,11 @@ contract ECDSAStakeRegistryPermissioned is ECDSAStakeRegistry {
     error OperatorAlreadyAllowlisted();
 
     constructor(
-        IDelegationManager _delegationManager
-    ) ECDSAStakeRegistry(_delegationManager) {
+        IDelegationManager _delegationManager,
+        IAllocationManager _allocationManager,
+        address _avsRegistrar,
+        IAVSDirectory _avsDirectory
+    ) ECDSAStakeRegistry(_delegationManager, _allocationManager, _avsRegistrar, _avsDirectory) {
         // _disableInitializers();
     }
 
@@ -66,7 +72,12 @@ contract ECDSAStakeRegistryPermissioned is ECDSAStakeRegistry {
     function _ejectOperator(
         address _operator
     ) internal {
-        _deregisterOperator(_operator);
+        if (operatorRegisteredOnAVSDirectory(_operator)) {
+            _deregisterOperatorM2Quorum(_operator);
+        }
+        if (operatorRegisteredOnCurrentOperatorSets(_operator)) {
+            _deregisterOperatorFromOperatorSets(_operator);
+        }
         emit OperatorEjected(_operator);
     }
 
@@ -94,13 +105,11 @@ contract ECDSAStakeRegistryPermissioned is ECDSAStakeRegistry {
         }
         delete allowlistedOperators[_operator];
         emit OperatorRevoked(_operator);
-        if (_operatorRegistered[_operator]) {
-            _ejectOperator(_operator);
-        }
+        _ejectOperator(_operator);
     }
 
     /// @inheritdoc ECDSAStakeRegistry
-    function _registerOperatorWithSig(
+    function _registerOperatorM2Quorum(
         address _operator,
         ISignatureUtils.SignatureWithSaltAndExpiry memory _operatorSignature,
         address _operatorSigningKey
@@ -108,6 +117,6 @@ contract ECDSAStakeRegistryPermissioned is ECDSAStakeRegistry {
         if (allowlistedOperators[_operator] != true) {
             revert OperatorNotAllowlisted();
         }
-        super._registerOperatorWithSig(_operator, _operatorSignature, _operatorSigningKey);
+        super._registerOperatorM2Quorum(_operator, _operatorSignature, _operatorSigningKey);
     }
 }


### PR DESCRIPTION
# Description

This PR is a draft (tests excluded) that updates the ECDSA contracts to support both M2 registration and the new slashing-release operator set functionality, especially useful in the migration phase. The key changes enable operators to register through both pathways and obtain correct weights while maintaining backwards compatibility.

## Key Changes

### ECDSAStakeRegistry
- Added support for operator set registration via AllocationManager
- Added weight calculation for both M2 quorum and operator sets
- Added functions to check operator registration status across both systems
- Added support for disabling M2 quorum registration

### ECDSAServiceManagerBase
- Added functions to implement `IServiceManager`:
1. deregisterOperatorFromOperatorSets
2. addPendingAdmin
3. removePendingAdmin
4. removeAdmin
5. setAppointee
6. removeAppointee

### ECDSAAVSRegistrar
- An AVS Registrar example for ECDSAStakeRegistry
- It will call `ECDSAStakeRegistry::onOperatorSetRegistered` and `ECDSAStakeRegistry::onOperatorSetDeregistered` upon registration and deregistration respectively

### ECDSAStakeRegistryEqualWeight
- Added `_deregisterOperatorFromOperatorSets` for `_ejectOperator`

### ECDSAStakeRegistryPermissioned
- Update operator status check

## Implementation Details

- Operators can now be registered (from view of stake registry) through either:
  1. M2 quorum (legacy) via `registerOperatorM2Quorum()`
  2. Operator sets via `AllocationManager`

- Weight calculation considers both:
  1. M2 quorum weight (`getQuorumWeight()`)
  2. Operator set weight (`getOperatorSetWeight()`)

- Registration status checks include (an operator is considered to be registered if either of the below check returns true):
  1. M2 quorum registration (`operatorRegisteredOnAVSDirectory()`)
  2. Operator set registration (`operatorRegisteredOnCurrentOperatorSets()`)

- Added ability to disable M2 quorum registration via `ECDSAStakeRegistry::disableM2QuorumRegistration()`