### PR TITLE
chore: bump core dependency to v1.3.0

### DIFF
--- a/test/mocks/DelegationMock.sol
+++ b/test/mocks/DelegationMock.sol
@@ -268,6 +268,20 @@ contract DelegationIntermediate is IDelegationManager {
         return new bytes32[](0);
     }
 
+    function queuedWithdrawals(
+        bytes32 withdrawalRoot
+    ) external view override returns (IDelegationManagerTypes.Withdrawal memory withdrawal) {
+        return IDelegationManagerTypes.Withdrawal({
+            staker: address(0),
+            delegatedTo: address(0),
+            withdrawer: address(0),
+            nonce: 0,
+            startBlock: 0,
+            strategies: new IStrategy[](0),
+            scaledShares: new uint256[](0)
+        });
+    }
+
     function convertToDepositShares(
         address staker,
         IStrategy[] memory strategies,


### PR DESCRIPTION
**Motivation:**

The core contracts had a release yesterday for the audit fixes from the cantina competition and we want to target this branch for the middleware audit

**Modifications:**

Bump dependency

**Result:**

Target the latest stable core release for testnet
