### PR TITLE
chore(index-registry): add QuorumAlreadyExists error

### DIFF
--- a/src/IndexRegistry.sol
+++ b/src/IndexRegistry.sol
@@ -89,7 +89,7 @@ contract IndexRegistry is IndexRegistryStorage {
     function initializeQuorum(
         uint8 quorumNumber
     ) public virtual onlyRegistryCoordinator {
-        require(_operatorCountHistory[quorumNumber].length == 0, QuorumDoesNotExist());
+        require(_operatorCountHistory[quorumNumber].length == 0, QuorumAlreadyExists());
 
         _operatorCountHistory[quorumNumber].push(
             QuorumUpdate({numOperators: 0, fromBlockNumber: uint32(block.number)})

--- a/src/interfaces/IIndexRegistry.sol
+++ b/src/interfaces/IIndexRegistry.sol
@@ -6,6 +6,8 @@ interface IIndexRegistryErrors {
     error OnlyRegistryCoordinator();
     /// @notice Thrown when attempting to query a quorum that has no history.
     error QuorumDoesNotExist();
+    /// @notice Thrown when attempting to initialize a quorum that already exists.
+    error QuorumAlreadyExists();
     /// @notice Thrown when attempting to look up an operator that does not exist at the specified block number.
     error OperatorIdDoesNotExist();
 }


### PR DESCRIPTION
**Motivation:**

The existing logic used the QuorumDoesNotExist error even in the case when a quorum already existed. This was misleading and did not properly reflect the error scenario. Accurate error handling is essential for debugging and for ensuring clarity during interactions with the contract.

**Modifications:**
* Introduced a new custom error QuorumAlreadyExists in the IndexRegistryErrors interface.
* Updated the initializeQuorum function in IndexRegistry to use the new QuorumAlreadyExists error when a quorum is already initialized.

**Result:**
* The error handling logic is now more precise.
* Developers and users will get clearer feedback when attempting to initialize an already existing quorum.
