### PR TITLE
fix: enforce quorum registration on churn

### DIFF
--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -705,8 +705,11 @@ contract SlashingRegistryCoordinator is
         bytes32 idToKick = _operatorInfo[operatorToKick].operatorId;
         require(newOperator != operatorToKick, CannotChurnSelf());
         require(kickParams.quorumNumber == quorumNumber, QuorumOperatorCountMismatch());
+
+        uint192 quorumBitmap;
+        quorumBitmap = uint192(BitmapUtils.setBit(quorumBitmap, quorumNumber));
         require(
-            quorumNumber.isSubsetOf(_currentOperatorBitmap(idToKick)),
+            quorumBitmap.isSubsetOf(_currentOperatorBitmap(idToKick)),
             OperatorNotRegisteredForQuorum()
         );
 

--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -677,6 +677,7 @@ contract SlashingRegistryCoordinator is
     /**
      * @notice Validates that an incoming operator is eligible to replace an existing
      * operator based on the stake of both
+     * @dev In order to be churned out, the existing operator must be registered for the quorum
      * @dev In order to churn, the incoming operator needs to have more stake than the
      * existing operator by a proportion given by `kickBIPsOfOperatorStake`
      * @dev In order to be churned out, the existing operator needs to have a proportion
@@ -704,6 +705,10 @@ contract SlashingRegistryCoordinator is
         bytes32 idToKick = _operatorInfo[operatorToKick].operatorId;
         require(newOperator != operatorToKick, CannotChurnSelf());
         require(kickParams.quorumNumber == quorumNumber, QuorumOperatorCountMismatch());
+        require(
+            quorumNumber.isSubsetOf(_currentOperatorBitmap(idToKick)),
+            OperatorNotRegisteredForQuorum()
+        );
 
         // Get the target operator's stake and check that it is below the kick thresholds
         uint96 operatorToKickStake = stakeRegistry.getCurrentStake(idToKick, quorumNumber);

--- a/src/interfaces/ISlashingRegistryCoordinator.sol
+++ b/src/interfaces/ISlashingRegistryCoordinator.sol
@@ -59,6 +59,8 @@ interface ISlashingRegistryCoordinatorErrors {
     error LookAheadPeriodTooLong();
     /// @notice Thrown when the number of operators in a quorum would exceed the maximum allowed.
     error MaxOperatorCountReached();
+    /// @notice Thrown when the operator is not registered for the quorum.
+    error OperatorNotRegisteredForQuorum();
 }
 
 interface ISlashingRegistryCoordinatorTypes {

--- a/test/unit/SlashingRegistryCoordinatorUnit.t.sol
+++ b/test/unit/SlashingRegistryCoordinatorUnit.t.sol
@@ -1938,7 +1938,6 @@ contract SlashingRegistryCoordinator_RegisterWithChurn is
     }
 
     /// @dev Asserts that an operator cannot be churned out if it is not registered for the quorum
-    /// @dev We register the operator to kick in quorum 2 so that it is still registered after deregistration
     function test_registerOperatorWithChurn_revert_notRegisteredForQuorum() public {
         _setOperatorWeight(testOperator.key.addr, registeringStake);
         _setOperatorWeight(operatorToKick.key.addr, operatorToKickStake);
@@ -1949,6 +1948,12 @@ contract SlashingRegistryCoordinator_RegisterWithChurn is
         strategyParams[0] =
             IStakeRegistryTypes.StrategyParams({strategy: mockStrategy, multiplier: 1 ether});
 
+        operatorSetParams = ISlashingRegistryCoordinatorTypes.OperatorSetParam({
+            maxOperatorCount: 1,
+            kickBIPsOfOperatorStake: 5000,
+            kickBIPsOfTotalStake: 5000
+        });
+
         vm.startPrank(proxyAdminOwner);
         slashingRegistryCoordinator.createTotalDelegatedStakeQuorum(
             operatorSetParams,
@@ -1957,30 +1962,16 @@ contract SlashingRegistryCoordinator_RegisterWithChurn is
         );
         vm.stopPrank();
 
-        // Register the operatorToKick in the new quorum
-        uint32[] memory operatorSetIds = new uint32[](1);
-        operatorSetIds[0] = 2;
-        registerOperatorInSlashingRegistryCoordinator(operatorToKick, "socket:8545", operatorSetIds);
+        // Register extra operator in the new quorum
+        registerOperatorInSlashingRegistryCoordinator(extraOperator1, "socket:8545", uint32(2));
 
-        // Deregister the operatorToKick from quorum 1
-        IAllocationManagerTypes.DeregisterParams memory deregisterParams = IAllocationManagerTypes
-            .DeregisterParams({
-            operator: operatorToKick.key.addr,
-            avs: address(serviceManager),
-            operatorSetIds: operatorSetIds
-        });
 
-        vm.prank(operatorToKick.key.addr);
-        IAllocationManager(coreDeployment.allocationManager).deregisterFromOperatorSets(
-            deregisterParams
-        );
-
-        // Try to churn the operator
+        // Setup churn data
         ISlashingRegistryCoordinatorTypes.OperatorKickParam[] memory operatorKickParams =
             new ISlashingRegistryCoordinatorTypes.OperatorKickParam[](quorumNumbers.length);
         operatorKickParams[0] = ISlashingRegistryCoordinatorTypes.OperatorKickParam({
             operator: operatorToKick.key.addr,
-            quorumNumber: uint8(quorumNumbers[0])
+            quorumNumber: uint8(2) // 3rd quorum
         });
 
         ISignatureUtilsMixinTypes.SignatureWithSaltAndExpiry memory churnApproverSignature =
@@ -1988,7 +1979,7 @@ contract SlashingRegistryCoordinator_RegisterWithChurn is
             testOperator.key.addr,
             testOperatorId,
             operatorKickParams,
-            bytes32(uint256(3)), // Different salt from previous tests
+            bytes32(uint256(4)),
             defaultExpiry
         );
 
@@ -1998,7 +1989,7 @@ contract SlashingRegistryCoordinator_RegisterWithChurn is
         IAllocationManagerTypes.RegisterParams memory registerParams = IAllocationManagerTypes
             .RegisterParams({
             avs: address(serviceManager),
-            operatorSetIds: new uint32[](quorumNumbers.length),
+            operatorSetIds: new uint32[](1),
             data: abi.encode(
                 ISlashingRegistryCoordinatorTypes.RegistrationType.CHURN,
                 "socket:8545",
@@ -2008,9 +1999,7 @@ contract SlashingRegistryCoordinator_RegisterWithChurn is
             )
         });
 
-        for (uint256 i = 0; i < quorumNumbers.length; i++) {
-            registerParams.operatorSetIds[i] = uint8(quorumNumbers[i]);
-        }
+        registerParams.operatorSetIds[0] = uint32(2);
 
         vm.prank(testOperator.key.addr);
         vm.expectRevert(abi.encodeWithSignature("OperatorNotRegisteredForQuorum()"));

--- a/test/unit/SlashingRegistryCoordinatorUnit.t.sol
+++ b/test/unit/SlashingRegistryCoordinatorUnit.t.sol
@@ -1965,7 +1965,6 @@ contract SlashingRegistryCoordinator_RegisterWithChurn is
         // Register extra operator in the new quorum
         registerOperatorInSlashingRegistryCoordinator(extraOperator1, "socket:8545", uint32(2));
 
-
         // Setup churn data
         ISlashingRegistryCoordinatorTypes.OperatorKickParam[] memory operatorKickParams =
             new ISlashingRegistryCoordinatorTypes.OperatorKickParam[](quorumNumbers.length);

--- a/test/unit/SlashingRegistryCoordinatorUnit.t.sol
+++ b/test/unit/SlashingRegistryCoordinatorUnit.t.sol
@@ -1937,16 +1937,49 @@ contract SlashingRegistryCoordinator_RegisterWithChurn is
         );
     }
 
+    /// @dev Asserts that an operator cannot be churned out if it is not registered for the quorum
+    /// @dev We register the operator to kick in quorum 2 so that it is still registered after deregistration
     function test_registerOperatorWithChurn_revert_notRegisteredForQuorum() public {
         _setOperatorWeight(testOperator.key.addr, registeringStake);
+        _setOperatorWeight(operatorToKick.key.addr, operatorToKickStake);
 
-        Operator memory unregisteredOperator = operatorsByID[operatorIds.at(5)];
-        _setOperatorWeight(unregisteredOperator.key.addr, operatorToKickStake);
+        // Create a new quorum
+        IStakeRegistryTypes.StrategyParams[] memory strategyParams =
+            new IStakeRegistryTypes.StrategyParams[](1);
+        strategyParams[0] =
+            IStakeRegistryTypes.StrategyParams({strategy: mockStrategy, multiplier: 1 ether});
 
+        vm.startPrank(proxyAdminOwner);
+        slashingRegistryCoordinator.createTotalDelegatedStakeQuorum(
+            operatorSetParams,
+            1 ether, // minimum stake
+            strategyParams
+        );
+        vm.stopPrank();
+
+        // Register the operatorToKick in the new quorum
+        uint32[] memory operatorSetIds = new uint32[](1);
+        operatorSetIds[0] = 2;
+        registerOperatorInSlashingRegistryCoordinator(operatorToKick, "socket:8545", operatorSetIds);
+
+        // Deregister the operatorToKick from quorum 1
+        IAllocationManagerTypes.DeregisterParams memory deregisterParams = IAllocationManagerTypes
+            .DeregisterParams({
+            operator: operatorToKick.key.addr,
+            avs: address(serviceManager),
+            operatorSetIds: operatorSetIds
+        });
+
+        vm.prank(operatorToKick.key.addr);
+        IAllocationManager(coreDeployment.allocationManager).deregisterFromOperatorSets(
+            deregisterParams
+        );
+
+        // Try to churn the operator
         ISlashingRegistryCoordinatorTypes.OperatorKickParam[] memory operatorKickParams =
             new ISlashingRegistryCoordinatorTypes.OperatorKickParam[](quorumNumbers.length);
         operatorKickParams[0] = ISlashingRegistryCoordinatorTypes.OperatorKickParam({
-            operator: unregisteredOperator.key.addr,
+            operator: operatorToKick.key.addr,
             quorumNumber: uint8(quorumNumbers[0])
         });
 
@@ -1980,7 +2013,7 @@ contract SlashingRegistryCoordinator_RegisterWithChurn is
         }
 
         vm.prank(testOperator.key.addr);
-        vm.expectRevert(abi.encodeWithSignature("OperatorNotRegistered()"));
+        vm.expectRevert(abi.encodeWithSignature("OperatorNotRegisteredForQuorum()"));
         IAllocationManager(coreDeployment.allocationManager).registerForOperatorSets(
             testOperator.key.addr, registerParams
         );


### PR DESCRIPTION
NOTE: #464 was merged to wrong target

**Motivation:**

It is possible to break the `maxOperatorCount` invariant by doing the following:

Let's assume there are two quorums, 1 and 2, with a `maxOperatorCount` of 2. 

1. Alice & Bob register for quorum 1
2. Bob registers for quorum 2
3. Bob deregisters from quorum 1, Charlie enters
4. Quorum 1 Members: Alice/Charlie. Quorum 2 members: Bob
5. Eve creates a churn registration that exits Bob.  Quorum 1 has 3 members. This works just fine since we allow a churn to occur if the `operatorToKick` is registered to the AVS (not the quorum): https://github.com/Layr-Labs/eigenlayer-middleware/blob/f5adbcac55d9336cd646ce71bc467aa7e20f1a12/src/SlashingRegistryCoordinator.sol#L405-L408

Although this assumes that the `churnApprover` is buggy, we should still be enforcing that you are churning a user if they are registered for the quorum. 

**Modifications:**

Require that the `operatorToKick` is registered for the quorum. 

**Result:**

Stricter churn guarantees. 