### PR TITLE
fix: remove stale stakes flag

### DIFF
--- a/docs/BLSSignatureChecker.md
+++ b/docs/BLSSignatureChecker.md
@@ -90,7 +90,6 @@ This method performs the following steps. Note that each step involves lookups o
     * `quorumNumbers` MUST be an ordered list of valid, initialized quorums
     * `params.nonSignerPubkeys` MUST ONLY contain unique pubkeys, in ascending order of their pubkey hash
 * For each quorum:
-    * If stale stakes are forbidden (see [`BLSSignatureChecker.setStaleStakesForbidden`](#blssignaturecheckersetstalestakesforbidden)), check the last `quorumUpdateBlockNumber` is within `DelegationManager.minWithdrawalDelayBlocks` of `referenceBlockNumber`. This references a value in the EigenLayer core contracts - see [EigenLayer core docs][core-docs-dev] for more info.
     * Validate that each `params.quorumApks` corresponds to the quorum's apk at the `referenceBlockNumber`
 * For each historical state lookup, the `referenceBlockNumber` and provided index MUST point to a valid historical entry: 
     * `referenceBlockNumber` MUST come after the entry's `updateBlockNumber`
@@ -173,27 +172,3 @@ For each quorum, this returns:
 * `uint32[] quorumApkIndices`: The indices in `BLSApkRegistry.apkHistory` where the quorum's apk can be found at `referenceBlockNumber`. Length is equal to the number of quorums in `quorumNumbers`.
 * `uint32[] totalStakeIndices`: The indices in `StakeRegistry._totalStakeHistory` where each quorum's total stake can be found at `referenceBlockNumber`. Length is equal to the number of quorums in `quorumNumbers`.
 * `uint32[][] nonSignerStakeIndices`: For each quorum, a list of the indices of each nonsigner's `StakeRegistry.operatorStakeHistory` entry at `referenceBlockNumber`. Length is equal to the number of quorums in `quorumNumbers`, and each sub-list is equal in length to the number of nonsigners in `nonSignerOperatorIds` registered for that quorum at `referenceBlockNumber`
-
----
-
-### System Configuration
-
-#### `BLSSignatureChecker.setStaleStakesForbidden`
-
-```solidity
-function setStaleStakesForbidden(
-    bool value
-) 
-    external 
-    onlyCoordinatorOwner
-```
-
-This method allows the `RegistryCoordinator` Owner to update `staleStakesForbidden` in the `BLSSignatureChecker`. If stale stakes are forbidden, `BLSSignatureChecker.checkSignatures` will perform an additional check when querying each quorum's apk, Operator stakes, and total stakes.
-
-This additional check requires that each quorum was updated within a certain block window of the `referenceBlockNumber` passed into `BLSSignatureChecker.checkSignatures`.
-
-*Effects*:
-* Sets `staleStakesForbidden` to `value`
-
-*Requirements*:
-* Caller MUST be the `RegistryCoordinator` Owner

--- a/src/BLSSignatureChecker.sol
+++ b/src/BLSSignatureChecker.sol
@@ -33,15 +33,6 @@ contract BLSSignatureChecker is BLSSignatureCheckerStorage {
         ISlashingRegistryCoordinator _registryCoordinator
     ) BLSSignatureCheckerStorage(_registryCoordinator) {}
 
-    /// ACTIONS
-
-    /// @inheritdoc IBLSSignatureChecker
-    function setStaleStakesForbidden(
-        bool value
-    ) external onlyCoordinatorOwner {
-        _setStaleStakesForbidden(value);
-    }
-
     /// VIEW
 
     /// @inheritdoc IBLSSignatureChecker
@@ -138,21 +129,7 @@ contract BLSSignatureChecker is BLSSignatureCheckerStorage {
          * - subtract the stake for each nonsigner to calculate the stake belonging to signers
          */
         {
-            bool _staleStakesForbidden = staleStakesForbidden;
-            uint256 withdrawalDelayBlocks =
-                _staleStakesForbidden ? delegation.minWithdrawalDelayBlocks() : 0;
-
             for (uint256 i = 0; i < quorumNumbers.length; i++) {
-                // If we're disallowing stale stake updates, check that each quorum's last update block
-                // is within withdrawalDelayBlocks
-                if (_staleStakesForbidden) {
-                    require(
-                        registryCoordinator.quorumUpdateBlockNumber(uint8(quorumNumbers[i]))
-                            + withdrawalDelayBlocks > referenceBlockNumber,
-                        StaleStakesForbidden()
-                    );
-                }
-
                 // Validate params.quorumApks is correct for this quorum at the referenceBlockNumber,
                 // then add it to the total apk
                 require(
@@ -243,12 +220,5 @@ contract BLSSignatureChecker is BLSSignatureCheckerStorage {
             apkG2,
             PAIRING_EQUALITY_CHECK_GAS
         );
-    }
-
-    function _setStaleStakesForbidden(
-        bool value
-    ) internal {
-        staleStakesForbidden = value;
-        emit StaleStakesForbiddenUpdate(value);
     }
 }

--- a/src/BLSSignatureCheckerStorage.sol
+++ b/src/BLSSignatureCheckerStorage.sol
@@ -21,8 +21,8 @@ abstract contract BLSSignatureCheckerStorage is IBLSSignatureChecker {
 
     /// STATE
 
-    /// @inheritdoc IBLSSignatureChecker
-    bool public staleStakesForbidden;
+    /// @dev Deprecated storage for the staleStakesForbidden flag.
+    bool internal __deprecated_staleStakesForbidden;
 
     constructor(
         ISlashingRegistryCoordinator _registryCoordinator

--- a/src/interfaces/IBLSSignatureChecker.sol
+++ b/src/interfaces/IBLSSignatureChecker.sol
@@ -20,8 +20,6 @@ interface IBLSSignatureCheckerErrors {
     error InvalidReferenceBlocknumber();
     /// @notice Thrown when the non signer pubkeys are not sorted.
     error NonSignerPubkeysNotSorted();
-    /// @notice Thrown when StakeRegistry updates have not been updated within withdrawalDelayBlocks window
-    error StaleStakesForbidden();
     /// @notice Thrown when the quorum apk hash in storage does not match provided quorum apk.
     error InvalidQuorumApkHash();
     /// @notice Thrown when BLS pairing precompile call fails.
@@ -70,12 +68,7 @@ interface IBLSSignatureCheckerTypes {
     }
 }
 
-interface IBLSSignatureCheckerEvents is IBLSSignatureCheckerTypes {
-    /// @notice Emitted when `staleStakesForbiddenUpdate` is set.
-    event StaleStakesForbiddenUpdate(bool value);
-}
-
-interface IBLSSignatureChecker is IBLSSignatureCheckerErrors, IBLSSignatureCheckerEvents {
+interface IBLSSignatureChecker is IBLSSignatureCheckerErrors, IBLSSignatureCheckerTypes {
     /* STATE */
 
     /*
@@ -105,23 +98,6 @@ interface IBLSSignatureChecker is IBLSSignatureCheckerErrors, IBLSSignatureCheck
      * @dev This value is immutable and set during contract construction.
      */
     function delegation() external view returns (IDelegationManager);
-
-    /*
-     * @notice Returns whether stale stakes are forbidden in signature verification.
-     * @return True if stale stakes are forbidden, false otherwise.
-     */
-    function staleStakesForbidden() external view returns (bool);
-
-    /* ACTIONS */
-
-    /*
-     * @notice Sets `value` as the new staleStakesForbidden flag.
-     * @param value True to forbid stale stakes, false to allow them.
-     * @dev Access restricted to the registry coordinator owner.
-     */
-    function setStaleStakesForbidden(
-        bool value
-    ) external;
 
     /* VIEW */
 

--- a/test/unit/BLSSignatureCheckerUnit.t.sol
+++ b/test/unit/BLSSignatureCheckerUnit.t.sol
@@ -16,32 +16,10 @@ contract BLSSignatureCheckerUnitTests is BLSMockAVSDeployer {
 
     BLSSignatureChecker blsSignatureChecker;
 
-    event StaleStakesForbiddenUpdate(bool value);
-
     function setUp() public virtual {
         _setUpBLSMockAVSDeployer();
 
         blsSignatureChecker = new BLSSignatureChecker(registryCoordinator);
-    }
-
-    function test_setStaleStakesForbidden_revert_notRegCoordOwner() public {
-        cheats.expectRevert(IBLSSignatureCheckerErrors.OnlyRegistryCoordinatorOwner.selector);
-        blsSignatureChecker.setStaleStakesForbidden(true);
-    }
-
-    function test_setStaleStakesForbidden() public {
-        testFuzz_setStaleStakesForbidden(false);
-        testFuzz_setStaleStakesForbidden(true);
-    }
-
-    function testFuzz_setStaleStakesForbidden(
-        bool newState
-    ) public {
-        cheats.expectEmit(true, true, true, true, address(blsSignatureChecker));
-        emit StaleStakesForbiddenUpdate(newState);
-        cheats.prank(registryCoordinatorOwner);
-        blsSignatureChecker.setStaleStakesForbidden(newState);
-        assertEq(blsSignatureChecker.staleStakesForbidden(), newState, "state not set correctly");
     }
 
     // this test checks that a valid signature from maxOperatorsToRegister with a random number of nonsigners is checked
@@ -335,52 +313,6 @@ contract BLSSignatureCheckerUnitTests is BLSMockAVSDeployer {
             nonSignerStakesAndSignature.nonSignerPubkeys[0]
         );
         cheats.expectRevert(IBLSSignatureCheckerErrors.NonSignerPubkeysNotSorted.selector);
-        blsSignatureChecker.checkSignatures(
-            msgHash, quorumNumbers, referenceBlockNumber, nonSignerStakesAndSignature
-        );
-    }
-
-    function test_checkSignatures_revert_staleStakes() public {
-        uint256 numNonSigners = 2;
-        uint256 quorumBitmap = 1;
-        uint256 nonRandomNumber = 777;
-        bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(quorumBitmap);
-
-        (
-            uint32 referenceBlockNumber,
-            BLSSignatureChecker.NonSignerStakesAndSignature memory nonSignerStakesAndSignature
-        ) = _registerSignatoriesAndGetNonSignerStakeAndSignatureRandom(
-            nonRandomNumber, numNonSigners, quorumBitmap
-        );
-
-        // make sure the `staleStakesForbidden` flag is set to 'true'
-        testFuzz_setStaleStakesForbidden(true);
-
-        uint256 stalestUpdateBlock = type(uint256).max;
-        for (uint256 i = 0; i < quorumNumbers.length; ++i) {
-            uint256 quorumUpdateBlockNumber =
-                registryCoordinator.quorumUpdateBlockNumber(uint8(quorumNumbers[i]));
-            if (quorumUpdateBlockNumber < stalestUpdateBlock) {
-                stalestUpdateBlock = quorumUpdateBlockNumber;
-            }
-        }
-
-        // move referenceBlockNumber forward to a block number the last block number where the stakes will be considered "not stale"
-        referenceBlockNumber =
-            uint32(stalestUpdateBlock + delegationMock.minWithdrawalDelayBlocks()) - 1;
-        // roll forward to make the reference block number valid
-        // we roll to referenceBlockNumber + 1 because the current block number is not a valid reference block
-
-        cheats.roll(referenceBlockNumber + 1);
-        blsSignatureChecker.checkSignatures(
-            msgHash, quorumNumbers, referenceBlockNumber, nonSignerStakesAndSignature
-        );
-
-        // move referenceBlockNumber forward one more block, making the stakes "stale"
-        referenceBlockNumber += 1;
-        // roll forward to reference + 1 to ensure the referenceBlockNumber is still valid
-        cheats.roll(referenceBlockNumber + 1);
-        cheats.expectRevert(IBLSSignatureCheckerErrors.StaleStakesForbidden.selector);
         blsSignatureChecker.checkSignatures(
             msgHash, quorumNumbers, referenceBlockNumber, nonSignerStakesAndSignature
         );


### PR DESCRIPTION
**Motivation:**

The stale stakes flag is buggy since it doesn't properly get the `quorumUpdateBlockNumber` in the given range. The fix is to add checkpointed storage for the latest quorum update block number. Since we are moving towards a cert-verifier world, it's simpler to remove this feature rather than ship checkpointed storage OR broken code. 

**Modifications:**

Removed `staleStakesForbidden`. 

**Result:**

Cleaner code