### PR TITLE
chore: update to use relative imports

### DIFF
--- a/test/events/IStakeRegistryEvents.sol
+++ b/test/events/IStakeRegistryEvents.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {IStakeRegistry, IStrategy} from "src/interfaces/IStakeRegistry.sol";
+import {IStakeRegistry, IStrategy} from "../../src/interfaces/IStakeRegistry.sol";
 
 interface IStakeRegistryEvents {
     /// @notice emitted whenever the stake of `operator` is updated

--- a/test/ffi/UpdateOperators.t.sol
+++ b/test/ffi/UpdateOperators.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import "test/integration/User.t.sol";
+import "../integration/User.t.sol";
 
-import "test/integration/IntegrationChecks.t.sol";
+import "../integration/IntegrationChecks.t.sol";
 
 contract Integration_AVS_Sync_GasCosts_FFI is IntegrationChecks {
     using BN254 for *;

--- a/test/integration/IntegrationBase.t.sol
+++ b/test/integration/IntegrationBase.t.sol
@@ -6,12 +6,12 @@ import "forge-std/Test.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 
-import "src/libraries/BitmapUtils.sol";
-import "src/libraries/BN254.sol";
+import "../../src/libraries/BitmapUtils.sol";
+import "../../src/libraries/BN254.sol";
 
-import "test/integration/IntegrationConfig.t.sol";
-import "test/integration/TimeMachine.t.sol";
-import "test/integration/User.t.sol";
+import "./IntegrationConfig.t.sol";
+import "./TimeMachine.t.sol";
+import "./User.t.sol";
 
 abstract contract IntegrationBase is IntegrationConfig {
     using Strings for *;

--- a/test/integration/IntegrationChecks.t.sol
+++ b/test/integration/IntegrationChecks.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import "test/integration/IntegrationBase.t.sol";
-import "test/integration/User.t.sol";
+import "./IntegrationBase.t.sol";
+import "./User.t.sol";
 
 /// @notice Contract that provides utility functions to reuse common test blocks & checks
 contract IntegrationChecks is IntegrationBase {

--- a/test/integration/IntegrationConfig.t.sol
+++ b/test/integration/IntegrationConfig.t.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.27;
 
 import "forge-std/Test.sol";
 
-import "test/integration/IntegrationDeployer.t.sol";
-import "test/ffi/util/G2Operations.sol";
-import "test/integration/utils/BitmapStrings.t.sol";
+import "./IntegrationDeployer.t.sol";
+import "../ffi/util/G2Operations.sol";
+import "./utils/BitmapStrings.t.sol";
 import {ISlashingRegistryCoordinatorTypes} from
     "../../src/interfaces/ISlashingRegistryCoordinator.sol";
 

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -27,22 +27,22 @@ import "eigenlayer-contracts/src/contracts/permissions/PermissionController.sol"
 import "eigenlayer-contracts/src/test/mocks/ETHDepositMock.sol";
 
 // Middleware contracts
-import "src/RegistryCoordinator.sol";
-import "src/StakeRegistry.sol";
-import "src/IndexRegistry.sol";
-import "src/BLSApkRegistry.sol";
-import "test/mocks/ServiceManagerMock.sol";
-import "src/OperatorStateRetriever.sol";
-import "src/SocketRegistry.sol";
+import "../../src/RegistryCoordinator.sol";
+import "../../src/StakeRegistry.sol";
+import "../../src/IndexRegistry.sol";
+import "../../src/BLSApkRegistry.sol";
+import "../mocks/ServiceManagerMock.sol";
+import "../../src/OperatorStateRetriever.sol";
+import "../../src/SocketRegistry.sol";
 
 // Mocks and More
-import "src/libraries/BN254.sol";
-import "src/libraries/BitmapUtils.sol";
+import "../../src/libraries/BN254.sol";
+import "../../src/libraries/BitmapUtils.sol";
 
 import "eigenlayer-contracts/src/test/mocks/EmptyContract.sol";
-// import "src/test/integration/mocks/ServiceManagerMock.t.sol";
-import "test/integration/User.t.sol";
-import "test/integration/OperatorSetUser.t.sol";
+// import "../integration/mocks/ServiceManagerMock.t.sol";
+import "./User.t.sol";
+import "./OperatorSetUser.t.sol";
 
 abstract contract IntegrationDeployer is Test, IUserDeployer {
     using Strings for *;

--- a/test/integration/OperatorSetUser.t.sol
+++ b/test/integration/OperatorSetUser.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import "test/integration/User.t.sol";
+import "./User.t.sol";
 import "forge-std/console.sol";
 
 contract OperatorSetUser is User {

--- a/test/integration/User.t.sol
+++ b/test/integration/User.t.sol
@@ -17,19 +17,19 @@ import "eigenlayer-contracts/src/contracts/core/AVSDirectory.sol";
 import "eigenlayer-contracts/src/contracts/core/AllocationManager.sol";
 
 // Middleware
-import "src/interfaces/IRegistryCoordinator.sol";
-import "src/RegistryCoordinator.sol";
-import "src/BLSApkRegistry.sol";
-import "src/IndexRegistry.sol";
-import "src/StakeRegistry.sol";
-import "src/ServiceManagerBase.sol";
+import "../../src/interfaces/IRegistryCoordinator.sol";
+import "../../src/RegistryCoordinator.sol";
+import "../../src/BLSApkRegistry.sol";
+import "../../src/IndexRegistry.sol";
+import "../../src/StakeRegistry.sol";
+import "../../src/ServiceManagerBase.sol";
 
-import "src/libraries/BN254.sol";
-import "src/libraries/BitmapUtils.sol";
-import "test/integration/TimeMachine.t.sol";
-import "test/integration/utils/Sort.t.sol";
-import "test/integration/utils/BitmapStrings.t.sol";
-import "test/mocks/ServiceManagerMock.sol";
+import "../../src/libraries/BN254.sol";
+import "../../src/libraries/BitmapUtils.sol";
+import "./TimeMachine.t.sol";
+import "./utils/Sort.t.sol";
+import "./utils/BitmapStrings.t.sol";
+import "../mocks/ServiceManagerMock.sol";
 
 interface IUserDeployer {
     function slashingRegistryCoordinator() external view returns (SlashingRegistryCoordinator);

--- a/test/integration/tests/Full_Register_Deregister.t.sol
+++ b/test/integration/tests/Full_Register_Deregister.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import "test/integration/User.t.sol";
+import "../User.t.sol";
 
-import "test/integration/IntegrationChecks.t.sol";
+import "../IntegrationChecks.t.sol";
 
 contract Integration_Full_Register_Deregister is IntegrationChecks {
     using BitmapUtils for *;

--- a/test/integration/tests/NonFull_Register_CoreBalanceChange_Update.t.sol
+++ b/test/integration/tests/NonFull_Register_CoreBalanceChange_Update.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import "test/integration/User.t.sol";
+import "../User.t.sol";
 
-import "test/integration/IntegrationChecks.t.sol";
+import "../IntegrationChecks.t.sol";
 
 contract Integration_NonFull_Register_CoreBalanceChange_Update is IntegrationChecks {
     // 1. Register for all quorums

--- a/test/integration/tests/NonFull_Register_Deregister.t.sol
+++ b/test/integration/tests/NonFull_Register_Deregister.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import "test/integration/User.t.sol";
+import "../User.t.sol";
 
-import "test/integration/IntegrationChecks.t.sol";
+import "../IntegrationChecks.t.sol";
 
 contract Integration_NonFull_Register_Deregister is IntegrationChecks {
     using BitmapUtils for *;

--- a/test/unit/StakeRegistryUnit.t.sol
+++ b/test/unit/StakeRegistryUnit.t.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.8.27;
 
 import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import "test/utils/MockAVSDeployer.sol";
+import "../utils/MockAVSDeployer.sol";
 
-import {StakeRegistry} from "src/StakeRegistry.sol";
-import {IStakeRegistry, IStakeRegistryErrors} from "src/interfaces/IStakeRegistry.sol";
-import {IStakeRegistryEvents} from "test/events/IStakeRegistryEvents.sol";
-import {ISocketRegistry} from "src/interfaces/ISocketRegistry.sol";
+import {StakeRegistry} from "../../src/StakeRegistry.sol";
+import {IStakeRegistry, IStakeRegistryErrors} from "../../src/interfaces/IStakeRegistry.sol";
+import {IStakeRegistryEvents} from "../events/IStakeRegistryEvents.sol";
+import {ISocketRegistry} from "../../src/interfaces/ISocketRegistry.sol";
 
 import "../utils/MockAVSDeployer.sol";
 

--- a/test/utils/OperatorWalletLib.sol
+++ b/test/utils/OperatorWalletLib.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {Vm} from "forge-std/Vm.sol";
-import {BN254} from "src/libraries/BN254.sol";
+import {BN254} from "../../src/libraries/BN254.sol";
 import {BN256G2} from "./BN256G2.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 


### PR DESCRIPTION
**Motivation:**

absolute imports cause issues for integrators and downstream dependencies

**Modifications:**

Updated absolute import paths to be relative 

**Result:**

No more absolute imports used in the repo
