### PR TITLE
fix: ci workflow needs secret

### DIFF
--- a/.github/workflows/forge-test-intense.yml
+++ b/.github/workflows/forge-test-intense.yml
@@ -9,11 +9,7 @@ on:
       - dev
 
 env:
-  FOUNDRY_PROFILE: ci
-  RPC_MAINNET: ${{ secrets.RPC_MAINNET }}
-  RPC_HOLESKY: ${{ secrets.RPC_HOLESKY }}
-  HOLESKY_RPC_URL: ${{ secrets.HOLESKY_RPC_URL }}
-  CHAIN_ID: ${{ secrets.CHAIN_ID }}
+  FOUNDRY_PROFILE: intense
 
 jobs:
   # -----------------------------------------------------------------------
@@ -47,4 +43,5 @@ jobs:
         run: |
           echo -e "\033[1;33mWarning: This workflow may take several hours to complete.\033[0m"
           echo -e "\033[1;33mThis intense fuzzing workflow is optional but helps catch edge cases through extended testing.\033[0m"
-          FOUNDRY_PROFILE=intense forge test -vvv
+          echo "Current FOUNDRY_PROFILE: $FOUNDRY_PROFILE"
+          forge test -vvv

--- a/.github/workflows/forge-test-intense.yml
+++ b/.github/workflows/forge-test-intense.yml
@@ -12,9 +12,10 @@ env:
   FOUNDRY_PROFILE: ci
   RPC_MAINNET: ${{ secrets.RPC_MAINNET }}
   RPC_HOLESKY: ${{ secrets.RPC_HOLESKY }}
+  HOLESKY_RPC_URL: ${{ secrets.HOLESKY_RPC_URL }}
   CHAIN_ID: ${{ secrets.CHAIN_ID }}
-  
-jobs:      
+
+jobs:
   # -----------------------------------------------------------------------
   # Forge Test (Intense)
   # -----------------------------------------------------------------------

--- a/foundry.toml
+++ b/foundry.toml
@@ -102,6 +102,7 @@
     optimizer=true
     optimizer_runs = 100
     runs = 5000
+    ignore = ["./test/fork/**/*"]
 
 [profile.forktest.fuzz]
     runs = 16

--- a/test/fork/End2End.t.sol
+++ b/test/fork/End2End.t.sol
@@ -4,30 +4,30 @@ pragma solidity ^0.8.12;
 import {Vm} from "forge-std/Vm.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {Test, console2 as console} from "forge-std/Test.sol";
-import {OperatorLib} from "./utils/OperatorLib.sol";
-import {UpgradeableProxyLib} from "./unit/UpgradeableProxyLib.sol";
-import {MiddlewareDeployLib} from "./utils/MiddlewareDeployLib.sol";
-import {BN254} from "../src/libraries/BN254.sol";
+import {OperatorLib} from "../utils/OperatorLib.sol";
+import {UpgradeableProxyLib} from "../unit/UpgradeableProxyLib.sol";
+import {MiddlewareDeployLib} from "../utils/MiddlewareDeployLib.sol";
+import {BN254} from "../../src/libraries/BN254.sol";
 import {IDelegationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
 import {IAllocationManagerTypes} from
     "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
-import {IServiceManager} from "../src/interfaces/IServiceManager.sol";
-import {IStakeRegistry, IStakeRegistryTypes} from "../src/interfaces/IStakeRegistry.sol";
+import {IServiceManager} from "../../src/interfaces/IServiceManager.sol";
+import {IStakeRegistry, IStakeRegistryTypes} from "../../src/interfaces/IStakeRegistry.sol";
 import {IAVSRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
-import {RegistryCoordinator} from "../src/RegistryCoordinator.sol";
-import {IRegistryCoordinator} from "../src/interfaces/IRegistryCoordinator.sol";
+import {RegistryCoordinator} from "../../src/RegistryCoordinator.sol";
+import {IRegistryCoordinator} from "../../src/interfaces/IRegistryCoordinator.sol";
 import {OperatorSet} from "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 import {AllocationManager} from "eigenlayer-contracts/src/contracts/core/AllocationManager.sol";
 import {PermissionController} from
     "eigenlayer-contracts/src/contracts/permissions/PermissionController.sol";
-import {ServiceManagerMock} from "./mocks/ServiceManagerMock.sol";
+import {ServiceManagerMock} from "../mocks/ServiceManagerMock.sol";
 import {
     ISlashingRegistryCoordinator,
     ISlashingRegistryCoordinatorTypes
-} from "../src/interfaces/ISlashingRegistryCoordinator.sol";
-import {ERC20Mock} from "./mocks/ERC20Mock.sol";
+} from "../../src/interfaces/ISlashingRegistryCoordinator.sol";
+import {ERC20Mock} from "../mocks/ERC20Mock.sol";
 import {IStrategyFactory} from "eigenlayer-contracts/src/contracts/interfaces/IStrategyFactory.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 


### PR DESCRIPTION
**Motivation:**

The CI workflow needs access to the HOLESKY_RPC_URL secret for running tests on the Holesky testnet. This was missing in the workflow configuration.

**Modifications:**

Ignore fork tests on intense CI workflows

**Result:**

No longer run fork tests on intense CI setting