### PR TITLE
test: partial and full test cases with stake updates

### DIFF
--- a/src/slashers/InstantSlasher.sol
+++ b/src/slashers/InstantSlasher.sol
@@ -24,5 +24,9 @@ contract InstantSlasher is IInstantSlasher, SlasherBase {
     ) external virtual override(IInstantSlasher) onlySlasher {
         uint256 requestId = nextRequestId++;
         _fulfillSlashingRequest(requestId, _slashingParams);
+
+        address[] memory operators = new address[](1);
+        operators[0] = _slashingParams.operator;
+        slashingRegistryCoordinator.updateOperators(operators);
     }
 }

--- a/src/slashers/VetoableSlasher.sol
+++ b/src/slashers/VetoableSlasher.sol
@@ -94,7 +94,7 @@ contract VetoableSlasher is IVetoableSlasher, SlasherBase {
         emit SlashingRequestCancelled(requestId);
     }
 
-    /// @notice Internal function to fullfill a slashing request and mark it as completed
+    /// @notice Internal function to fulfill a slashing request and mark it as completed
     /// @param requestId The ID of the slashing request to fulfill
     function _fulfillSlashingRequestAndMarkAsCompleted(
         uint256 requestId
@@ -109,6 +109,10 @@ contract VetoableSlasher is IVetoableSlasher, SlasherBase {
         request.status = IVetoableSlasherTypes.SlashingStatus.Completed;
 
         _fulfillSlashingRequest(requestId, request.params);
+
+        address[] memory operators = new address[](1);
+        operators[0] = request.params.operator;
+        slashingRegistryCoordinator.updateOperators(operators);
     }
 
     /// @notice Internal function to verify if an account is the veto committee

--- a/test/unit/InstantSlasher.t.sol
+++ b/test/unit/InstantSlasher.t.sol
@@ -200,6 +200,7 @@ contract InstantSlasherTest is Test {
         slashingRegistryCoordinator =
             SlashingRegistryCoordinator(middlewareDeployments.slashingRegistryCoordinator);
         instantSlasher = InstantSlasher(middlewareDeployments.instantSlasher);
+        stakeRegistry = StakeRegistry(middlewareDeployments.stakeRegistry);
 
         PermissionController(coreDeployment.permissionController).setAppointee(
             address(serviceManager),
@@ -213,6 +214,13 @@ contract InstantSlasherTest is Test {
             address(instantSlasher),
             coreDeployment.allocationManager,
             AllocationManager.slashOperator.selector
+        );
+
+        PermissionController(coreDeployment.permissionController).setAppointee(
+            address(serviceManager),
+            address(slashingRegistryCoordinator),
+            coreDeployment.allocationManager,
+            AllocationManager.deregisterFromOperatorSets.selector
         );
 
         PermissionController(coreDeployment.permissionController).setAppointee(
@@ -262,26 +270,6 @@ contract InstantSlasherTest is Test {
         assertEq(instantSlasher.slasher(), slasher);
     }
 
-    function _createMockSlashingParams()
-        internal
-        view
-        returns (IAllocationManagerTypes.SlashingParams memory)
-    {
-        IStrategy[] memory strategies = new IStrategy[](1);
-        strategies[0] = mockStrategy;
-
-        uint256[] memory wadsToSlash = new uint256[](1);
-        wadsToSlash[0] = 0.5e18; // 50% slash
-
-        return IAllocationManagerTypes.SlashingParams({
-            operator: operatorWallet.key.addr,
-            operatorSetId: 1,
-            strategies: strategies,
-            wadsToSlash: wadsToSlash,
-            description: "Test slashing"
-        });
-    }
-
     function test_fulfillSlashingRequest_revert_notSlasher() public {
         IAllocationManagerTypes.SlashingParams memory params = _createMockSlashingParams();
         vm.expectRevert(ISlasherErrors.OnlySlasher.selector);
@@ -289,13 +277,11 @@ contract InstantSlasherTest is Test {
     }
 
     function test_fulfillSlashingRequest() public {
-        vm.skip(false);
         vm.startPrank(operatorWallet.key.addr);
         IDelegationManager(coreDeployment.delegationManager).registerAsOperator(
             address(0), 1, "metadata"
         );
 
-        // Mint tokens and deposit into strategy
         uint256 depositAmount = 1 ether;
         mockToken.mint(operatorWallet.key.addr, depositAmount);
         mockToken.approve(address(coreDeployment.strategyManager), depositAmount);
@@ -303,14 +289,12 @@ contract InstantSlasherTest is Test {
             mockStrategy, mockToken, depositAmount
         );
 
-        // Set allocation delay
         uint32 minDelay = 1;
         IAllocationManager(coreDeployment.allocationManager).setAllocationDelay(
             operatorWallet.key.addr, minDelay
         );
         vm.stopPrank();
 
-        // Assert operator has allocation delay set
         (bool isSet,) = IAllocationManager(coreDeployment.allocationManager).getAllocationDelay(
             operatorWallet.key.addr
         );
@@ -318,7 +302,6 @@ contract InstantSlasherTest is Test {
 
         vm.roll(block.number + ALLOCATION_CONFIGURATION_DELAY + 1);
 
-        // Set up allocation parameters
         IStrategy[] memory allocStrategies = new IStrategy[](1);
         allocStrategies[0] = mockStrategy;
 
@@ -354,7 +337,6 @@ contract InstantSlasherTest is Test {
 
         uint32[] memory operatorSetIds = new uint32[](1);
         operatorSetIds[0] = 0;
-        // Create BLS signing key params
         bytes32 messageHash = slashingRegistryCoordinator.calculatePubkeyRegistrationMessageHash(
             operatorWallet.key.addr
         );
@@ -367,7 +349,6 @@ contract InstantSlasherTest is Test {
             pubkeyG2: operatorWallet.signingKey.publicKeyG2
         });
 
-        // Encode registration data with socket and pubkey params
         bytes memory registrationData = abi.encode(
             ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, "socket", pubkeyParams
         );
@@ -385,7 +366,6 @@ contract InstantSlasherTest is Test {
 
         vm.roll(block.number + 100);
 
-        // Create slashing params
         IAllocationManagerTypes.SlashingParams memory params = IAllocationManagerTypes
             .SlashingParams({
             operator: operatorWallet.key.addr,
@@ -395,13 +375,253 @@ contract InstantSlasherTest is Test {
             description: "Test slashing"
         });
 
-        // Set each wad to slash to 1e18 (100% slash)
         for (uint256 i = 0; i < params.wadsToSlash.length; i++) {
             params.wadsToSlash[i] = 1e18;
         }
 
-        // Execute slashing
         vm.prank(slasher);
         instantSlasher.fulfillSlashingRequest(params);
+    }
+
+    function test_partialSlashUpdatesWeight() public {
+        bytes32 operatorId = _setupOperatorForSlashing();
+
+        uint96 initialOperatorStake =
+            stakeRegistry.weightOfOperatorForQuorum(0, operatorWallet.key.addr);
+        uint96 initialTotalStake = stakeRegistry.getCurrentTotalStake(0);
+
+        assertEq(initialOperatorStake, 2 ether, "Initial operator stake is incorrect");
+
+        IAllocationManagerTypes.SlashingParams memory params = _getPartialSlashingParams();
+
+        vm.prank(slasher);
+        instantSlasher.fulfillSlashingRequest(params);
+
+        uint96 postSlashingStake =
+            stakeRegistry.weightOfOperatorForQuorum(0, operatorWallet.key.addr);
+        uint96 totalStakeAfter = stakeRegistry.getCurrentTotalStake(0);
+
+        assertEq(postSlashingStake, 1 ether, "Incorrect post-slash stake");
+
+        assertEq(totalStakeAfter, initialTotalStake - 1 ether, "Total stake incorrect");
+
+        uint192 bitmap = slashingRegistryCoordinator.getCurrentQuorumBitmap(operatorId);
+        assertTrue(bitmap & 1 != 0, "Operator removed from quorum 0");
+
+        ISlashingRegistryCoordinatorTypes.OperatorStatus status =
+            slashingRegistryCoordinator.getOperatorStatus(operatorWallet.key.addr);
+        assertEq(
+            uint256(status),
+            uint256(ISlashingRegistryCoordinatorTypes.OperatorStatus.REGISTERED),
+            "Operator not in REGISTERED status"
+        );
+    }
+
+    function test_fullySlashRemovesOperator() public {
+        bytes32 operatorId = _setupOperatorForSlashing();
+
+        // Verify operator is registered before slashing
+        uint96 initialOperatorStake =
+            stakeRegistry.weightOfOperatorForQuorum(0, operatorWallet.key.addr);
+        uint96 initialTotalStake = stakeRegistry.getCurrentTotalStake(0);
+
+        assertEq(initialOperatorStake, 2 ether, "Initial operator stake is incorrect");
+
+        uint192 initialBitmap = slashingRegistryCoordinator.getCurrentQuorumBitmap(operatorId);
+        assertTrue(initialBitmap & 1 != 0, "Operator should be in quorum 0 before slashing");
+
+        ISlashingRegistryCoordinatorTypes.OperatorStatus initialStatus =
+            slashingRegistryCoordinator.getOperatorStatus(operatorWallet.key.addr);
+        assertEq(
+            uint256(initialStatus),
+            uint256(ISlashingRegistryCoordinatorTypes.OperatorStatus.REGISTERED),
+            "Operator should be in REGISTERED status before slashing"
+        );
+
+        // Perform full slashing (100%)
+        IAllocationManagerTypes.SlashingParams memory params = _getSlashingParams();
+
+        vm.prank(slasher);
+        instantSlasher.fulfillSlashingRequest(params);
+
+        // Verify operator is removed after slashing
+        uint96 postSlashingStake =
+            stakeRegistry.weightOfOperatorForQuorum(0, operatorWallet.key.addr);
+        uint96 totalStakeAfter = stakeRegistry.getCurrentTotalStake(0);
+
+        assertEq(postSlashingStake, 0, "Post-slash stake should be zero");
+        assertEq(
+            totalStakeAfter,
+            initialTotalStake - 2 ether,
+            "Total stake should be reduced by full amount"
+        );
+
+        uint192 finalBitmap = slashingRegistryCoordinator.getCurrentQuorumBitmap(operatorId);
+        assertEq(finalBitmap & 1, 0, "Operator should be removed from quorum 0");
+
+        ISlashingRegistryCoordinatorTypes.OperatorStatus finalStatus =
+            slashingRegistryCoordinator.getOperatorStatus(operatorWallet.key.addr);
+        assertEq(
+            uint256(finalStatus),
+            uint256(ISlashingRegistryCoordinatorTypes.OperatorStatus.DEREGISTERED),
+            "Operator should be in DEREGISTERED status after full slashing"
+        );
+    }
+
+    function _createMockSlashingParams()
+        internal
+        view
+        returns (IAllocationManagerTypes.SlashingParams memory)
+    {
+        IStrategy[] memory strategies = new IStrategy[](1);
+        strategies[0] = mockStrategy;
+
+        uint256[] memory wadsToSlash = new uint256[](1);
+        wadsToSlash[0] = 0.5e18; // 50% slash
+
+        return IAllocationManagerTypes.SlashingParams({
+            operator: operatorWallet.key.addr,
+            operatorSetId: 1,
+            strategies: strategies,
+            wadsToSlash: wadsToSlash,
+            description: "Test slashing"
+        });
+    }
+
+    function _getSlashingParams()
+        internal
+        view
+        returns (IAllocationManagerTypes.SlashingParams memory)
+    {
+        IStrategy[] memory allocStrategies = new IStrategy[](1);
+        allocStrategies[0] = mockStrategy;
+
+        IAllocationManagerTypes.SlashingParams memory params = IAllocationManagerTypes
+            .SlashingParams({
+            operator: operatorWallet.key.addr,
+            operatorSetId: 0,
+            strategies: allocStrategies,
+            wadsToSlash: new uint256[](allocStrategies.length),
+            description: "Full slash test"
+        });
+
+        for (uint256 i = 0; i < params.wadsToSlash.length; i++) {
+            params.wadsToSlash[i] = 1e18; // 100% slash
+        }
+
+        return params;
+    }
+
+    function _getPartialSlashingParams()
+        internal
+        view
+        returns (IAllocationManagerTypes.SlashingParams memory)
+    {
+        IStrategy[] memory allocStrategies = new IStrategy[](1);
+        allocStrategies[0] = mockStrategy;
+
+        IAllocationManagerTypes.SlashingParams memory params = IAllocationManagerTypes
+            .SlashingParams({
+            operator: operatorWallet.key.addr,
+            operatorSetId: 0,
+            strategies: allocStrategies,
+            wadsToSlash: new uint256[](allocStrategies.length),
+            description: "Partial slash test"
+        });
+
+        for (uint256 i = 0; i < params.wadsToSlash.length; i++) {
+            params.wadsToSlash[i] = 0.5e18; // 50% slash
+        }
+
+        return params;
+    }
+
+    function _setupOperatorForSlashing() internal returns (bytes32) {
+        vm.startPrank(operatorWallet.key.addr);
+        IDelegationManager(coreDeployment.delegationManager).registerAsOperator(
+            address(0), 1, "metadata"
+        );
+
+        uint256 depositAmount = 2 ether;
+        mockToken.mint(operatorWallet.key.addr, depositAmount);
+        mockToken.approve(address(coreDeployment.strategyManager), depositAmount);
+        IStrategyManager(coreDeployment.strategyManager).depositIntoStrategy(
+            mockStrategy, mockToken, depositAmount
+        );
+
+        uint32 minDelay = 1;
+        IAllocationManager(coreDeployment.allocationManager).setAllocationDelay(
+            operatorWallet.key.addr, minDelay
+        );
+        vm.stopPrank();
+
+        vm.roll(block.number + ALLOCATION_CONFIGURATION_DELAY + 1);
+
+        IStrategy[] memory allocStrategies = new IStrategy[](1);
+        allocStrategies[0] = mockStrategy;
+
+        uint64[] memory magnitudes = new uint64[](1);
+        magnitudes[0] = uint64(1 ether); // Allocate full magnitude (2 ETH)
+
+        OperatorSet memory operatorSet = OperatorSet({avs: address(serviceManager), id: 0});
+
+        vm.startPrank(serviceManager);
+        IAllocationManagerTypes.CreateSetParams[] memory createParams =
+            new IAllocationManagerTypes.CreateSetParams[](1);
+        createParams[0] =
+            IAllocationManagerTypes.CreateSetParams({operatorSetId: 0, strategies: allocStrategies});
+        IAllocationManager(coreDeployment.allocationManager).setAVSRegistrar(
+            address(serviceManager), IAVSRegistrar(address(slashingRegistryCoordinator))
+        );
+        vm.stopPrank();
+
+        vm.startPrank(operatorWallet.key.addr);
+
+        IAllocationManagerTypes.AllocateParams[] memory allocParams =
+            new IAllocationManagerTypes.AllocateParams[](1);
+        allocParams[0] = IAllocationManagerTypes.AllocateParams({
+            operatorSet: operatorSet,
+            strategies: allocStrategies,
+            newMagnitudes: magnitudes
+        });
+
+        IAllocationManager(coreDeployment.allocationManager).modifyAllocations(
+            operatorWallet.key.addr, allocParams
+        );
+        vm.roll(block.number + 100);
+
+        uint32[] memory operatorSetIds = new uint32[](1);
+        operatorSetIds[0] = 0;
+        bytes32 messageHash = slashingRegistryCoordinator.calculatePubkeyRegistrationMessageHash(
+            operatorWallet.key.addr
+        );
+        IBLSApkRegistryTypes.PubkeyRegistrationParams memory pubkeyParams = IBLSApkRegistryTypes
+            .PubkeyRegistrationParams({
+            pubkeyRegistrationSignature: SigningKeyOperationsLib.sign(
+                operatorWallet.signingKey, messageHash
+            ),
+            pubkeyG1: operatorWallet.signingKey.publicKeyG1,
+            pubkeyG2: operatorWallet.signingKey.publicKeyG2
+        });
+
+        bytes memory registrationData = abi.encode(
+            ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, "socket", pubkeyParams
+        );
+
+        IAllocationManagerTypes.RegisterParams memory registerParams = IAllocationManagerTypes
+            .RegisterParams({
+            avs: address(serviceManager),
+            operatorSetIds: operatorSetIds,
+            data: registrationData
+        });
+        IAllocationManager(coreDeployment.allocationManager).registerForOperatorSets(
+            operatorWallet.key.addr, registerParams
+        );
+        vm.stopPrank();
+
+        vm.roll(block.number + 100);
+
+        bytes32 operatorId = slashingRegistryCoordinator.getOperatorId(operatorWallet.key.addr);
+        return operatorId;
     }
 }

--- a/test/unit/VetoableSlasher.t.sol
+++ b/test/unit/VetoableSlasher.t.sol
@@ -239,6 +239,13 @@ contract VetoableSlasherTest is Test {
 
         PermissionController(coreDeployment.permissionController).setAppointee(
             address(serviceManager),
+            address(slashingRegistryCoordinator),
+            coreDeployment.allocationManager,
+            AllocationManager.deregisterFromOperatorSets.selector
+        );
+
+        PermissionController(coreDeployment.permissionController).setAppointee(
+            address(serviceManager),
             proxyAdminOwner,
             coreDeployment.allocationManager,
             AllocationManager.updateAVSMetadataURI.selector
@@ -473,7 +480,6 @@ contract VetoableSlasherTest is Test {
 
         vm.roll(block.number + 100);
 
-        // Create slashing params
         IAllocationManagerTypes.SlashingParams memory params = IAllocationManagerTypes
             .SlashingParams({
             operator: operatorWallet.key.addr,
@@ -483,7 +489,6 @@ contract VetoableSlasherTest is Test {
             description: "Test slashing"
         });
 
-        // Set each wad to slash to 1e18 (100% slash)
         for (uint256 i = 0; i < params.wadsToSlash.length; i++) {
             params.wadsToSlash[i] = 1e18;
         }
@@ -491,7 +496,6 @@ contract VetoableSlasherTest is Test {
         vm.prank(slasher);
         vetoableSlasher.queueSlashingRequest(params);
 
-        // Wait for veto period to pass
         vm.roll(block.number + vetoWindowBlocks + 1);
 
         vm.prank(slasher);
@@ -503,5 +507,261 @@ contract VetoableSlasherTest is Test {
             IVetoableSlasherTypes.SlashingStatus status
         ) = vetoableSlasher.slashingRequests(0);
         assertEq(uint8(status), uint8(IVetoableSlasherTypes.SlashingStatus.Completed));
+    }
+
+    function _getFullSlashingParams()
+        internal
+        view
+        returns (IAllocationManagerTypes.SlashingParams memory)
+    {
+        IStrategy[] memory allocStrategies = new IStrategy[](1);
+        allocStrategies[0] = mockStrategy;
+
+        IAllocationManagerTypes.SlashingParams memory params = IAllocationManagerTypes
+            .SlashingParams({
+            operator: operatorWallet.key.addr,
+            operatorSetId: 0,
+            strategies: allocStrategies,
+            wadsToSlash: new uint256[](allocStrategies.length),
+            description: "Full slash test"
+        });
+
+        for (uint256 i = 0; i < params.wadsToSlash.length; i++) {
+            params.wadsToSlash[i] = 1e18; // 100% slash
+        }
+
+        return params;
+    }
+
+    function _getPartialSlashingParams()
+        internal
+        view
+        returns (IAllocationManagerTypes.SlashingParams memory)
+    {
+        IStrategy[] memory allocStrategies = new IStrategy[](1);
+        allocStrategies[0] = mockStrategy;
+
+        IAllocationManagerTypes.SlashingParams memory params = IAllocationManagerTypes
+            .SlashingParams({
+            operator: operatorWallet.key.addr,
+            operatorSetId: 0,
+            strategies: allocStrategies,
+            wadsToSlash: new uint256[](allocStrategies.length),
+            description: "Partial slash test"
+        });
+
+        for (uint256 i = 0; i < params.wadsToSlash.length; i++) {
+            params.wadsToSlash[i] = 0.5e18; // 50% slash
+        }
+
+        return params;
+    }
+
+    function test_fulfillSlashingRequest_updatesWeightButMaintainsMembership() public {
+        bytes32 operatorId = _setupOperatorForSlashing();
+
+        uint96 initialOperatorStake =
+            stakeRegistry.weightOfOperatorForQuorum(0, operatorWallet.key.addr);
+        uint96 initialTotalStake = stakeRegistry.getCurrentTotalStake(0);
+
+        assertEq(initialOperatorStake, 2 ether, "Initial operator stake is incorrect");
+
+        IAllocationManagerTypes.SlashingParams memory params = _getPartialSlashingParams();
+
+        vm.prank(slasher);
+        vetoableSlasher.queueSlashingRequest(params);
+
+        vm.roll(block.number + vetoWindowBlocks + 1);
+
+        vm.prank(slasher);
+        vetoableSlasher.fulfillSlashingRequest(0);
+
+        uint96 postSlashingStake =
+            stakeRegistry.weightOfOperatorForQuorum(0, operatorWallet.key.addr);
+        uint96 totalStakeAfter = stakeRegistry.getCurrentTotalStake(0);
+
+        assertEq(postSlashingStake, 1 ether, "Incorrect post-slash stake");
+
+        assertEq(totalStakeAfter, initialTotalStake - 1 ether, "Total stake incorrect");
+
+        uint192 bitmap = slashingRegistryCoordinator.getCurrentQuorumBitmap(operatorId);
+        assertTrue(bitmap & 1 != 0, "Operator removed from quorum 0");
+
+        ISlashingRegistryCoordinatorTypes.OperatorStatus status =
+            slashingRegistryCoordinator.getOperatorStatus(operatorWallet.key.addr);
+        assertEq(
+            uint256(status),
+            uint256(ISlashingRegistryCoordinatorTypes.OperatorStatus.REGISTERED),
+            "Operator not in REGISTERED status"
+        );
+
+        // Verify slashing request status is completed
+        (,, IVetoableSlasherTypes.SlashingStatus slashStatus) = vetoableSlasher.slashingRequests(0);
+        assertEq(
+            uint8(slashStatus),
+            uint8(IVetoableSlasherTypes.SlashingStatus.Completed),
+            "Slashing request not marked as completed"
+        );
+    }
+
+    // Helper function to set up operator for slashing test
+    function _setupOperatorForSlashing() internal returns (bytes32) {
+        vm.startPrank(operatorWallet.key.addr);
+        IDelegationManager(coreDeployment.delegationManager).registerAsOperator(
+            address(0), 1, "metadata"
+        );
+
+        uint256 depositAmount = 2 ether;
+        mockToken.mint(operatorWallet.key.addr, depositAmount);
+        mockToken.approve(address(coreDeployment.strategyManager), depositAmount);
+        IStrategyManager(coreDeployment.strategyManager).depositIntoStrategy(
+            mockStrategy, mockToken, depositAmount
+        );
+
+        uint32 minDelay = 1;
+        IAllocationManager(coreDeployment.allocationManager).setAllocationDelay(
+            operatorWallet.key.addr, minDelay
+        );
+        vm.stopPrank();
+
+        vm.roll(block.number + ALLOCATION_CONFIGURATION_DELAY + 1);
+
+        IStrategy[] memory allocStrategies = new IStrategy[](1);
+        allocStrategies[0] = mockStrategy;
+
+        uint64[] memory magnitudes = new uint64[](1);
+        magnitudes[0] = uint64(1 ether); // Allocate full magnitude (2 ETH)
+
+        OperatorSet memory operatorSet = OperatorSet({avs: address(serviceManager), id: 0});
+
+        vm.startPrank(serviceManager);
+        IAllocationManagerTypes.CreateSetParams[] memory createParams =
+            new IAllocationManagerTypes.CreateSetParams[](1);
+        createParams[0] =
+            IAllocationManagerTypes.CreateSetParams({operatorSetId: 0, strategies: allocStrategies});
+        IAllocationManager(coreDeployment.allocationManager).setAVSRegistrar(
+            address(serviceManager), IAVSRegistrar(address(slashingRegistryCoordinator))
+        );
+        vm.stopPrank();
+
+        vm.startPrank(operatorWallet.key.addr);
+
+        IAllocationManagerTypes.AllocateParams[] memory allocParams =
+            new IAllocationManagerTypes.AllocateParams[](1);
+        allocParams[0] = IAllocationManagerTypes.AllocateParams({
+            operatorSet: operatorSet,
+            strategies: allocStrategies,
+            newMagnitudes: magnitudes
+        });
+
+        IAllocationManager(coreDeployment.allocationManager).modifyAllocations(
+            operatorWallet.key.addr, allocParams
+        );
+        vm.roll(block.number + 100);
+
+        uint32[] memory operatorSetIds = new uint32[](1);
+        operatorSetIds[0] = 0;
+        bytes32 messageHash = slashingRegistryCoordinator.calculatePubkeyRegistrationMessageHash(
+            operatorWallet.key.addr
+        );
+        IBLSApkRegistryTypes.PubkeyRegistrationParams memory pubkeyParams = IBLSApkRegistryTypes
+            .PubkeyRegistrationParams({
+            pubkeyRegistrationSignature: SigningKeyOperationsLib.sign(
+                operatorWallet.signingKey, messageHash
+            ),
+            pubkeyG1: operatorWallet.signingKey.publicKeyG1,
+            pubkeyG2: operatorWallet.signingKey.publicKeyG2
+        });
+
+        bytes memory registrationData = abi.encode(
+            ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL, "socket", pubkeyParams
+        );
+
+        IAllocationManagerTypes.RegisterParams memory registerParams = IAllocationManagerTypes
+            .RegisterParams({
+            avs: address(serviceManager),
+            operatorSetIds: operatorSetIds,
+            data: registrationData
+        });
+        IAllocationManager(coreDeployment.allocationManager).registerForOperatorSets(
+            operatorWallet.key.addr, registerParams
+        );
+        vm.stopPrank();
+
+        vm.roll(block.number + 100);
+
+        bytes32 operatorId = slashingRegistryCoordinator.getOperatorId(operatorWallet.key.addr);
+        return operatorId;
+    }
+
+    function test_fulfillSlashingRequest_fullySlashesAndRemovesOperator() public {
+        bytes32 operatorId = _setupOperatorForSlashing();
+
+        // Verify operator is registered before slashing
+        uint96 initialOperatorStake =
+            stakeRegistry.weightOfOperatorForQuorum(0, operatorWallet.key.addr);
+        uint96 initialTotalStake = stakeRegistry.getCurrentTotalStake(0);
+
+        assertEq(initialOperatorStake, 2 ether, "Initial operator stake is incorrect");
+
+        uint192 initialBitmap = slashingRegistryCoordinator.getCurrentQuorumBitmap(operatorId);
+        assertTrue(initialBitmap & 1 != 0, "Operator should be in quorum 0 before slashing");
+
+        ISlashingRegistryCoordinatorTypes.OperatorStatus initialStatus =
+            slashingRegistryCoordinator.getOperatorStatus(operatorWallet.key.addr);
+        assertEq(
+            uint256(initialStatus),
+            uint256(ISlashingRegistryCoordinatorTypes.OperatorStatus.REGISTERED),
+            "Operator should be in REGISTERED status before slashing"
+        );
+
+        // Create a full slashing request (100%)
+        IAllocationManagerTypes.SlashingParams memory params = _getFullSlashingParams();
+
+        // Queue slashing request
+        vm.prank(slasher);
+        vetoableSlasher.queueSlashingRequest(params);
+
+        // Verify slashing request is queued
+        (
+            IAllocationManagerTypes.SlashingParams memory resultParams,
+            uint256 requestTimestamp,
+            IVetoableSlasherTypes.SlashingStatus status
+        ) = vetoableSlasher.slashingRequests(0);
+        assertEq(uint8(status), uint8(IVetoableSlasherTypes.SlashingStatus.Requested));
+
+        // Wait for veto period to pass
+        vm.roll(block.number + vetoWindowBlocks + 1);
+
+        // Execute slashing
+        vm.prank(slasher);
+        vetoableSlasher.fulfillSlashingRequest(0);
+
+        // Verify slashing request is completed
+        (,, status) = vetoableSlasher.slashingRequests(0);
+        assertEq(uint8(status), uint8(IVetoableSlasherTypes.SlashingStatus.Completed));
+
+        // Verify operator is fully slashed and removed
+        uint96 postSlashingStake =
+            stakeRegistry.weightOfOperatorForQuorum(0, operatorWallet.key.addr);
+        uint96 totalStakeAfter = stakeRegistry.getCurrentTotalStake(0);
+
+        assertEq(postSlashingStake, 0, "Post-slash stake should be zero");
+        assertEq(
+            totalStakeAfter,
+            initialTotalStake - 2 ether,
+            "Total stake should be reduced by full amount"
+        );
+
+        uint192 finalBitmap = slashingRegistryCoordinator.getCurrentQuorumBitmap(operatorId);
+        assertEq(finalBitmap & 1, 0, "Operator should be removed from quorum 0");
+
+        ISlashingRegistryCoordinatorTypes.OperatorStatus finalStatus =
+            slashingRegistryCoordinator.getOperatorStatus(operatorWallet.key.addr);
+        assertEq(
+            uint256(finalStatus),
+            uint256(ISlashingRegistryCoordinatorTypes.OperatorStatus.DEREGISTERED),
+            "Operator should be in DEREGISTERED status after full slashing"
+        );
     }
 }


### PR DESCRIPTION
**Motivation:**

It's more intuitive to slash and operator and atomically update their weight

**Modifications:**

add a call to updateOperators to update the view the AVS has of their weight in the registry coordinator 

**Result:**

More intutive UX
