### PR TITLE
fix: dealloc delay inquality on quorum creation

### DIFF
--- a/src/SlashingRegistryCoordinator.sol
+++ b/src/SlashingRegistryCoordinator.sol
@@ -830,7 +830,8 @@ contract SlashingRegistryCoordinator is
         } else if (stakeType == IStakeRegistryTypes.StakeType.TOTAL_SLASHABLE) {
             // For slashable stake quorums, ensure lookAheadPeriod is less than DEALLOCATION_DELAY
             require(
-                AllocationManager(address(allocationManager)).DEALLOCATION_DELAY() > lookAheadPeriod,
+                lookAheadPeriod
+                    <= AllocationManager(address(allocationManager)).DEALLOCATION_DELAY(),
                 LookAheadPeriodTooLong()
             );
             stakeRegistry.initializeSlashableStakeQuorum(

--- a/test/unit/SlashingRegistryCoordinatorUnit.t.sol
+++ b/test/unit/SlashingRegistryCoordinatorUnit.t.sol
@@ -735,7 +735,7 @@ contract SlashingRegistryCoordinator_CreateSlashableStakeQuorum is
         uint32 deallocationDelay =
             AllocationManager(address(coreDeployment.allocationManager)).DEALLOCATION_DELAY();
 
-        uint32 tooLongLookAheadPeriod = deallocationDelay;
+        uint32 tooLongLookAheadPeriod = deallocationDelay + 1;
 
         vm.prank(proxyAdminOwner);
         vm.expectRevert(LookAheadPeriodTooLong.selector);


### PR DESCRIPTION
**Motivation:**

An operator is slashable for at least `DEALLOCATION_DELAY`. The check for the lookahead period should be exactly this amount, not less. 

**Modifications:**

Update check for `lookAheadPeriod` to be `<=DEALLOCATION_DELAY`. 

**Result:**

Symmetric checks with #463 
