### PR TITLE
chore: bump the core dependency to v1.4.0

### DIFF
--- a/test/mocks/EigenPodManagerMock.sol
+++ b/test/mocks/EigenPodManagerMock.sol
@@ -32,6 +32,18 @@ contract EigenPodManagerMock is Test, Pausable, IEigenPodManager {
         return type(uint64).max;
     }
 
+    function pectraForkTimestamp() external pure returns (uint64) {
+        return type(uint64).max;
+    }
+
+    function setPectraForkTimestamp(
+        uint64 timestamp
+    ) external {}
+
+    function setProofTimestampSetter(
+        address newProofTimestampSetter
+    ) external {}
+
     function createPod() external returns (address) {}
 
     function stake(


### PR DESCRIPTION
**Motivation:**

The core contracts will be deploying v1.4.0 to testnet tomorrow. This release bumps the core contracts to that release to be compatible with what will be live on holesky

**Modifications:**

Bump the core protocol dependency

**Result:**

Up to date with core contract release 1.4.0
