### PR TITLE
fix: storage layout regression

### DIFF
--- a/src/RegistryCoordinator.sol
+++ b/src/RegistryCoordinator.sol
@@ -34,7 +34,7 @@ import {RegistryCoordinatorStorage} from "./RegistryCoordinatorStorage.sol";
  *
  * @author Layr Labs, Inc.
  */
-contract RegistryCoordinator is RegistryCoordinatorStorage, SlashingRegistryCoordinator {
+contract RegistryCoordinator is SlashingRegistryCoordinator, RegistryCoordinatorStorage {
     using BitmapUtils for *;
 
     constructor(

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -44,11 +44,11 @@ import {SlashingRegistryCoordinatorStorage} from "./SlashingRegistryCoordinatorS
  * @author Layr Labs, Inc.
  */
 contract SlashingRegistryCoordinator is
-    SlashingRegistryCoordinatorStorage,
     Initializable,
     SemVerMixin,
     Pausable,
     OwnableUpgradeable,
+    SlashingRegistryCoordinatorStorage,
     EIP712Upgradeable,
     ISignatureUtilsMixin
 {


### PR DESCRIPTION
**Motivation:**

regression in the src / rc storage layouts

**Modifications:**

Re-order the inheritance to preserve the storage layout from the v0.5.4 rewards release

**Result:**

Consistent storage layout between releases
