### PR TITLE
feat: add table bytes to interface

### DIFF
--- a/src/crossChain/BLSTableCalculator.sol
+++ b/src/crossChain/BLSTableCalculator.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.27;
 
 import {IBLSTableCalculator} from "../interfaces/IBLSTableCalculator.sol";
-
+import {IOperatorTableCalculator} from "../interfaces/IOperatorTableCalculator.sol";
 import {IStakeRegistry} from "../interfaces/IStakeRegistry.sol";
 import {IBLSApkRegistry} from "../interfaces/IBLSApkRegistry.sol";
 import {OperatorSet} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
@@ -18,9 +18,14 @@ abstract contract BLSTableCalculator is IBLSTableCalculator {
     constructor(IBLSApkRegistry _blsApkRegistry) {
         blsApkRegistry = _blsApkRegistry;
     }
+
+    /// @inheritdoc IOperatorTableCalculator
+    function calculateOperatorTableBytes(OperatorSet calldata operatorSet) external view returns (bytes memory operatorTableBytes) {
+        return abi.encode(calculateOperatorTable(operatorSet));
+    }
     
     /// @inheritdoc IBLSTableCalculator
-    function calculateOperatorTable(OperatorSet calldata operatorSet) external view returns (BN254OperatorSetInfo memory operatorSetInfo) {
+    function calculateOperatorTable(OperatorSet calldata operatorSet) public view returns (BN254OperatorSetInfo memory operatorSetInfo) {
         validateOperatorSet(operatorSet);
 
         // Get the weights for all operators in the operatorSet

--- a/src/interfaces/IBLSTableCalculator.sol
+++ b/src/interfaces/IBLSTableCalculator.sol
@@ -4,7 +4,9 @@ pragma solidity ^0.8.27;
 import {BN254} from "../libraries/BN254.sol";
 import {OperatorSet} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
 import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
+import {IOperatorTableCalculator} from "./IOperatorTableCalculator.sol";
 import {IOperatorWeightCalculator} from "./IOperatorWeightCalculator.sol";
+
 interface IBLSTableCalculatorErrors {
     /// @notice Thrown when the operatorSet does not exist in EigenLayer core.
     error InvalidOperatorSet();
@@ -33,7 +35,7 @@ interface IBLSTableCalculatorTypes {
 interface IBLSTableCalculatorEvents is IBLSTableCalculatorTypes {
 }
 
-interface IBLSTableCalculator is IOperatorWeightCalculator, IBLSTableCalculatorErrors, IBLSTableCalculatorEvents {
+interface IBLSTableCalculator is IOperatorTableCalculator, IOperatorWeightCalculator, IBLSTableCalculatorErrors, IBLSTableCalculatorEvents {
     /**
      * @notice calculates the operatorInfos for a given operatorSet
      * @param operatorSet the operatorSet to calculate the operator table for

--- a/src/interfaces/IOperatorTableCalculator.sol
+++ b/src/interfaces/IOperatorTableCalculator.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {OperatorSet} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+
+interface IOperatorTableCalculator {
+	/**
+	 * @notice calculates the operatorTableBytes for a given operatorSet
+	 * @param operatorSet the operatorSet to calculate the operatorTableBytes for
+	 * @return operatorTableBytes The operatorTable bytes
+	 */
+	function calculateOperatorTableBytes(OperatorSet calldata operatorSet) 
+		external view returns(bytes memory operatorTableBytes);
+} 


### PR DESCRIPTION
adds a method that returns the abi encoded operator table bytes to be compatible with generation protocol

