### PR TITLE
feat: add view function for total operator count in quorum

### DIFF
--- a/src/IndexRegistry.sol
+++ b/src/IndexRegistry.sol
@@ -332,6 +332,14 @@ contract IndexRegistry is IndexRegistryStorage {
         return _latestQuorumUpdate(quorumNumber).numOperators;
     }
 
+    /// @inheritdoc IIndexRegistry
+    function totalOperatorsForQuorumAtBlockNumber(
+        uint8 quorumNumber,
+        uint32 blockNumber
+    ) external view returns (uint32) {
+        return _operatorCountAtBlockNumber(quorumNumber, blockNumber);
+    }
+
     function _checkRegistryCoordinator() internal view {
         require(msg.sender == address(registryCoordinator), OnlyRegistryCoordinator());
     }

--- a/src/interfaces/IIndexRegistry.sol
+++ b/src/interfaces/IIndexRegistry.sol
@@ -175,4 +175,15 @@ interface IIndexRegistry is IIndexRegistryErrors, IIndexRegistryEvents {
     function totalOperatorsForQuorum(
         uint8 quorumNumber
     ) external view returns (uint32);
+
+    /*
+     * @notice Returns the total number of operators in quorum `quorumNumber` at block `blockNumber`.
+     * @param quorumNumber The identifier of the quorum.
+     * @param blockNumber The block number to query.
+     * @return The total number of operators at the specified block.
+     */
+    function totalOperatorsForQuorumAtBlockNumber(
+        uint8 quorumNumber,
+        uint32 blockNumber
+    ) external view returns (uint32);
 }

--- a/test/unit/IndexRegistryUnit.t.sol
+++ b/test/unit/IndexRegistryUnit.t.sol
@@ -424,6 +424,23 @@ contract IndexRegistryUnitTests_configAndGetters is IndexRegistryUnitTests {
         assertEq(quorumUpdate.numOperators, 0, "numOperators not 0");
         assertEq(quorumUpdate.fromBlockNumber, block.number, "fromBlockNumber not correct");
     }
+
+    function test_totalOperatorsForQuorumAtBlockNumber() public {
+        uint8 quorumNumber = nextQuorum;
+        _initializeQuorum();
+        uint32 blockNumInit = uint32(block.number);
+
+        // Initially, 0 operators
+        assertEq(indexRegistry.totalOperatorsForQuorumAtBlockNumber(quorumNumber, blockNumInit), 0);
+
+        vm.roll(block.number + 5);
+        uint32 blockNumReg1 = uint32(block.number);
+        (, bytes32 operatorId1) = _selectNewOperator();
+        _registerOperatorSingleQuorum(operatorId1, quorumNumber);
+        // Check count at current and past blocks
+        assertEq(indexRegistry.totalOperatorsForQuorumAtBlockNumber(quorumNumber, blockNumReg1), 1);
+        assertEq(indexRegistry.totalOperatorsForQuorumAtBlockNumber(quorumNumber, blockNumInit), 0);
+    }
 }
 
 contract IndexRegistryUnitTests_registerOperator is IndexRegistryUnitTests {
@@ -474,7 +491,7 @@ contract IndexRegistryUnitTests_registerOperator is IndexRegistryUnitTests {
      * 2. quorumNumbers ordered in ascending order
      * 3. quorumBitmap is <= uint192.max
      * 4. quorumNumbers.length != 0
-     * 5. operator is not already registerd for any quorums being registered for
+     * 5. operator is not already registered for any quorums being registered for
      */
     function test_registerOperator() public {
         // register an operator
@@ -601,7 +618,7 @@ contract IndexRegistryUnitTests_registerOperator is IndexRegistryUnitTests {
      * 2. quorumNumbers ordered in ascending order
      * 3. quorumBitmap is <= uint192.max
      * 4. quorumNumbers.length != 0
-     * 5. operator is not already registerd for any quorums being registered for
+     * 5. operator is not already registered for any quorums being registered for
      */
     function testFuzz_registerOperator_MultipleQuorums(
         uint192 bitmap


### PR DESCRIPTION
**Motivation:**

Getting the operator count in a quorum at a past block requires 2 calls.  This would make it take 1 and improve DEVX for getting this info 

**Modifications:**

Expose the checked mapping and return the data

**Result:**

Total operator count for quorum available via a view function