### PR TITLE
refactor: return strings outside of struct to avoid stack too deep

### DIFF
--- a/src/OperatorStateRetriever.sol
+++ b/src/OperatorStateRetriever.sol
@@ -20,41 +20,36 @@ contract OperatorStateRetriever {
         uint96 stake;
     }
 
-    struct OperatorWithSocket {
-        address operator;
-        bytes32 operatorId;
-        uint96 stake;
-        string socket;
-    }
-
     struct CheckSignaturesIndices {
         uint32[] nonSignerQuorumBitmapIndices;
         uint32[] quorumApkIndices;
-        uint32[] totalStakeIndices;  
+        uint32[] totalStakeIndices;
         uint32[][] nonSignerStakeIndices; // nonSignerStakeIndices[quorumNumberIndex][nonSignerIndex]
     }
 
     /**
      * @notice This function is intended to to be called by AVS operators every time a new task is created (i.e.)
-     * the AVS coordinator makes a request to AVS operators. Since all of the crucial information is kept onchain, 
+     * the AVS coordinator makes a request to AVS operators. Since all of the crucial information is kept onchain,
      * operators don't need to run indexers to fetch the data.
      * @param registryCoordinator is the registry coordinator to fetch the AVS registry information from
-     * @param operatorId the id of the operator to fetch the quorums lists 
+     * @param operatorId the id of the operator to fetch the quorums lists
      * @param blockNumber is the block number to get the operator state for
      * @return 1) the quorumBitmap of the operator at the given blockNumber
-     *         2) 2d array of Operator structs. For each quorum the provided operator 
+     *         2) 2d array of Operator structs. For each quorum the provided operator
      *            was a part of at `blockNumber`, an ordered list of operators.
      */
     function getOperatorState(
-        IRegistryCoordinator registryCoordinator, 
-        bytes32 operatorId, 
+        IRegistryCoordinator registryCoordinator,
+        bytes32 operatorId,
         uint32 blockNumber
     ) external view returns (uint256, Operator[][] memory) {
         bytes32[] memory operatorIds = new bytes32[](1);
         operatorIds[0] = operatorId;
-        uint256 index = registryCoordinator.getQuorumBitmapIndicesAtBlockNumber(blockNumber, operatorIds)[0];
-    
-        uint256 quorumBitmap = registryCoordinator.getQuorumBitmapAtBlockNumberByIndex(operatorId, blockNumber, index);
+        uint256 index =
+            registryCoordinator.getQuorumBitmapIndicesAtBlockNumber(blockNumber, operatorIds)[0];
+
+        uint256 quorumBitmap =
+            registryCoordinator.getQuorumBitmapAtBlockNumberByIndex(operatorId, blockNumber, index);
 
         bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(quorumBitmap);
 
@@ -62,7 +57,7 @@ contract OperatorStateRetriever {
     }
 
     /**
-     * @notice returns the ordered list of operators (id and stake) for each quorum. The AVS coordinator 
+     * @notice returns the ordered list of operators (id and stake) for each quorum. The AVS coordinator
      * may call this function directly to get the operator state for a given block number
      * @param registryCoordinator is the registry coordinator to fetch the AVS registry information from
      * @param quorumNumbers are the ids of the quorums to get the operator state for
@@ -70,10 +65,10 @@ contract OperatorStateRetriever {
      * @return 2d array of Operators. For each quorum, an ordered list of Operators
      */
     function getOperatorState(
-        IRegistryCoordinator registryCoordinator, 
-        bytes memory quorumNumbers, 
+        IRegistryCoordinator registryCoordinator,
+        bytes memory quorumNumbers,
         uint32 blockNumber
-    ) public view returns(Operator[][] memory) {
+    ) public view returns (Operator[][] memory) {
         IStakeRegistry stakeRegistry = registryCoordinator.stakeRegistry();
         IIndexRegistry indexRegistry = registryCoordinator.indexRegistry();
         IBLSApkRegistry blsApkRegistry = registryCoordinator.blsApkRegistry();
@@ -81,131 +76,169 @@ contract OperatorStateRetriever {
         Operator[][] memory operators = new Operator[][](quorumNumbers.length);
         for (uint256 i = 0; i < quorumNumbers.length; i++) {
             uint8 quorumNumber = uint8(quorumNumbers[i]);
-            bytes32[] memory operatorIds = indexRegistry.getOperatorListAtBlockNumber(quorumNumber, blockNumber);
+            bytes32[] memory operatorIds =
+                indexRegistry.getOperatorListAtBlockNumber(quorumNumber, blockNumber);
             operators[i] = new Operator[](operatorIds.length);
             for (uint256 j = 0; j < operatorIds.length; j++) {
                 operators[i][j] = Operator({
                     operator: blsApkRegistry.getOperatorFromPubkeyHash(operatorIds[j]),
                     operatorId: bytes32(operatorIds[j]),
-                    stake: stakeRegistry.getStakeAtBlockNumber(bytes32(operatorIds[j]), quorumNumber, blockNumber)
+                    stake: stakeRegistry.getStakeAtBlockNumber(
+                        bytes32(operatorIds[j]), quorumNumber, blockNumber
+                    )
                 });
             }
         }
-            
+
         return operators;
     }
 
     /**
      * @notice This function is intended to to be called by AVS operators every time a new task is created (i.e.)
-     * the AVS coordinator makes a request to AVS operators. Since all of the crucial information is kept onchain, 
+     * the AVS coordinator makes a request to AVS operators. Since all of the crucial information is kept onchain,
      * operators don't need to run indexers to fetch the data.
      * @param registryCoordinator is the registry coordinator to fetch the AVS registry information from
-     * @param operatorId the id of the operator to fetch the quorums lists 
+     * @param operatorId the id of the operator to fetch the quorums lists
      * @param blockNumber is the block number to get the operator state for
-     * @return 1) the quorumBitmap of the operator at the given blockNumber
-     *         2) 2d array of OperatorWithSocket structs. For each quorum the provided operator 
-     *            was a part of at `blockNumber`, an ordered list of operators.
+     * @return quorumBitmap the quorumBitmap of the operator at the given blockNumber
+     * @return operators a 2d array of Operators. For each quorum, an ordered list of Operators
+     * @return sockets a 2d array of sockets. For each quorum, an ordered list of sockets
      */
     function getOperatorStateWithSocket(
-        IRegistryCoordinator registryCoordinator, 
-        bytes32 operatorId, 
+        IRegistryCoordinator registryCoordinator,
+        bytes32 operatorId,
         uint32 blockNumber
-    ) external view returns (uint256, OperatorWithSocket[][] memory) {
+    )
+        external
+        view
+        returns (uint256 quorumBitmap, Operator[][] memory operators, string[][] memory sockets)
+    {
         bytes32[] memory operatorIds = new bytes32[](1);
         operatorIds[0] = operatorId;
-        uint256 index = registryCoordinator.getQuorumBitmapIndicesAtBlockNumber(blockNumber, operatorIds)[0];
-    
-        uint256 quorumBitmap = registryCoordinator.getQuorumBitmapAtBlockNumberByIndex(operatorId, blockNumber, index);
+        uint256 index =
+            registryCoordinator.getQuorumBitmapIndicesAtBlockNumber(blockNumber, operatorIds)[0];
+
+        quorumBitmap =
+            registryCoordinator.getQuorumBitmapAtBlockNumberByIndex(operatorId, blockNumber, index);
 
         bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(quorumBitmap);
 
-        return (quorumBitmap, getOperatorStateWithSocket(registryCoordinator, quorumNumbers, blockNumber));
+        (operators, sockets) =
+            getOperatorStateWithSocket(registryCoordinator, quorumNumbers, blockNumber);
+
+        return (quorumBitmap, operators, sockets);
+    }
+
+    struct Registries {
+        IStakeRegistry stakeRegistry;
+        IIndexRegistry indexRegistry;
+        IBLSApkRegistry blsApkRegistry;
+        ISocketRegistry socketRegistry;
     }
 
     /**
-     * @notice returns the ordered list of operators (id, stake, socket) for each quorum. The AVS coordinator 
+     * @notice returns the ordered list of operators (id, stake, socket) for each quorum. The AVS coordinator
      * may call this function directly to get the operator state for a given block number
      * @param registryCoordinator is the registry coordinator to fetch the AVS registry information from
      * @param quorumNumbers are the ids of the quorums to get the operator state for
      * @param blockNumber is the block number to get the operator state for
-     * @return operatorWithSockets a 2d array of OperatorsWithSocket. For each quorum, an ordered list of OperatorsWithSocket
+     * @return operators a 2d array of Operators. For each quorum, an ordered list of Operators
+     * @return sockets a 2d array of sockets. For each quorum, an ordered list of sockets
      */
-     function getOperatorStateWithSocket(
+    function getOperatorStateWithSocket(
         IRegistryCoordinator registryCoordinator,
         bytes memory quorumNumbers,
         uint32 blockNumber
-    ) public view returns (OperatorWithSocket[][] memory operatorWithSockets) {
-        IStakeRegistry stakeRegistry = registryCoordinator.stakeRegistry();
-        IIndexRegistry indexRegistry = registryCoordinator.indexRegistry();
-        IBLSApkRegistry blsApkRegistry = registryCoordinator.blsApkRegistry();
-        ISocketRegistry socketRegistry = registryCoordinator.socketRegistry();
+    ) public view returns (Operator[][] memory operators, string[][] memory sockets) {
+        Registries memory registries = Registries({
+            stakeRegistry: registryCoordinator.stakeRegistry(),
+            indexRegistry: registryCoordinator.indexRegistry(),
+            blsApkRegistry: registryCoordinator.blsApkRegistry(),
+            socketRegistry: registryCoordinator.socketRegistry()
+        });
 
-        operatorWithSockets = new OperatorWithSocket[][](quorumNumbers.length);
+        operators = new Operator[][](quorumNumbers.length);
+        sockets = new string[][](quorumNumbers.length);
         for (uint256 i = 0; i < quorumNumbers.length; i++) {
             uint8 quorumNumber = uint8(quorumNumbers[i]);
-            bytes32[] memory operatorIds = indexRegistry.getOperatorListAtBlockNumber(quorumNumber, blockNumber);
-            operatorWithSockets[i] = new OperatorWithSocket[](operatorIds.length);
+            bytes32[] memory operatorIds =
+                registries.indexRegistry.getOperatorListAtBlockNumber(quorumNumber, blockNumber);
+            operators[i] = new Operator[](operatorIds.length);
+            sockets[i] = new string[](operatorIds.length);
             for (uint256 j = 0; j < operatorIds.length; j++) {
-                operatorWithSockets[i][j] = OperatorWithSocket({
-                    operator: blsApkRegistry.getOperatorFromPubkeyHash(operatorIds[j]),
+                operators[i][j] = Operator({
+                    operator: registries.blsApkRegistry.getOperatorFromPubkeyHash(operatorIds[j]),
                     operatorId: bytes32(operatorIds[j]),
-                    stake: stakeRegistry.getStakeAtBlockNumber(bytes32(operatorIds[j]), quorumNumber, blockNumber),
-                    socket: socketRegistry.getOperatorSocket(bytes32(operatorIds[j]))
+                    stake: registries.stakeRegistry.getStakeAtBlockNumber(
+                        bytes32(operatorIds[j]), quorumNumber, blockNumber
+                    )
                 });
+                sockets[i][j] = registries.socketRegistry.getOperatorSocket(bytes32(operatorIds[j]));
             }
         }
     }
 
     /**
      * @notice this is called by the AVS operator to get the relevant indices for the checkSignatures function
-     * if they are not running an indexer    
+     * if they are not running an indexer
      * @param registryCoordinator is the registry coordinator to fetch the AVS registry information from
      * @param referenceBlockNumber is the block number to get the indices for
      * @param quorumNumbers are the ids of the quorums to get the operator state for
      * @param nonSignerOperatorIds are the ids of the nonsigning operators
      * @return 1) the indices of the quorumBitmaps for each of the operators in the @param nonSignerOperatorIds array at the given blocknumber
      *         2) the indices of the total stakes entries for the given quorums at the given blocknumber
-     *         3) the indices of the stakes of each of the nonsigners in each of the quorums they were a 
+     *         3) the indices of the stakes of each of the nonsigners in each of the quorums they were a
      *            part of (for each nonsigner, an array of length the number of quorums they were a part of
      *            that are also part of the provided quorumNumbers) at the given blocknumber
      *         4) the indices of the quorum apks for each of the provided quorums at the given blocknumber
      */
     function getCheckSignaturesIndices(
         IRegistryCoordinator registryCoordinator,
-        uint32 referenceBlockNumber, 
-        bytes calldata quorumNumbers, 
+        uint32 referenceBlockNumber,
+        bytes calldata quorumNumbers,
         bytes32[] calldata nonSignerOperatorIds
     ) external view returns (CheckSignaturesIndices memory) {
         IStakeRegistry stakeRegistry = registryCoordinator.stakeRegistry();
         CheckSignaturesIndices memory checkSignaturesIndices;
 
         // get the indices of the quorumBitmap updates for each of the operators in the nonSignerOperatorIds array
-        checkSignaturesIndices.nonSignerQuorumBitmapIndices = registryCoordinator.getQuorumBitmapIndicesAtBlockNumber(referenceBlockNumber, nonSignerOperatorIds);
+        checkSignaturesIndices.nonSignerQuorumBitmapIndices = registryCoordinator
+            .getQuorumBitmapIndicesAtBlockNumber(referenceBlockNumber, nonSignerOperatorIds);
 
         // get the indices of the totalStake updates for each of the quorums in the quorumNumbers array
-        checkSignaturesIndices.totalStakeIndices = stakeRegistry.getTotalStakeIndicesAtBlockNumber(referenceBlockNumber, quorumNumbers);
-        
+        checkSignaturesIndices.totalStakeIndices =
+            stakeRegistry.getTotalStakeIndicesAtBlockNumber(referenceBlockNumber, quorumNumbers);
+
         checkSignaturesIndices.nonSignerStakeIndices = new uint32[][](quorumNumbers.length);
-        for (uint8 quorumNumberIndex = 0; quorumNumberIndex < quorumNumbers.length; quorumNumberIndex++) {
+        for (
+            uint8 quorumNumberIndex = 0;
+            quorumNumberIndex < quorumNumbers.length;
+            quorumNumberIndex++
+        ) {
             uint256 numNonSignersForQuorum = 0;
             // this array's length will be at most the number of nonSignerOperatorIds, this will be trimmed after it is filled
-            checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex] = new uint32[](nonSignerOperatorIds.length);
+            checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex] =
+                new uint32[](nonSignerOperatorIds.length);
 
-            for (uint i = 0; i < nonSignerOperatorIds.length; i++) {
+            for (uint256 i = 0; i < nonSignerOperatorIds.length; i++) {
                 // get the quorumBitmap for the operator at the given blocknumber and index
-                uint192 nonSignerQuorumBitmap = 
-                    registryCoordinator.getQuorumBitmapAtBlockNumberByIndex(
-                        nonSignerOperatorIds[i], 
-                        referenceBlockNumber, 
-                        checkSignaturesIndices.nonSignerQuorumBitmapIndices[i]
-                    );
-                
-                require(nonSignerQuorumBitmap != 0, "OperatorStateRetriever.getCheckSignaturesIndices: operator must be registered at blocknumber");
-                
+                uint192 nonSignerQuorumBitmap = registryCoordinator
+                    .getQuorumBitmapAtBlockNumberByIndex(
+                    nonSignerOperatorIds[i],
+                    referenceBlockNumber,
+                    checkSignaturesIndices.nonSignerQuorumBitmapIndices[i]
+                );
+
+                require(
+                    nonSignerQuorumBitmap != 0,
+                    "OperatorStateRetriever.getCheckSignaturesIndices: operator must be registered at blocknumber"
+                );
+
                 // if the operator was a part of the quorum and the quorum is a part of the provided quorumNumbers
                 if ((nonSignerQuorumBitmap >> uint8(quorumNumbers[quorumNumberIndex])) & 1 == 1) {
                     // get the index of the stake update for the operator at the given blocknumber and quorum number
-                    checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex][numNonSignersForQuorum] = stakeRegistry.getStakeUpdateIndexAtBlockNumber(
+                    checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex][numNonSignersForQuorum]
+                    = stakeRegistry.getStakeUpdateIndexAtBlockNumber(
                         nonSignerOperatorIds[i],
                         uint8(quorumNumbers[quorumNumberIndex]),
                         referenceBlockNumber
@@ -216,15 +249,18 @@ contract OperatorStateRetriever {
 
             // resize the array to the number of nonSigners for this quorum
             uint32[] memory nonSignerStakeIndicesForQuorum = new uint32[](numNonSignersForQuorum);
-            for (uint i = 0; i < numNonSignersForQuorum; i++) {
-                nonSignerStakeIndicesForQuorum[i] = checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex][i];
+            for (uint256 i = 0; i < numNonSignersForQuorum; i++) {
+                nonSignerStakeIndicesForQuorum[i] =
+                    checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex][i];
             }
-            checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex] = nonSignerStakeIndicesForQuorum;
+            checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex] =
+                nonSignerStakeIndicesForQuorum;
         }
 
         IBLSApkRegistry blsApkRegistry = registryCoordinator.blsApkRegistry();
         // get the indices of the quorum apks for each of the provided quorums at the given blocknumber
-        checkSignaturesIndices.quorumApkIndices = blsApkRegistry.getApkIndicesAtBlockNumber(quorumNumbers, referenceBlockNumber);
+        checkSignaturesIndices.quorumApkIndices =
+            blsApkRegistry.getApkIndicesAtBlockNumber(quorumNumbers, referenceBlockNumber);
 
         return checkSignaturesIndices;
     }
@@ -240,10 +276,13 @@ contract OperatorStateRetriever {
         bytes32[] memory operatorIds,
         uint32 blockNumber
     ) external view returns (uint256[] memory) {
-        uint32[] memory quorumBitmapIndices = registryCoordinator.getQuorumBitmapIndicesAtBlockNumber(blockNumber, operatorIds);
+        uint32[] memory quorumBitmapIndices =
+            registryCoordinator.getQuorumBitmapIndicesAtBlockNumber(blockNumber, operatorIds);
         uint256[] memory quorumBitmaps = new uint256[](operatorIds.length);
         for (uint256 i = 0; i < operatorIds.length; i++) {
-            quorumBitmaps[i] = registryCoordinator.getQuorumBitmapAtBlockNumberByIndex(operatorIds[i], blockNumber, quorumBitmapIndices[i]);
+            quorumBitmaps[i] = registryCoordinator.getQuorumBitmapAtBlockNumberByIndex(
+                operatorIds[i], blockNumber, quorumBitmapIndices[i]
+            );
         }
         return quorumBitmaps;
     }
@@ -279,5 +318,4 @@ contract OperatorStateRetriever {
             operators[i] = registryCoordinator.getOperatorFromId(operatorIds[i]);
         }
     }
-    
 }

--- a/src/OperatorStateRetriever.sol
+++ b/src/OperatorStateRetriever.sol
@@ -23,33 +23,31 @@ contract OperatorStateRetriever {
     struct CheckSignaturesIndices {
         uint32[] nonSignerQuorumBitmapIndices;
         uint32[] quorumApkIndices;
-        uint32[] totalStakeIndices;
+        uint32[] totalStakeIndices;  
         uint32[][] nonSignerStakeIndices; // nonSignerStakeIndices[quorumNumberIndex][nonSignerIndex]
     }
 
     /**
      * @notice This function is intended to to be called by AVS operators every time a new task is created (i.e.)
-     * the AVS coordinator makes a request to AVS operators. Since all of the crucial information is kept onchain,
+     * the AVS coordinator makes a request to AVS operators. Since all of the crucial information is kept onchain, 
      * operators don't need to run indexers to fetch the data.
      * @param registryCoordinator is the registry coordinator to fetch the AVS registry information from
-     * @param operatorId the id of the operator to fetch the quorums lists
+     * @param operatorId the id of the operator to fetch the quorums lists 
      * @param blockNumber is the block number to get the operator state for
      * @return 1) the quorumBitmap of the operator at the given blockNumber
-     *         2) 2d array of Operator structs. For each quorum the provided operator
+     *         2) 2d array of Operator structs. For each quorum the provided operator 
      *            was a part of at `blockNumber`, an ordered list of operators.
      */
     function getOperatorState(
-        IRegistryCoordinator registryCoordinator,
-        bytes32 operatorId,
+        IRegistryCoordinator registryCoordinator, 
+        bytes32 operatorId, 
         uint32 blockNumber
     ) external view returns (uint256, Operator[][] memory) {
         bytes32[] memory operatorIds = new bytes32[](1);
         operatorIds[0] = operatorId;
-        uint256 index =
-            registryCoordinator.getQuorumBitmapIndicesAtBlockNumber(blockNumber, operatorIds)[0];
-
-        uint256 quorumBitmap =
-            registryCoordinator.getQuorumBitmapAtBlockNumberByIndex(operatorId, blockNumber, index);
+        uint256 index = registryCoordinator.getQuorumBitmapIndicesAtBlockNumber(blockNumber, operatorIds)[0];
+    
+        uint256 quorumBitmap = registryCoordinator.getQuorumBitmapAtBlockNumberByIndex(operatorId, blockNumber, index);
 
         bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(quorumBitmap);
 
@@ -57,7 +55,7 @@ contract OperatorStateRetriever {
     }
 
     /**
-     * @notice returns the ordered list of operators (id and stake) for each quorum. The AVS coordinator
+     * @notice returns the ordered list of operators (id and stake) for each quorum. The AVS coordinator 
      * may call this function directly to get the operator state for a given block number
      * @param registryCoordinator is the registry coordinator to fetch the AVS registry information from
      * @param quorumNumbers are the ids of the quorums to get the operator state for
@@ -65,10 +63,10 @@ contract OperatorStateRetriever {
      * @return 2d array of Operators. For each quorum, an ordered list of Operators
      */
     function getOperatorState(
-        IRegistryCoordinator registryCoordinator,
-        bytes memory quorumNumbers,
+        IRegistryCoordinator registryCoordinator, 
+        bytes memory quorumNumbers, 
         uint32 blockNumber
-    ) public view returns (Operator[][] memory) {
+    ) public view returns(Operator[][] memory) {
         IStakeRegistry stakeRegistry = registryCoordinator.stakeRegistry();
         IIndexRegistry indexRegistry = registryCoordinator.indexRegistry();
         IBLSApkRegistry blsApkRegistry = registryCoordinator.blsApkRegistry();
@@ -76,59 +74,49 @@ contract OperatorStateRetriever {
         Operator[][] memory operators = new Operator[][](quorumNumbers.length);
         for (uint256 i = 0; i < quorumNumbers.length; i++) {
             uint8 quorumNumber = uint8(quorumNumbers[i]);
-            bytes32[] memory operatorIds =
-                indexRegistry.getOperatorListAtBlockNumber(quorumNumber, blockNumber);
+            bytes32[] memory operatorIds = indexRegistry.getOperatorListAtBlockNumber(quorumNumber, blockNumber);
             operators[i] = new Operator[](operatorIds.length);
             for (uint256 j = 0; j < operatorIds.length; j++) {
                 operators[i][j] = Operator({
                     operator: blsApkRegistry.getOperatorFromPubkeyHash(operatorIds[j]),
                     operatorId: bytes32(operatorIds[j]),
-                    stake: stakeRegistry.getStakeAtBlockNumber(
-                        bytes32(operatorIds[j]), quorumNumber, blockNumber
-                    )
+                    stake: stakeRegistry.getStakeAtBlockNumber(bytes32(operatorIds[j]), quorumNumber, blockNumber)
                 });
             }
         }
-
+            
         return operators;
     }
 
     /**
      * @notice This function is intended to to be called by AVS operators every time a new task is created (i.e.)
-     * the AVS coordinator makes a request to AVS operators. Since all of the crucial information is kept onchain,
+     * the AVS coordinator makes a request to AVS operators. Since all of the crucial information is kept onchain, 
      * operators don't need to run indexers to fetch the data.
      * @param registryCoordinator is the registry coordinator to fetch the AVS registry information from
-     * @param operatorId the id of the operator to fetch the quorums lists
+     * @param operatorId the id of the operator to fetch the quorums lists 
      * @param blockNumber is the block number to get the operator state for
      * @return quorumBitmap the quorumBitmap of the operator at the given blockNumber
      * @return operators a 2d array of Operators. For each quorum, an ordered list of Operators
      * @return sockets a 2d array of sockets. For each quorum, an ordered list of sockets
      */
     function getOperatorStateWithSocket(
-        IRegistryCoordinator registryCoordinator,
-        bytes32 operatorId,
+        IRegistryCoordinator registryCoordinator, 
+        bytes32 operatorId, 
         uint32 blockNumber
-    )
-        external
-        view
-        returns (uint256 quorumBitmap, Operator[][] memory operators, string[][] memory sockets)
-    {
+    ) external view returns (uint256 quorumBitmap, Operator[][] memory operators, string[][] memory sockets) {
         bytes32[] memory operatorIds = new bytes32[](1);
         operatorIds[0] = operatorId;
-        uint256 index =
-            registryCoordinator.getQuorumBitmapIndicesAtBlockNumber(blockNumber, operatorIds)[0];
-
-        quorumBitmap =
-            registryCoordinator.getQuorumBitmapAtBlockNumberByIndex(operatorId, blockNumber, index);
+        uint256 index = registryCoordinator.getQuorumBitmapIndicesAtBlockNumber(blockNumber, operatorIds)[0];
+    
+        quorumBitmap = registryCoordinator.getQuorumBitmapAtBlockNumberByIndex(operatorId, blockNumber, index);
 
         bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(quorumBitmap);
 
         (operators, sockets) =
             getOperatorStateWithSocket(registryCoordinator, quorumNumbers, blockNumber);
-
-        return (quorumBitmap, operators, sockets);
     }
 
+    /// @dev Used below to avoid stack too deep.
     struct Registries {
         IStakeRegistry stakeRegistry;
         IIndexRegistry indexRegistry;
@@ -137,7 +125,7 @@ contract OperatorStateRetriever {
     }
 
     /**
-     * @notice returns the ordered list of operators (id, stake, socket) for each quorum. The AVS coordinator
+     * @notice returns the ordered list of operators (id, stake, socket) for each quorum. The AVS coordinator 
      * may call this function directly to get the operator state for a given block number
      * @param registryCoordinator is the registry coordinator to fetch the AVS registry information from
      * @param quorumNumbers are the ids of the quorums to get the operator state for
@@ -145,7 +133,7 @@ contract OperatorStateRetriever {
      * @return operators a 2d array of Operators. For each quorum, an ordered list of Operators
      * @return sockets a 2d array of sockets. For each quorum, an ordered list of sockets
      */
-    function getOperatorStateWithSocket(
+     function getOperatorStateWithSocket(
         IRegistryCoordinator registryCoordinator,
         bytes memory quorumNumbers,
         uint32 blockNumber
@@ -161,17 +149,14 @@ contract OperatorStateRetriever {
         sockets = new string[][](quorumNumbers.length);
         for (uint256 i = 0; i < quorumNumbers.length; i++) {
             uint8 quorumNumber = uint8(quorumNumbers[i]);
-            bytes32[] memory operatorIds =
-                registries.indexRegistry.getOperatorListAtBlockNumber(quorumNumber, blockNumber);
+            bytes32[] memory operatorIds = registries.indexRegistry.getOperatorListAtBlockNumber(quorumNumber, blockNumber);
             operators[i] = new Operator[](operatorIds.length);
             sockets[i] = new string[](operatorIds.length);
             for (uint256 j = 0; j < operatorIds.length; j++) {
                 operators[i][j] = Operator({
                     operator: registries.blsApkRegistry.getOperatorFromPubkeyHash(operatorIds[j]),
                     operatorId: bytes32(operatorIds[j]),
-                    stake: registries.stakeRegistry.getStakeAtBlockNumber(
-                        bytes32(operatorIds[j]), quorumNumber, blockNumber
-                    )
+                    stake: registries.stakeRegistry.getStakeAtBlockNumber(bytes32(operatorIds[j]), quorumNumber, blockNumber)
                 });
                 sockets[i][j] = registries.socketRegistry.getOperatorSocket(bytes32(operatorIds[j]));
             }
@@ -180,65 +165,54 @@ contract OperatorStateRetriever {
 
     /**
      * @notice this is called by the AVS operator to get the relevant indices for the checkSignatures function
-     * if they are not running an indexer
+     * if they are not running an indexer    
      * @param registryCoordinator is the registry coordinator to fetch the AVS registry information from
      * @param referenceBlockNumber is the block number to get the indices for
      * @param quorumNumbers are the ids of the quorums to get the operator state for
      * @param nonSignerOperatorIds are the ids of the nonsigning operators
      * @return 1) the indices of the quorumBitmaps for each of the operators in the @param nonSignerOperatorIds array at the given blocknumber
      *         2) the indices of the total stakes entries for the given quorums at the given blocknumber
-     *         3) the indices of the stakes of each of the nonsigners in each of the quorums they were a
+     *         3) the indices of the stakes of each of the nonsigners in each of the quorums they were a 
      *            part of (for each nonsigner, an array of length the number of quorums they were a part of
      *            that are also part of the provided quorumNumbers) at the given blocknumber
      *         4) the indices of the quorum apks for each of the provided quorums at the given blocknumber
      */
     function getCheckSignaturesIndices(
         IRegistryCoordinator registryCoordinator,
-        uint32 referenceBlockNumber,
-        bytes calldata quorumNumbers,
+        uint32 referenceBlockNumber, 
+        bytes calldata quorumNumbers, 
         bytes32[] calldata nonSignerOperatorIds
     ) external view returns (CheckSignaturesIndices memory) {
         IStakeRegistry stakeRegistry = registryCoordinator.stakeRegistry();
         CheckSignaturesIndices memory checkSignaturesIndices;
 
         // get the indices of the quorumBitmap updates for each of the operators in the nonSignerOperatorIds array
-        checkSignaturesIndices.nonSignerQuorumBitmapIndices = registryCoordinator
-            .getQuorumBitmapIndicesAtBlockNumber(referenceBlockNumber, nonSignerOperatorIds);
+        checkSignaturesIndices.nonSignerQuorumBitmapIndices = registryCoordinator.getQuorumBitmapIndicesAtBlockNumber(referenceBlockNumber, nonSignerOperatorIds);
 
         // get the indices of the totalStake updates for each of the quorums in the quorumNumbers array
-        checkSignaturesIndices.totalStakeIndices =
-            stakeRegistry.getTotalStakeIndicesAtBlockNumber(referenceBlockNumber, quorumNumbers);
-
+        checkSignaturesIndices.totalStakeIndices = stakeRegistry.getTotalStakeIndicesAtBlockNumber(referenceBlockNumber, quorumNumbers);
+        
         checkSignaturesIndices.nonSignerStakeIndices = new uint32[][](quorumNumbers.length);
-        for (
-            uint8 quorumNumberIndex = 0;
-            quorumNumberIndex < quorumNumbers.length;
-            quorumNumberIndex++
-        ) {
+        for (uint8 quorumNumberIndex = 0; quorumNumberIndex < quorumNumbers.length; quorumNumberIndex++) {
             uint256 numNonSignersForQuorum = 0;
             // this array's length will be at most the number of nonSignerOperatorIds, this will be trimmed after it is filled
-            checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex] =
-                new uint32[](nonSignerOperatorIds.length);
+            checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex] = new uint32[](nonSignerOperatorIds.length);
 
-            for (uint256 i = 0; i < nonSignerOperatorIds.length; i++) {
+            for (uint i = 0; i < nonSignerOperatorIds.length; i++) {
                 // get the quorumBitmap for the operator at the given blocknumber and index
-                uint192 nonSignerQuorumBitmap = registryCoordinator
-                    .getQuorumBitmapAtBlockNumberByIndex(
-                    nonSignerOperatorIds[i],
-                    referenceBlockNumber,
-                    checkSignaturesIndices.nonSignerQuorumBitmapIndices[i]
-                );
-
-                require(
-                    nonSignerQuorumBitmap != 0,
-                    "OperatorStateRetriever.getCheckSignaturesIndices: operator must be registered at blocknumber"
-                );
-
+                uint192 nonSignerQuorumBitmap = 
+                    registryCoordinator.getQuorumBitmapAtBlockNumberByIndex(
+                        nonSignerOperatorIds[i], 
+                        referenceBlockNumber, 
+                        checkSignaturesIndices.nonSignerQuorumBitmapIndices[i]
+                    );
+                
+                require(nonSignerQuorumBitmap != 0, "OperatorStateRetriever.getCheckSignaturesIndices: operator must be registered at blocknumber");
+                
                 // if the operator was a part of the quorum and the quorum is a part of the provided quorumNumbers
                 if ((nonSignerQuorumBitmap >> uint8(quorumNumbers[quorumNumberIndex])) & 1 == 1) {
                     // get the index of the stake update for the operator at the given blocknumber and quorum number
-                    checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex][numNonSignersForQuorum]
-                    = stakeRegistry.getStakeUpdateIndexAtBlockNumber(
+                    checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex][numNonSignersForQuorum] = stakeRegistry.getStakeUpdateIndexAtBlockNumber(
                         nonSignerOperatorIds[i],
                         uint8(quorumNumbers[quorumNumberIndex]),
                         referenceBlockNumber
@@ -249,18 +223,15 @@ contract OperatorStateRetriever {
 
             // resize the array to the number of nonSigners for this quorum
             uint32[] memory nonSignerStakeIndicesForQuorum = new uint32[](numNonSignersForQuorum);
-            for (uint256 i = 0; i < numNonSignersForQuorum; i++) {
-                nonSignerStakeIndicesForQuorum[i] =
-                    checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex][i];
+            for (uint i = 0; i < numNonSignersForQuorum; i++) {
+                nonSignerStakeIndicesForQuorum[i] = checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex][i];
             }
-            checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex] =
-                nonSignerStakeIndicesForQuorum;
+            checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex] = nonSignerStakeIndicesForQuorum;
         }
 
         IBLSApkRegistry blsApkRegistry = registryCoordinator.blsApkRegistry();
         // get the indices of the quorum apks for each of the provided quorums at the given blocknumber
-        checkSignaturesIndices.quorumApkIndices =
-            blsApkRegistry.getApkIndicesAtBlockNumber(quorumNumbers, referenceBlockNumber);
+        checkSignaturesIndices.quorumApkIndices = blsApkRegistry.getApkIndicesAtBlockNumber(quorumNumbers, referenceBlockNumber);
 
         return checkSignaturesIndices;
     }
@@ -276,13 +247,10 @@ contract OperatorStateRetriever {
         bytes32[] memory operatorIds,
         uint32 blockNumber
     ) external view returns (uint256[] memory) {
-        uint32[] memory quorumBitmapIndices =
-            registryCoordinator.getQuorumBitmapIndicesAtBlockNumber(blockNumber, operatorIds);
+        uint32[] memory quorumBitmapIndices = registryCoordinator.getQuorumBitmapIndicesAtBlockNumber(blockNumber, operatorIds);
         uint256[] memory quorumBitmaps = new uint256[](operatorIds.length);
         for (uint256 i = 0; i < operatorIds.length; i++) {
-            quorumBitmaps[i] = registryCoordinator.getQuorumBitmapAtBlockNumberByIndex(
-                operatorIds[i], blockNumber, quorumBitmapIndices[i]
-            );
+            quorumBitmaps[i] = registryCoordinator.getQuorumBitmapAtBlockNumberByIndex(operatorIds[i], blockNumber, quorumBitmapIndices[i]);
         }
         return quorumBitmaps;
     }
@@ -318,4 +286,5 @@ contract OperatorStateRetriever {
             operators[i] = registryCoordinator.getOperatorFromId(operatorIds[i]);
         }
     }
+    
 }

--- a/test/unit/OperatorStateRetrieverUnit.t.sol
+++ b/test/unit/OperatorStateRetrieverUnit.t.sol
@@ -138,8 +138,6 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
         assertEq(operators[1][0].stake, defaultStake - 1);
     }
 
-    ////////////////////////////////
-
     function test_getOperatorStateWithSocket_revert_neverRegistered() public {
         cheats.expectRevert(
             "RegCoord.getQuorumBitmapIndexAtBlockNumber: no bitmap update found for operator at blockNumber"
@@ -149,9 +147,9 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
         );
     }
 
-    function test_getOperatorStateWithSocket_revert_registeredFirstAfterReferenceBlockNumber()
-        public
-    {
+    
+
+    function test_getOperatorStateWithSocket_revert_registeredFirstAfterReferenceBlockNumber() public {
         cheats.roll(registrationBlockNumber);
         _registerOperatorWithCoordinator(defaultOperator, 1, defaultPubKey);
 
@@ -209,9 +207,7 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
         );
     }
 
-    function test_getOperatorStateWithSocket_revert_quorumNotCreatedAtReferenceBlockNumber()
-        public
-    {
+    function test_getOperatorStateWithSocket_revert_quorumNotCreatedAtReferenceBlockNumber() public {
         cheats.roll(registrationBlockNumber);
         IRegistryCoordinator.OperatorSetParam memory operatorSetParams = IRegistryCoordinator
             .OperatorSetParam({
@@ -238,6 +234,7 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
         );
     }
 
+    
     function test_getOperatorStateWithSocket_returnsCorrect() public {
         uint256 quorumBitmapOne = 1;
         uint256 quorumBitmapThree = 3;
@@ -270,8 +267,6 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
         assertEq(operators[1][0].operatorId, otherOperatorId);
         assertEq(operators[1][0].stake, defaultStake - 1);
     }
-
-    ////////////////////////////////
 
     function test_getCheckSignaturesIndices_revert_neverRegistered() public {
         bytes32[] memory nonSignerOperatorIds = new bytes32[](1);
@@ -494,9 +489,7 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
         assertEq(checkSignaturesIndices.nonSignerStakeIndices[1][0], 0);
     }
 
-    function testGetOperatorState_Valid(
-        uint256 pseudoRandomNumber
-    ) public {
+    function testGetOperatorState_Valid(uint256 pseudoRandomNumber) public {
         // register random operators and get the expected indices within the quorums and the metadata for the operators
         (
             OperatorMetadata[] memory operatorMetadatas,
@@ -565,9 +558,7 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
         );
     }
 
-    function testCheckSignaturesIndices_NoNonSigners_Valid(
-        uint256 pseudoRandomNumber
-    ) public {
+    function testCheckSignaturesIndices_NoNonSigners_Valid(uint256 pseudoRandomNumber) public {
         (
             OperatorMetadata[] memory operatorMetadatas,
             uint256[][] memory expectedOperatorOverallIndices
@@ -632,9 +623,7 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
         }
     }
 
-    function testCheckSignaturesIndices_FewNonSigners_Valid(
-        uint256 pseudoRandomNumber
-    ) public {
+    function testCheckSignaturesIndices_FewNonSigners_Valid(uint256 pseudoRandomNumber) public {
         (
             OperatorMetadata[] memory operatorMetadatas,
             uint256[][] memory expectedOperatorOverallIndices

--- a/test/unit/OperatorStateRetrieverUnit.t.sol
+++ b/test/unit/OperatorStateRetrieverUnit.t.sol
@@ -140,8 +140,6 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
 
     ////////////////////////////////
 
-    /*
-
     function test_getOperatorStateWithSocket_revert_neverRegistered() public {
         cheats.expectRevert(
             "RegCoord.getQuorumBitmapIndexAtBlockNumber: no bitmap update found for operator at blockNumber"
@@ -151,9 +149,9 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
         );
     }
 
-    
-
-    function test_getOperatorStateWithSocket_revert_registeredFirstAfterReferenceBlockNumber() public {
+    function test_getOperatorStateWithSocket_revert_registeredFirstAfterReferenceBlockNumber()
+        public
+    {
         cheats.roll(registrationBlockNumber);
         _registerOperatorWithCoordinator(defaultOperator, 1, defaultPubKey);
 
@@ -175,7 +173,7 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
         cheats.prank(defaultOperator);
         registryCoordinator.deregisterOperator(BitmapUtils.bitmapToBytesArray(quorumBitmap));
 
-        (uint256 fetchedQuorumBitmap, OperatorStateRetriever.OperatorWithSocket[][] memory operators) =
+        (uint256 fetchedQuorumBitmap, OperatorStateRetriever.Operator[][] memory operators,) =
         operatorStateRetriever.getOperatorStateWithSocket(
             registryCoordinator, defaultOperatorId, uint32(block.number)
         );
@@ -188,7 +186,7 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
         cheats.roll(registrationBlockNumber);
         _registerOperatorWithCoordinator(defaultOperator, quorumBitmap, defaultPubKey);
 
-        (uint256 fetchedQuorumBitmap, OperatorStateRetriever.OperatorWithSocket[][] memory operators) =
+        (uint256 fetchedQuorumBitmap, OperatorStateRetriever.Operator[][] memory operators,) =
         operatorStateRetriever.getOperatorStateWithSocket(
             registryCoordinator, defaultOperatorId, uint32(block.number)
         );
@@ -211,7 +209,9 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
         );
     }
 
-    function test_getOperatorStateWithSocket_revert_quorumNotCreatedAtReferenceBlockNumber() public {
+    function test_getOperatorStateWithSocket_revert_quorumNotCreatedAtReferenceBlockNumber()
+        public
+    {
         cheats.roll(registrationBlockNumber);
         IRegistryCoordinator.OperatorSetParam memory operatorSetParams = IRegistryCoordinator
             .OperatorSetParam({
@@ -238,7 +238,6 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
         );
     }
 
-    
     function test_getOperatorStateWithSocket_returnsCorrect() public {
         uint256 quorumBitmapOne = 1;
         uint256 quorumBitmapThree = 3;
@@ -252,7 +251,7 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
             otherOperator, quorumBitmapThree, otherPubKey, defaultStake - 1
         );
 
-        OperatorStateRetriever.OperatorWithSocket[][] memory operators = operatorStateRetriever
+        (OperatorStateRetriever.Operator[][] memory operators,) = operatorStateRetriever
             .getOperatorStateWithSocket(
             registryCoordinator,
             BitmapUtils.bitmapToBytesArray(quorumBitmapThree),
@@ -271,9 +270,7 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
         assertEq(operators[1][0].operatorId, otherOperatorId);
         assertEq(operators[1][0].stake, defaultStake - 1);
     }
-    */
 
-    
     ////////////////////////////////
 
     function test_getCheckSignaturesIndices_revert_neverRegistered() public {
@@ -497,7 +494,9 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
         assertEq(checkSignaturesIndices.nonSignerStakeIndices[1][0], 0);
     }
 
-    function testGetOperatorState_Valid(uint256 pseudoRandomNumber) public {
+    function testGetOperatorState_Valid(
+        uint256 pseudoRandomNumber
+    ) public {
         // register random operators and get the expected indices within the quorums and the metadata for the operators
         (
             OperatorMetadata[] memory operatorMetadatas,
@@ -566,7 +565,9 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
         );
     }
 
-    function testCheckSignaturesIndices_NoNonSigners_Valid(uint256 pseudoRandomNumber) public {
+    function testCheckSignaturesIndices_NoNonSigners_Valid(
+        uint256 pseudoRandomNumber
+    ) public {
         (
             OperatorMetadata[] memory operatorMetadatas,
             uint256[][] memory expectedOperatorOverallIndices
@@ -631,7 +632,9 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
         }
     }
 
-    function testCheckSignaturesIndices_FewNonSigners_Valid(uint256 pseudoRandomNumber) public {
+    function testCheckSignaturesIndices_FewNonSigners_Valid(
+        uint256 pseudoRandomNumber
+    ) public {
         (
             OperatorMetadata[] memory operatorMetadatas,
             uint256[][] memory expectedOperatorOverallIndices
@@ -752,7 +755,7 @@ contract OperatorStateRetrieverUnitTests is MockAVSDeployer {
         OperatorStateRetriever.Operator[][] memory operators,
         uint256[][] memory expectedOperatorOverallIndices,
         OperatorMetadata[] memory operatorMetadatas
-    ) internal {
+    ) internal pure {
         // for each quorum
         for (uint256 j = 0; j < quorumNumbers.length; j++) {
             // make sure the each operator id and stake is correct


### PR DESCRIPTION
**Motivation:**

The existing PR has stack too deep in tests. Need to move strings outside of the nested struct. There are a few long term things that we can do that I will list here, but I don't think it is necessary immediately because this is just an off-chain view getter that can easily be changed out later so it's just for reference.

* For some reason, via-ir compilation is disabled. This can often help with stack too deep issues, but will require some changes in the code that would expand the scope of the PR too much.
* We can make a socket a fixed size to fix the issue. Right now, a socket is an arbitrary length string. To me right now, the way socket is set is totally opaque so I can't really suggest anything about HOW we can make it a fixed size yet.

**Modifications:**

Move strings outside the nested struct.

**Result:**

Tests will work!
