### PR TITLE
fix: keep storage layout the same

### DIFF
--- a/src/SlashingRegistryCoordinatorStorage.sol
+++ b/src/SlashingRegistryCoordinatorStorage.sol
@@ -73,6 +73,9 @@ abstract contract SlashingRegistryCoordinatorStorage is ISlashingRegistryCoordin
     /// @notice mapping from quorum number to the latest block that all quorums were updated all at once
     mapping(uint8 => uint256) public quorumUpdateBlockNumber;
 
+    /// @notice the dynamic-length array of the registries this coordinator is coordinating
+    /// @dev DEPRECATED: This slot is no longer used but kept for storage layout compatibility
+    address[] private registries;
     /// @notice the address of the entity allowed to sign off on operators getting kicked out of the AVS during registration
     address public churnApprover;
     /// @notice the address of the entity allowed to eject operators from the AVS


### PR DESCRIPTION
**Motivation:**

Needs to be maintained for storage layout compatibility for the RegistryCoordinator

**Modifications:**

Add back the registries array as a place holder for the slot it used to take up

**Result:**

Storage layout will be compatible with prior version
