### PR TITLE
Store G2 onchain 

### DIFF
--- a/src/BLSApkRegistry.sol
+++ b/src/BLSApkRegistry.sol
@@ -6,6 +6,7 @@ import {BLSApkRegistryStorage, IBLSApkRegistry} from "./BLSApkRegistryStorage.so
 import {ISlashingRegistryCoordinator} from "./interfaces/ISlashingRegistryCoordinator.sol";
 
 import {BN254} from "./libraries/BN254.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 contract BLSApkRegistry is BLSApkRegistryStorage {
     using BN254 for BN254.G1Point;
@@ -16,10 +17,36 @@ contract BLSApkRegistry is BLSApkRegistryStorage {
         _;
     }
 
+    /// @notice when applied to a function, only allows the RegistryCoordinator owner to call it
+    modifier onlyRegistryCoordinatorOwner() {
+        _checkRegistryCoordinatorOwner();
+        _;
+    }
+
     /// @notice Sets the (immutable) `registryCoordinator` address
     constructor(
         ISlashingRegistryCoordinator _slashingRegistryCoordinator
     ) BLSApkRegistryStorage(_slashingRegistryCoordinator) {}
+
+
+    /// @inheritdoc IBLSApkRegistry
+    function getOperatorPubkeyG2(
+        address operator
+    ) public view override returns (BN254.G2Point memory) {
+        return operatorToPubkeyG2[operator];
+    }
+
+    /// @notice Checks if a G2 pubkey is already set for an operator
+    function _checkG2PubkeyNotSet(address operator) internal view {
+        BN254.G2Point memory existingG2Pubkey = getOperatorPubkeyG2(operator);
+        require(
+            existingG2Pubkey.X[0] == 0 &&
+            existingG2Pubkey.X[1] == 0 &&
+            existingG2Pubkey.Y[0] == 0 &&
+            existingG2Pubkey.Y[1] == 0,
+            G2PubkeyAlreadySet()
+        );
+    }
 
     /**
      *
@@ -115,6 +142,34 @@ contract BLSApkRegistry is BLSApkRegistryStorage {
 
         emit NewPubkeyRegistration(operator, params.pubkeyG1, params.pubkeyG2);
         return pubkeyHash;
+    }
+
+    /// @notice Verifies and registers a G2 public key for an operator that already has a G1 key
+    /// @dev This is meant to be used as a one-time way to add G2 public keys for operators that have G1 keys but no G2 key on chain
+    /// @param operator The address of the operator to register the G2 key for
+    /// @param pubkeyG2 The G2 public key to register
+    function verifyAndRegisterG2PubkeyForOperator(
+        address operator,
+        BN254.G2Point calldata pubkeyG2
+    ) external onlyRegistryCoordinatorOwner {
+        // Get the operator's G1 pubkey. Reverts if they have not registered a key
+        (BN254.G1Point memory pubkeyG1,) = getRegisteredPubkey(operator);
+
+        _checkG2PubkeyNotSet(operator);
+
+        require(
+            BN254.pairing(
+                pubkeyG1,
+                BN254.negGeneratorG2(),
+                BN254.generatorG1(),
+                pubkeyG2
+            ),
+            InvalidBLSSignatureOrPrivateKey()
+        );
+
+        operatorToPubkeyG2[operator] = pubkeyG2;
+
+        emit NewG2PubkeyRegistration(operator, pubkeyG2);
     }
 
     /**
@@ -265,5 +320,12 @@ contract BLSApkRegistry is BLSApkRegistryStorage {
 
     function _checkRegistryCoordinator() internal view {
         require(msg.sender == address(registryCoordinator), OnlyRegistryCoordinatorOwner());
+    }
+
+    function _checkRegistryCoordinatorOwner() internal view {
+        require(
+            msg.sender == Ownable(address(registryCoordinator)).owner(),
+            OnlyRegistryCoordinatorOwner()
+        );
     }
 }

--- a/src/BLSApkRegistry.sol
+++ b/src/BLSApkRegistry.sol
@@ -138,12 +138,7 @@ contract BLSApkRegistry is BLSApkRegistryStorage {
         _checkG2PubkeyNotSet(operator);
 
         require(
-            BN254.pairing(
-                pubkeyG1,
-                BN254.negGeneratorG2(),
-                BN254.generatorG1(),
-                pubkeyG2
-            ),
+            BN254.pairing(pubkeyG1, BN254.negGeneratorG2(), BN254.generatorG1(), pubkeyG2),
             InvalidBLSSignatureOrPrivateKey()
         );
 
@@ -317,13 +312,13 @@ contract BLSApkRegistry is BLSApkRegistryStorage {
     }
 
     /// @notice Checks if a G2 pubkey is already set for an operator
-    function _checkG2PubkeyNotSet(address operator) internal view {
+    function _checkG2PubkeyNotSet(
+        address operator
+    ) internal view {
         BN254.G2Point memory existingG2Pubkey = getOperatorPubkeyG2(operator);
         require(
-            existingG2Pubkey.X[0] == 0 &&
-            existingG2Pubkey.X[1] == 0 &&
-            existingG2Pubkey.Y[0] == 0 &&
-            existingG2Pubkey.Y[1] == 0,
+            existingG2Pubkey.X[0] == 0 && existingG2Pubkey.X[1] == 0 && existingG2Pubkey.Y[0] == 0
+                && existingG2Pubkey.Y[1] == 0,
             G2PubkeyAlreadySet()
         );
     }

--- a/src/BLSApkRegistry.sol
+++ b/src/BLSApkRegistry.sol
@@ -109,6 +109,7 @@ contract BLSApkRegistry is BLSApkRegistryStorage {
         );
 
         operatorToPubkey[operator] = params.pubkeyG1;
+        operatorToPubkeyG2[operator] = params.pubkeyG2;
         operatorToPubkeyHash[operator] = pubkeyHash;
         pubkeyHashToOperator[pubkeyHash] = operator;
 

--- a/src/BLSApkRegistry.sol
+++ b/src/BLSApkRegistry.sol
@@ -28,26 +28,6 @@ contract BLSApkRegistry is BLSApkRegistryStorage {
         ISlashingRegistryCoordinator _slashingRegistryCoordinator
     ) BLSApkRegistryStorage(_slashingRegistryCoordinator) {}
 
-
-    /// @inheritdoc IBLSApkRegistry
-    function getOperatorPubkeyG2(
-        address operator
-    ) public view override returns (BN254.G2Point memory) {
-        return operatorToPubkeyG2[operator];
-    }
-
-    /// @notice Checks if a G2 pubkey is already set for an operator
-    function _checkG2PubkeyNotSet(address operator) internal view {
-        BN254.G2Point memory existingG2Pubkey = getOperatorPubkeyG2(operator);
-        require(
-            existingG2Pubkey.X[0] == 0 &&
-            existingG2Pubkey.X[1] == 0 &&
-            existingG2Pubkey.Y[0] == 0 &&
-            existingG2Pubkey.Y[1] == 0,
-            G2PubkeyAlreadySet()
-        );
-    }
-
     /**
      *
      *                   EXTERNAL FUNCTIONS - REGISTRY COORDINATOR
@@ -248,7 +228,7 @@ contract BLSApkRegistry is BLSApkRegistryStorage {
                 revert BlockNumberBeforeFirstUpdate();
             }
 
-            // Loop backward through apkHistory until we find an entry that preceeds `blockNumber`
+            // Loop backward through apkHistory until we find an entry that precedes `blockNumber`
             for (uint256 j = quorumApkUpdatesLength; j > 0; j--) {
                 if (apkHistory[quorumNumber][j - 1].updateBlockNumber <= blockNumber) {
                     indices[i] = uint32(j - 1);
@@ -318,6 +298,13 @@ contract BLSApkRegistry is BLSApkRegistryStorage {
         return operatorToPubkeyHash[operator];
     }
 
+    /// @inheritdoc IBLSApkRegistry
+    function getOperatorPubkeyG2(
+        address operator
+    ) public view override returns (BN254.G2Point memory) {
+        return operatorToPubkeyG2[operator];
+    }
+
     function _checkRegistryCoordinator() internal view {
         require(msg.sender == address(registryCoordinator), OnlyRegistryCoordinatorOwner());
     }
@@ -326,6 +313,18 @@ contract BLSApkRegistry is BLSApkRegistryStorage {
         require(
             msg.sender == Ownable(address(registryCoordinator)).owner(),
             OnlyRegistryCoordinatorOwner()
+        );
+    }
+
+    /// @notice Checks if a G2 pubkey is already set for an operator
+    function _checkG2PubkeyNotSet(address operator) internal view {
+        BN254.G2Point memory existingG2Pubkey = getOperatorPubkeyG2(operator);
+        require(
+            existingG2Pubkey.X[0] == 0 &&
+            existingG2Pubkey.X[1] == 0 &&
+            existingG2Pubkey.Y[0] == 0 &&
+            existingG2Pubkey.Y[1] == 0,
+            G2PubkeyAlreadySet()
         );
     }
 }

--- a/src/BLSApkRegistryStorage.sol
+++ b/src/BLSApkRegistryStorage.sol
@@ -24,14 +24,13 @@ abstract contract BLSApkRegistryStorage is Initializable, IBLSApkRegistry {
     mapping(bytes32 pubkeyHash => address operator) public pubkeyHashToOperator;
     /// @inheritdoc IBLSApkRegistry
     mapping(address operator => BN254.G1Point pubkeyG1) public operatorToPubkey;
-    mapping(address operator => BN254.G2Point) internal operatorToPubkeyG2;
-
-    /// AGGREGATE PUBLIC KEY STORAGE
 
     /// @inheritdoc IBLSApkRegistry
     mapping(uint8 quorumNumber => IBLSApkRegistryTypes.ApkUpdate[]) public apkHistory;
     /// @inheritdoc IBLSApkRegistry
     mapping(uint8 quorumNumber => BN254.G1Point) public currentApk;
+
+    mapping(address operator => BN254.G2Point) internal operatorToPubkeyG2;
 
     constructor(
         ISlashingRegistryCoordinator _slashingRegistryCoordinator
@@ -41,12 +40,5 @@ abstract contract BLSApkRegistryStorage is Initializable, IBLSApkRegistry {
         _disableInitializers();
     }
 
-    /// @inheritdoc IBLSApkRegistry
-    function getOperatorPubkeyG2(
-        address operator
-    ) external view override returns (BN254.G2Point memory) {
-        return operatorToPubkeyG2[operator];
-    }
-
-    uint256[45] private __GAP;
+    uint256[44] private __GAP;
 }

--- a/src/BLSApkRegistryStorage.sol
+++ b/src/BLSApkRegistryStorage.sol
@@ -24,6 +24,7 @@ abstract contract BLSApkRegistryStorage is Initializable, IBLSApkRegistry {
     mapping(bytes32 pubkeyHash => address operator) public pubkeyHashToOperator;
     /// @inheritdoc IBLSApkRegistry
     mapping(address operator => BN254.G1Point pubkeyG1) public operatorToPubkey;
+    mapping(address operator => BN254.G2Point) internal operatorToPubkeyG2;
 
     /// AGGREGATE PUBLIC KEY STORAGE
 
@@ -38,6 +39,13 @@ abstract contract BLSApkRegistryStorage is Initializable, IBLSApkRegistry {
         registryCoordinator = address(_slashingRegistryCoordinator);
         // disable initializers so that the implementation contract cannot be initialized
         _disableInitializers();
+    }
+
+    /// @inheritdoc IBLSApkRegistry
+    function getOperatorPubkeyG2(
+        address operator
+    ) external view override returns (BN254.G2Point memory) {
+        return operatorToPubkeyG2[operator];
     }
 
     uint256[45] private __GAP;

--- a/src/interfaces/IBLSApkRegistry.sol
+++ b/src/interfaces/IBLSApkRegistry.sol
@@ -26,6 +26,8 @@ interface IBLSApkRegistryErrors {
     error BlockNumberNotLatest();
     /// @notice Thrown when the block number is before the first update.
     error BlockNumberBeforeFirstUpdate();
+    /// @notice Thrown when a G2 pubkey has already been set for an operator
+    error G2PubkeyAlreadySet();
 }
 
 interface IBLSApkRegistryTypes {
@@ -50,6 +52,7 @@ interface IBLSApkRegistryTypes {
         BN254.G1Point pubkeyG1;
         BN254.G2Point pubkeyG2;
     }
+
 }
 
 interface IBLSApkRegistryEvents is IBLSApkRegistryTypes {
@@ -78,6 +81,9 @@ interface IBLSApkRegistryEvents is IBLSApkRegistryTypes {
      * @param quorumNumbers The quorum numbers the operator is being deregistered from.
      */
     event OperatorRemovedFromQuorums(address operator, bytes32 operatorId, bytes quorumNumbers);
+
+    /// @notice Emitted when a G2 public key is registered for an operator
+    event NewG2PubkeyRegistration(address indexed operator, BN254.G2Point pubkeyG2);
 }
 
 interface IBLSApkRegistry is IBLSApkRegistryErrors, IBLSApkRegistryEvents {

--- a/src/interfaces/IBLSApkRegistry.sol
+++ b/src/interfaces/IBLSApkRegistry.sol
@@ -52,7 +52,6 @@ interface IBLSApkRegistryTypes {
         BN254.G1Point pubkeyG1;
         BN254.G2Point pubkeyG2;
     }
-
 }
 
 interface IBLSApkRegistryEvents is IBLSApkRegistryTypes {

--- a/src/interfaces/IBLSApkRegistry.sol
+++ b/src/interfaces/IBLSApkRegistry.sol
@@ -119,6 +119,15 @@ interface IBLSApkRegistry is IBLSApkRegistryErrors, IBLSApkRegistryEvents {
     ) external view returns (uint256, uint256);
 
     /*
+     * @notice Maps `operator` to their BLS public key in G2.
+     * @param operator The address of the operator.
+     * @return The operator's BLS public key in G2.
+     */
+    function getOperatorPubkeyG2(
+        address operator
+    ) external view returns (BN254.G2Point memory);
+
+    /*
      * @notice Stores the history of aggregate public key updates for `quorumNumber` at `index`.
      * @dev Returns a non-encoded IBLSApkRegistryTypes.ApkUpdate.
      * @param quorumNumber The identifier of the quorum.


### PR DESCRIPTION
Rationale:

- Maintaining arbitrary block range log indexing offchain is very expensive (rpc calls), error prone, and introduces a lot of bug vectors 
- The added gas cost in comparison to the rest of the transaction is negligible 
- This would enable retrieving all information needed for the `checkSignatures` entrypoint from a view function, instead of needing to maintain offchain indexing services coupled to signature verification for an arbitrary submitter of signatures 




cc @stevennevins @supernovahs