### PR TITLE
feat: add table calculators 

### DIFF
--- a/src/interfaces/IBN254TableCalculator.sol
+++ b/src/interfaces/IBN254TableCalculator.sol
@@ -2,7 +2,10 @@
 pragma solidity >=0.5.0;
 
 import {OperatorSet} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
-import {IOperatorTableCalculator, IOperatorTableCalculatorTypes} from "eigenlayer-contracts/src/contracts/interfaces/IOperatorTableCalculator.sol";
+import {
+    IOperatorTableCalculator,
+    IOperatorTableCalculatorTypes
+} from "eigenlayer-contracts/src/contracts/interfaces/IOperatorTableCalculator.sol";
 
 interface IBN254TableCalculator is IOperatorTableCalculator, IOperatorTableCalculatorTypes {
     /**

--- a/src/interfaces/IBN254TableCalculator.sol
+++ b/src/interfaces/IBN254TableCalculator.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.5.0;
+
+import {OperatorSet} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+import {IOperatorTableCalculator, IOperatorTableCalculatorTypes} from "eigenlayer-contracts/src/contracts/interfaces/IOperatorTableCalculator.sol";
+
+interface IBN254TableCalculator is IOperatorTableCalculator, IOperatorTableCalculatorTypes {
+    /**
+     * @notice calculates the operatorInfos for a given operatorSet
+     * @param operatorSet the operatorSet to calculate the operator table for
+     * @return operatorSetInfo the operatorSetInfo for the given operatorSet
+     * @dev The output of this function is converted to bytes via the `calculateOperatorTableBytes` function
+     */
+    function calculateOperatorTable(
+        OperatorSet calldata operatorSet
+    ) external view returns (BN254OperatorSetInfo memory operatorSetInfo);
+
+    /**
+     * @notice Get the operatorInfos for a given operatorSet
+     * @param operatorSet the operatorSet to get the operatorInfos for
+     * @return operatorInfos the operatorInfos for the given operatorSet
+     */
+    function getOperatorInfos(
+        OperatorSet calldata operatorSet
+    ) external view returns (BN254OperatorInfo[] memory operatorInfos);
+}

--- a/src/interfaces/IECDSATableCalculator.sol
+++ b/src/interfaces/IECDSATableCalculator.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.5.0;
+
+import {OperatorSet} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+import {IOperatorTableCalculator, IOperatorTableCalculatorTypes} from "eigenlayer-contracts/src/contracts/interfaces/IOperatorTableCalculator.sol";
+
+
+interface IECDSATableCalculator is
+    IOperatorTableCalculator,
+    IOperatorTableCalculatorTypes
+{
+    /**
+     * @notice calculates the operatorInfos for a given operatorSet
+     * @param operatorSet the operatorSet to calculate the operator table for
+     * @return operatorInfos the list of operatorInfos for the given operatorSet
+     * @dev The output of this function is converted to bytes via the `calculateOperatorTableBytes` function
+     */
+    function calculateOperatorTable(
+        OperatorSet calldata operatorSet
+    ) external view returns (ECDSAOperatorInfo[] memory operatorInfos);
+}

--- a/src/interfaces/IECDSATableCalculator.sol
+++ b/src/interfaces/IECDSATableCalculator.sol
@@ -2,13 +2,12 @@
 pragma solidity >=0.5.0;
 
 import {OperatorSet} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
-import {IOperatorTableCalculator, IOperatorTableCalculatorTypes} from "eigenlayer-contracts/src/contracts/interfaces/IOperatorTableCalculator.sol";
-
-
-interface IECDSATableCalculator is
+import {
     IOperatorTableCalculator,
     IOperatorTableCalculatorTypes
-{
+} from "eigenlayer-contracts/src/contracts/interfaces/IOperatorTableCalculator.sol";
+
+interface IECDSATableCalculator is IOperatorTableCalculator, IOperatorTableCalculatorTypes {
     /**
      * @notice calculates the operatorInfos for a given operatorSet
      * @param operatorSet the operatorSet to calculate the operator table for

--- a/src/middlewareV2/tableCalculator/BN254TableCalculator.sol
+++ b/src/middlewareV2/tableCalculator/BN254TableCalculator.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {OperatorSet} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+import {IAllocationManager} from
+    "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
+import {IKeyRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
+
+import "./BN254TableCalculatorBase.sol";
+
+/**
+ * @title BN254TableCalculator
+ * @notice Implementation that calculates BN254 operator tables using the sum of the minimum slashable stake weights
+ */
+contract BN254TableCalculator is BN254TableCalculatorBase {
+    // Immutables
+    /// @notice AllocationManager contract for managing operator allocations
+    IAllocationManager public immutable allocationManager;
+    /// @notice The default lookahead blocks for the slashable stake lookup
+    uint256 public immutable LOOKAHEAD_BLOCKS;
+
+    constructor(
+        IKeyRegistrar _keyRegistrar,
+        IAllocationManager _allocationManager,
+        uint256 _LOOKAHEAD_BLOCKS
+    ) BN254TableCalculatorBase(_keyRegistrar) {
+        allocationManager = _allocationManager;
+        LOOKAHEAD_BLOCKS = _LOOKAHEAD_BLOCKS;
+    }
+
+    /**
+     * @notice Get the operator weights for a given operatorSet based on the slashable stake.
+     * @param operatorSet The operatorSet to get the weights for
+     * @return operators The addresses of the operators in the operatorSet
+     * @return weights The weights for each operator in the operatorSet, this is a 2D array where the first index is the operator
+     * and the second index is the type of weight. In this case its of length 1 and returns the slashable stake for the operatorSet.
+     */
+    function _getOperatorWeights(
+        OperatorSet calldata operatorSet
+    ) internal view override returns (address[] memory operators, uint256[][] memory weights) {
+        // Get all operators & strategies in the operatorSet
+        address[] memory registeredOperators = allocationManager.getMembers(operatorSet);
+        IStrategy[] memory strategies = allocationManager.getStrategiesInOperatorSet(operatorSet);
+
+        // Get the minimum slashable stake for each operator
+        uint256[][] memory minSlashableStake = allocationManager.getMinimumSlashableStake({
+            operatorSet: operatorSet,
+            operators: registeredOperators,
+            strategies: strategies,
+            futureBlock: uint32(block.number + LOOKAHEAD_BLOCKS)
+        });
+
+        operators = new address[](registeredOperators.length);
+        weights = new uint256[][](registeredOperators.length);
+        uint256 operatorCount = 0;
+        for (uint256 i = 0; i < registeredOperators.length; ++i) {
+            // For the given operator, loop through the strategies and sum together to calculate the operator's weight for the operatorSet
+            uint256 totalWeight;
+            for (uint256 stratIndex = 0; stratIndex < strategies.length; ++stratIndex) {
+                totalWeight += minSlashableStake[i][stratIndex];
+            }
+
+            // If the operator has nonzero slashable stake, add them to the operators array
+            if (totalWeight > 0) {
+                // Initialize operator weights array of length 1 just for slashable stake
+                weights[operatorCount] = new uint256[](1);
+                weights[operatorCount][0] = totalWeight;
+
+                // Add the operator to the operators array
+                operators[operatorCount] = registeredOperators[i];
+                operatorCount++;
+            }
+        }
+
+        // Resize arrays to be the size of the number of operators with nonzero slashable stake
+        assembly {
+            mstore(operators, operatorCount)
+            mstore(weights, operatorCount)
+        }
+
+        return (operators, weights);
+    }
+}

--- a/src/middlewareV2/tableCalculator/BN254TableCalculatorBase.sol
+++ b/src/middlewareV2/tableCalculator/BN254TableCalculatorBase.sol
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {OperatorSet} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+import {IOperatorTableCalculator} from
+    "eigenlayer-contracts/src/contracts/interfaces/IOperatorTableCalculator.sol";
+import {IKeyRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
+import {Merkle} from "eigenlayer-contracts/src/contracts/libraries/Merkle.sol";
+import {BN254} from "eigenlayer-contracts/src/contracts/libraries/BN254.sol";
+import {IBN254TableCalculator} from "../../interfaces/IBN254TableCalculator.sol";
+
+/**
+ * @title BN254TableCalculatorBase
+ * @notice Abstract contract that provides base functionality for calculating BN254 operator tables
+ * @dev This contract contains all the core logic for operator table calculations,
+ *      with weight calculation left to be implemented by derived contracts
+ */
+abstract contract BN254TableCalculatorBase is IBN254TableCalculator {
+    using Merkle for bytes32[];
+    using BN254 for BN254.G1Point;
+
+    // Immutables
+    /// @notice KeyRegistrar contract for managing operator keys
+    IKeyRegistrar public immutable keyRegistrar;
+
+    constructor(
+        IKeyRegistrar _keyRegistrar
+    ) {
+        keyRegistrar = _keyRegistrar;
+    }
+
+    /// @inheritdoc IBN254TableCalculator
+    function calculateOperatorTable(
+        OperatorSet calldata operatorSet
+    ) external view virtual returns (BN254OperatorSetInfo memory operatorSetInfo) {
+        return _calculateOperatorTable(operatorSet);
+    }
+
+    /// @inheritdoc IOperatorTableCalculator
+    function calculateOperatorTableBytes(
+        OperatorSet calldata operatorSet
+    ) external view virtual returns (bytes memory operatorTableBytes) {
+        return abi.encode(_calculateOperatorTable(operatorSet));
+    }
+
+    /// @inheritdoc IOperatorTableCalculator
+    function getOperatorWeights(
+        OperatorSet calldata operatorSet
+    ) external view virtual returns (address[] memory operators, uint256[][] memory weights) {
+        return _getOperatorWeights(operatorSet);
+    }
+
+    /// @inheritdoc IOperatorTableCalculator
+    function getOperatorWeight(
+        OperatorSet calldata operatorSet,
+        address operator
+    ) external view virtual returns (uint256 weight) {
+        (address[] memory operators, uint256[][] memory weights) = _getOperatorWeights(operatorSet);
+
+        // Find the index of the operator in the operators array
+        for (uint256 i = 0; i < operators.length; i++) {
+            if (operators[i] == operator) {
+                return weights[i][0];
+            }
+        }
+
+        return 0;
+    }
+
+    /// @inheritdoc IBN254TableCalculator
+    function getOperatorInfos(
+        OperatorSet calldata operatorSet
+    ) external view virtual returns (BN254OperatorInfo[] memory) {
+        // Get the weights for all operators
+        (address[] memory operators, uint256[][] memory weights) = _getOperatorWeights(operatorSet);
+
+        BN254OperatorInfo[] memory operatorInfos = new BN254OperatorInfo[](operators.length);
+
+        for (uint256 i = 0; i < operators.length; i++) {
+            // Skip if the operator has not registered their key
+            if (!keyRegistrar.isRegistered(operatorSet, operators[i])) {
+                continue;
+            }
+
+            (BN254.G1Point memory g1Point,) = keyRegistrar.getBN254Key(operatorSet, operators[i]);
+            operatorInfos[i] = BN254OperatorInfo({pubkey: g1Point, weights: weights[i]});
+        }
+
+        return operatorInfos;
+    }
+
+    /**
+     * @notice Abstract function to get the operator weights for a given operatorSet
+     * @param operatorSet The operatorSet to get the weights for
+     * @return operators The addresses of the operators in the operatorSet
+     * @return weights The weights for each operator in the operatorSet, this is a 2D array where the first index is the operator
+     * and the second index is the type of weight
+     * @dev Must be implemented by derived contracts to define specific weight calculation logic
+     */
+    function _getOperatorWeights(
+        OperatorSet calldata operatorSet
+    ) internal view virtual returns (address[] memory operators, uint256[][] memory weights);
+
+    /**
+     * @notice Calculates the operator table for a given operatorSet, also calculates the aggregate pubkey for the operatorSet
+     * @param operatorSet The operatorSet to calculate the operator table for
+     * @return operatorSetInfo The operator table for the given operatorSet
+     * @dev This function:
+     * 1. Gets operator weights from the weight calculator
+     * 2. Collates weights into total weights
+     * 3. Creates a merkle tree of operator info
+     *    - assumes that the operator has a registered BN254 key
+     * 4. Calculates the aggregate public key
+     */
+    function _calculateOperatorTable(
+        OperatorSet calldata operatorSet
+    ) internal view returns (BN254OperatorSetInfo memory operatorSetInfo) {
+        // Get the weights for all operators in the operatorSet
+        (address[] memory operators, uint256[][] memory weights) = _getOperatorWeights(operatorSet);
+
+        // If there are no weights, return an empty operator set info
+        if (weights.length == 0) {
+            return BN254OperatorSetInfo({
+                operatorInfoTreeRoot: bytes32(0),
+                numOperators: 0,
+                aggregatePubkey: BN254.G1Point(0, 0),
+                totalWeights: new uint256[](0)
+            });
+        }
+
+        // Initialize arrays
+        uint256 subArrayLength = weights[0].length;
+        uint256[] memory totalWeights = new uint256[](subArrayLength);
+        bytes32[] memory operatorInfoLeaves = new bytes32[](operators.length);
+        BN254.G1Point memory aggregatePubkey;
+        uint256 operatorCount = 0;
+
+        for (uint256 i = 0; i < operators.length; i++) {
+            // Skip if the operator has not registered their key
+            if (!keyRegistrar.isRegistered(operatorSet, operators[i])) {
+                continue;
+            }
+
+            // Read the weights for the operator and encode them into the operatorInfoLeaves
+            // for all weights, add them to the total weights. The ith index returns the weights array for the ith operator
+            for (uint256 j = 0; j < subArrayLength; j++) {
+                totalWeights[j] += weights[i][j];
+            }
+            (BN254.G1Point memory g1Point,) = keyRegistrar.getBN254Key(operatorSet, operators[i]);
+            operatorInfoLeaves[i] =
+                keccak256(abi.encode(BN254OperatorInfo({pubkey: g1Point, weights: weights[i]})));
+
+            // Add the operator's G1 point to the aggregate pubkey
+            aggregatePubkey = aggregatePubkey.plus(g1Point);
+
+            // Increment the operator count
+            operatorCount++;
+        }
+
+        // If there are no operators, return an empty operator set info
+        if (operatorCount == 0) {
+            return BN254OperatorSetInfo({
+                operatorInfoTreeRoot: bytes32(0),
+                numOperators: 0,
+                aggregatePubkey: BN254.G1Point(0, 0),
+                totalWeights: new uint256[](0)
+            });
+        }
+
+        // Resize the operatorInfoLeaves array to the number of operators and merkleize
+        assembly {
+            mstore(operatorInfoLeaves, operatorCount)
+        }
+
+        bytes32 operatorInfoTreeRoot = operatorInfoLeaves.merkleizeKeccak();
+
+        return BN254OperatorSetInfo({
+            operatorInfoTreeRoot: operatorInfoTreeRoot,
+            numOperators: operatorCount,
+            aggregatePubkey: aggregatePubkey,
+            totalWeights: totalWeights
+        });
+    }
+}

--- a/src/middlewareV2/tableCalculator/ECDSATableCalculator.sol
+++ b/src/middlewareV2/tableCalculator/ECDSATableCalculator.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {OperatorSet} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+import {IAllocationManager} from
+    "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
+import {IKeyRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
+
+import "./ECDSATableCalculatorBase.sol";
+
+/**
+ * @title ECDSATableCalculator
+ * @notice Implementation that calculates ECDSA operator tables using the sum of the minimum slashable stake weights
+ */
+contract ECDSATableCalculator is ECDSATableCalculatorBase {
+    // Immutables
+    /// @notice AllocationManager contract for managing operator allocations
+    IAllocationManager public immutable allocationManager;
+    /// @notice The default lookahead blocks for the slashable stake lookup
+    uint256 public immutable LOOKAHEAD_BLOCKS;
+
+    constructor(
+        IKeyRegistrar _keyRegistrar,
+        IAllocationManager _allocationManager,
+        uint256 _LOOKAHEAD_BLOCKS
+    ) ECDSATableCalculatorBase(_keyRegistrar) {
+        allocationManager = _allocationManager;
+        LOOKAHEAD_BLOCKS = _LOOKAHEAD_BLOCKS;
+    }
+
+    /**
+     * @notice Get the operator weights for a given operatorSet based on the slashable stake.
+     * @param operatorSet The operatorSet to get the weights for
+     * @return operators The addresses of the operators in the operatorSet
+     * @return weights The weights for each operator in the operatorSet, this is a 2D array where the first index is the operator
+     * and the second index is the type of weight. In this case its of length 1 and returns the slashable stake for the operatorSet.
+     */
+    function _getOperatorWeights(
+        OperatorSet calldata operatorSet
+    ) internal view override returns (address[] memory operators, uint256[][] memory weights) {
+        // Get all operators & strategies in the operatorSet
+        address[] memory registeredOperators = allocationManager.getMembers(operatorSet);
+        IStrategy[] memory strategies = allocationManager.getStrategiesInOperatorSet(operatorSet);
+
+        // Get the minimum slashable stake for each operator
+        uint256[][] memory minSlashableStake = allocationManager.getMinimumSlashableStake({
+            operatorSet: operatorSet,
+            operators: registeredOperators,
+            strategies: strategies,
+            futureBlock: uint32(block.number + LOOKAHEAD_BLOCKS)
+        });
+
+        operators = new address[](registeredOperators.length);
+        weights = new uint256[][](registeredOperators.length);
+        uint256 operatorCount = 0;
+        for (uint256 i = 0; i < registeredOperators.length; ++i) {
+            // For the given operator, loop through the strategies and sum together to calculate the operator's weight for the operatorSet
+            uint256 totalWeight;
+            for (uint256 stratIndex = 0; stratIndex < strategies.length; ++stratIndex) {
+                totalWeight += minSlashableStake[i][stratIndex];
+            }
+
+            // If the operator has nonzero slashable stake, add them to the operators array
+            if (totalWeight > 0) {
+                // Initialize operator weights array of length 1 just for slashable stake
+                weights[operatorCount] = new uint256[](1);
+                weights[operatorCount][0] = totalWeight;
+
+                // Add the operator to the operators array
+                operators[operatorCount] = registeredOperators[i];
+                operatorCount++;
+            }
+        }
+
+        // Resize arrays to be the size of the number of operators with nonzero slashable stake
+        assembly {
+            mstore(operators, operatorCount)
+            mstore(weights, operatorCount)
+        }
+
+        return (operators, weights);
+    }
+}

--- a/src/middlewareV2/tableCalculator/ECDSATableCalculatorBase.sol
+++ b/src/middlewareV2/tableCalculator/ECDSATableCalculatorBase.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {OperatorSet} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+import {IOperatorTableCalculator} from
+    "eigenlayer-contracts/src/contracts/interfaces/IOperatorTableCalculator.sol";
+import {IKeyRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
+import {Merkle} from "eigenlayer-contracts/src/contracts/libraries/Merkle.sol";
+import {IECDSATableCalculator} from "../../interfaces/IECDSATableCalculator.sol";
+
+/**
+ * @title ECDSATableCalculatorBase
+ * @notice Abstract contract that provides base functionality for calculating ECDSA operator tables
+ * @dev This contract contains all the core logic for operator table calculations,
+ *      with weight calculation left to be implemented by derived contracts
+ */
+abstract contract ECDSATableCalculatorBase is IECDSATableCalculator {
+    using Merkle for bytes32[];
+
+    // Immutables
+    /// @notice KeyRegistrar contract for managing operator keys
+    IKeyRegistrar public immutable keyRegistrar;
+
+    constructor(
+        IKeyRegistrar _keyRegistrar
+    ) {
+        keyRegistrar = _keyRegistrar;
+    }
+
+    /// @inheritdoc IECDSATableCalculator
+    function calculateOperatorTable(
+        OperatorSet calldata operatorSet
+    ) external view virtual returns (ECDSAOperatorInfo[] memory operatorInfos) {
+        return _calculateOperatorTable(operatorSet);
+    }
+
+    /// @inheritdoc IOperatorTableCalculator
+    function calculateOperatorTableBytes(
+        OperatorSet calldata operatorSet
+    ) external view virtual returns (bytes memory operatorTableBytes) {
+        return abi.encode(_calculateOperatorTable(operatorSet));
+    }
+
+    /// @inheritdoc IOperatorTableCalculator
+    function getOperatorWeights(
+        OperatorSet calldata operatorSet
+    ) external view virtual returns (address[] memory operators, uint256[][] memory weights) {
+        return _getOperatorWeights(operatorSet);
+    }
+
+    /// @inheritdoc IOperatorTableCalculator
+    function getOperatorWeight(
+        OperatorSet calldata operatorSet,
+        address operator
+    ) external view virtual returns (uint256 weight) {
+        (address[] memory operators, uint256[][] memory weights) = _getOperatorWeights(operatorSet);
+
+        // Find the index of the operator in the operators array
+        for (uint256 i = 0; i < operators.length; i++) {
+            if (operators[i] == operator) {
+                return weights[i][0];
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * @notice Abstract function to get the operator weights for a given operatorSet
+     * @param operatorSet The operatorSet to get the weights for
+     * @return operators The addresses of the operators in the operatorSet
+     * @return weights The weights for each operator in the operatorSet, this is a 2D array where the first index is the operator
+     * and the second index is the type of weight
+     * @dev Must be implemented by derived contracts to define specific weight calculation logic
+     */
+    function _getOperatorWeights(
+        OperatorSet calldata operatorSet
+    ) internal view virtual returns (address[] memory operators, uint256[][] memory weights);
+
+    /**
+     * @notice Calculates the operator table for a given operatorSet
+     * @param operatorSet The operatorSet to calculate the operator table for
+     * @return operatorInfos The operator table for the given operatorSet
+     * @dev This function:
+     * 1. Gets operator weights from the weight calculator
+     * 2. Creates ECDSAOperatorInfo structs for each operator with registered ECDSA keys
+     */
+    function _calculateOperatorTable(
+        OperatorSet calldata operatorSet
+    ) internal view returns (ECDSAOperatorInfo[] memory operatorInfos) {
+        // Get the weights for all operators in the operatorSet
+        (address[] memory operators, uint256[][] memory weights) = _getOperatorWeights(operatorSet);
+
+        // If there are no weights, return an empty array
+        if (weights.length == 0) {
+            return new ECDSAOperatorInfo[](0);
+        }
+
+        // Create the operator infos array with maximum possible size
+        operatorInfos = new ECDSAOperatorInfo[](operators.length);
+        uint256 operatorCount = 0;
+
+        for (uint256 i = 0; i < operators.length; i++) {
+            // Skip if the operator has not registered their ECDSA key
+            if (!keyRegistrar.isRegistered(operatorSet, operators[i])) {
+                continue;
+            }
+
+            // Get the ECDSA address (public key) for the operator
+            address ecdsaAddress = keyRegistrar.getECDSAAddress(operatorSet, operators[i]);
+
+            // Create the ECDSAOperatorInfo struct
+            operatorInfos[operatorCount] =
+                ECDSAOperatorInfo({pubkey: ecdsaAddress, weights: weights[i]});
+
+            operatorCount++;
+        }
+
+        // If no operators have registered keys, return empty array
+        if (operatorCount == 0) {
+            return new ECDSAOperatorInfo[](0);
+        }
+
+        // Resize the array to the actual number of operators with registered keys
+        assembly {
+            mstore(operatorInfos, operatorCount)
+        }
+
+        return operatorInfos;
+    }
+}

--- a/test/tree/BN254TableCalculatorBase.tree
+++ b/test/tree/BN254TableCalculatorBase.tree
@@ -1,0 +1,31 @@
+.
+└── BN254TableCalculatorBase (**** denotes that integration tests are needed to fully validate path)
+    ├── when calculateOperatorTable is called
+    │   ├── given that there are no operators
+    │   │   └── it should return empty operator table with zero aggregate pubkey
+    │   ├── given that operators have no registered BN254 keys
+    │   │   └── it should skip those operators and return table without them
+    │   ├── given that all operators have registered BN254 keys
+    │   │   └── it should include all operators in the table and calculate aggregate pubkey
+    │   ├── given that weights array has multiple weight types
+    │   │   └── it should correctly sum all weight types in totalWeights
+    │   └── given that operators have mixed registration status
+    │       └── it should only include registered operators in calculations
+    ├── when calculateOperatorTableBytes is called
+    │   └── it should return the encoded bytes of the operator table
+    ├── when getOperatorWeights is called
+    │   └── it should return the result from _getOperatorWeights implementation
+    ├── when getOperatorWeight is called
+    │   ├── given that the operator exists in the set
+    │   │   └── it should return the first weight value for that operator
+    │   ├── given that the operator does not exist in the set
+    │   │   └── it should return zero
+    │   └── given that the operator exists but has empty weights
+    │       └── it should handle gracefully ****
+    └── when getOperatorInfos is called
+        ├── given that no operators are registered
+        │   └── it should return array with empty operator infos
+        ├── given that some operators are not registered
+        │   └── it should skip unregistered operators (leaving empty slots)
+        └── given that all operators are registered
+            └── it should return complete operator info for each operator 

--- a/test/tree/ECDSATableCalculatorBase.tree
+++ b/test/tree/ECDSATableCalculatorBase.tree
@@ -1,0 +1,34 @@
+.
+└── ECDSATableCalculatorBase (**** denotes that integration tests are needed to fully validate path)
+    ├── when calculateOperatorTable is called
+    │   ├── given that no operators are in the set
+    │   │   └── it should return empty operator info array
+    │   ├── given that operators exist but none have registered keys
+    │   │   └── it should return empty operator info array  
+    │   ├── given that all operators have registered keys
+    │   │   └── it should return operator infos with correct pubkeys and weights
+    │   ├── given that operators have multiple weight types
+    │   │   └── it should return operator infos with all weight types correctly
+    │   ├── given that some operators have registered keys and some have not
+    │   │   └── it should only include registered operators in the result
+    │   └── given that a single operator is registered
+    │       └── it should return single operator info with correct data
+    ├── when calculateOperatorTableBytes is called
+    │   ├── given valid operator set with registered operators
+    │   │   └── it should encode operator infos correctly as bytes
+    │   └── given various weight values (fuzz test)
+    │       └── it should encode and decode weights correctly
+    ├── when getOperatorWeights is called
+    │   ├── given operators and weights are set
+    │   │   └── it should return the implementation result correctly
+    │   └── given various numbers of operators (fuzz test)
+    │       └── it should return correct operator and weight arrays
+    └── when getOperatorWeight is called
+        ├── given that the operator exists in the set
+        │   └── it should return the correct weight
+        ├── given that the operator does not exist in the set
+        │   └── it should return 0
+        ├── given that the operator set is empty
+        │   └── it should return 0
+        └── given various operator and weight combinations (fuzz test)
+            └── it should return correct weight or 0 

--- a/test/unit/middlewareV2/BN254TableCalculatorBaseUnit.t.sol
+++ b/test/unit/middlewareV2/BN254TableCalculatorBaseUnit.t.sol
@@ -1,0 +1,693 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {KeyRegistrar, IKeyRegistrarTypes} from "eigenlayer-contracts/src/contracts/permissions/KeyRegistrar.sol";
+import {IKeyRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
+import {IOperatorTableCalculatorTypes} from "eigenlayer-contracts/src/contracts/interfaces/IOperatorTableCalculator.sol";
+import {IBN254TableCalculator} from "../../../src/interfaces/IBN254TableCalculator.sol";
+import {
+    OperatorSet,
+    OperatorSetLib
+} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+import {BN254} from "eigenlayer-contracts/src/contracts/libraries/BN254.sol";
+
+import {BN254TableCalculatorBase} from "../../../src/middlewareV2/tableCalculator/BN254TableCalculatorBase.sol";
+import {MockEigenLayerDeployer} from "./MockDeployer.sol";
+import "test/utils/Random.sol";
+
+// Mock implementation for testing abstract contract
+contract BN254TableCalculatorBaseHarness is BN254TableCalculatorBase {
+    // Storage for mock weights
+    mapping(bytes32 => address[]) internal _mockOperators;
+    mapping(bytes32 => uint[][]) internal _mockWeights;
+
+    constructor(IKeyRegistrar _keyRegistrar) BN254TableCalculatorBase(_keyRegistrar) {}
+
+    function setMockOperatorWeights(OperatorSet calldata operatorSet, address[] memory operators, uint[][] memory weights) external {
+        bytes32 key = operatorSet.key();
+        _mockOperators[key] = operators;
+        _mockWeights[key] = weights;
+    }
+
+    function _getOperatorWeights(OperatorSet calldata operatorSet)
+        internal
+        view
+        override
+        returns (address[] memory operators, uint[][] memory weights)
+    {
+        bytes32 key = operatorSet.key();
+        operators = _mockOperators[key];
+        weights = _mockWeights[key];
+    }
+}
+
+/**
+ * @title BN254TableCalculatorBaseUnitTests
+ * @notice Base contract for all BN254TableCalculatorBase unit tests
+ */
+contract BN254TableCalculatorBaseUnitTests is MockEigenLayerDeployer, IOperatorTableCalculatorTypes, IKeyRegistrarTypes {
+    using BN254 for BN254.G1Point;
+    using OperatorSetLib for OperatorSet;
+
+    // Test contracts
+    BN254TableCalculatorBaseHarness public calculator;
+
+    // Test addresses
+    address public avs1 = address(0x1);
+    address public avs2 = address(0x2);
+    address public operator1 = address(0x3);
+    address public operator2 = address(0x4);
+    address public operator3 = address(0x5);
+
+    // Test operator sets
+    OperatorSet defaultOperatorSet;
+    OperatorSet alternativeOperatorSet;
+
+    // BN254 test keys
+    uint constant BN254_PRIV_KEY_1 = 69;
+    uint constant BN254_PRIV_KEY_2 = 123;
+    uint constant BN254_PRIV_KEY_3 = 456;
+
+    BN254.G1Point bn254G1Key1;
+    BN254.G1Point bn254G1Key2;
+    BN254.G1Point bn254G1Key3;
+    BN254.G2Point bn254G2Key1;
+    BN254.G2Point bn254G2Key2;
+    BN254.G2Point bn254G2Key3;
+
+    function setUp() public virtual {
+        _deployMockEigenLayer();
+
+        // Deploy calculator with KeyRegistrar
+        calculator = new BN254TableCalculatorBaseHarness(IKeyRegistrar(address(keyRegistrar)));
+
+        // Set up operator sets
+        defaultOperatorSet = OperatorSet({avs: avs1, id: 0});
+        alternativeOperatorSet = OperatorSet({avs: avs2, id: 1});
+
+        // Set up BN254 keys
+        bn254G1Key1 = BN254.generatorG1().scalar_mul(BN254_PRIV_KEY_1);
+        bn254G1Key2 = BN254.generatorG1().scalar_mul(BN254_PRIV_KEY_2);
+
+        // Valid G2 points that correspond to the private keys
+        bn254G2Key1.X[1] = 19_101_821_850_089_705_274_637_533_855_249_918_363_070_101_489_527_618_151_493_230_256_975_900_223_847;
+        bn254G2Key1.X[0] = 5_334_410_886_741_819_556_325_359_147_377_682_006_012_228_123_419_628_681_352_847_439_302_316_235_957;
+        bn254G2Key1.Y[1] = 354_176_189_041_917_478_648_604_979_334_478_067_325_821_134_838_555_150_300_539_079_146_482_658_331;
+        bn254G2Key1.Y[0] = 4_185_483_097_059_047_421_902_184_823_581_361_466_320_657_066_600_218_863_748_375_739_772_335_928_910;
+
+        bn254G2Key2.X[1] = 19_276_105_129_625_393_659_655_050_515_259_006_463_014_579_919_681_138_299_520_812_914_148_935_621_072;
+        bn254G2Key2.X[0] = 14_066_454_060_412_929_535_985_836_631_817_650_877_381_034_334_390_275_410_072_431_082_437_297_539_867;
+        bn254G2Key2.Y[1] = 12_642_665_914_920_339_463_975_152_321_804_664_028_480_770_144_655_934_937_445_922_690_262_428_344_269;
+        bn254G2Key2.Y[0] = 10_109_651_107_942_685_361_120_988_628_892_759_706_059_655_669_161_016_107_907_096_760_613_704_453_218;
+
+        // Configure operator sets in AllocationManager
+        allocationManagerMock.setAVSRegistrar(avs1, avs1);
+        allocationManagerMock.setAVSRegistrar(avs2, avs2);
+
+        // Configure operator sets for BN254
+        vm.prank(avs1);
+        keyRegistrar.configureOperatorSet(defaultOperatorSet, IKeyRegistrarTypes.CurveType.BN254);
+
+        vm.prank(avs2);
+        keyRegistrar.configureOperatorSet(alternativeOperatorSet, IKeyRegistrarTypes.CurveType.BN254);
+    }
+
+    // Helper functions
+    function _registerOperatorKey(
+        address operator,
+        OperatorSet memory operatorSet,
+        BN254.G1Point memory g1Key,
+        BN254.G2Point memory g2Key,
+        uint privKey
+    ) internal {
+        bytes memory pubkey = abi.encode(g1Key.X, g1Key.Y, g2Key.X, g2Key.Y);
+        bytes memory signature = _generateBN254Signature(operator, operatorSet, pubkey, privKey);
+
+        vm.prank(operator);
+        keyRegistrar.registerKey(operator, operatorSet, pubkey, signature);
+    }
+
+    function _generateBN254Signature(address operator, OperatorSet memory operatorSet, bytes memory pubkey, uint privKey)
+        internal
+        view
+        returns (bytes memory)
+    {
+        bytes32 structHash = keccak256(
+            abi.encode(keyRegistrar.BN254_KEY_REGISTRATION_TYPEHASH(), operator, operatorSet.avs, operatorSet.id, keccak256(pubkey))
+        );
+        bytes32 messageHash = keyRegistrar.domainSeparator();
+        messageHash = keccak256(abi.encodePacked("\x19\x01", messageHash, structHash));
+
+        BN254.G1Point memory msgPoint = BN254.hashToG1(messageHash);
+        BN254.G1Point memory signature = msgPoint.scalar_mul(privKey);
+
+        return abi.encode(signature.X, signature.Y);
+    }
+
+    function _createSingleWeightArray(uint weight) internal pure returns (uint[][] memory) {
+        uint[][] memory weights = new uint[][](1);
+        weights[0] = new uint[](1);
+        weights[0][0] = weight;
+        return weights;
+    }
+
+    function _createMultiWeightArray(uint[] memory weightValues) internal pure returns (uint[][] memory) {
+        uint[][] memory weights = new uint[][](1);
+        weights[0] = weightValues;
+        return weights;
+    }
+
+    function _addG1Points(BN254.G1Point memory p1, BN254.G1Point memory p2) internal view returns (BN254.G1Point memory) {
+        if (p1.X == 0 && p1.Y == 0) return p2;
+        if (p2.X == 0 && p2.Y == 0) return p1;
+        return BN254.plus(p1, p2);
+    }
+}
+
+/**
+ * @title BN254TableCalculatorBaseUnitTests_calculateOperatorTable
+ * @notice Unit tests for BN254TableCalculatorBase.calculateOperatorTable
+ */
+contract BN254TableCalculatorBaseUnitTests_calculateOperatorTable is BN254TableCalculatorBaseUnitTests {
+    function test_noOperators() public {
+        // Set empty operators and weights
+        address[] memory operators = new address[](0);
+        uint[][] memory weights = new uint[][](0);
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        BN254OperatorSetInfo memory info = calculator.calculateOperatorTable(defaultOperatorSet);
+
+        assertEq(info.numOperators, 0, "Should have 0 operators");
+        assertEq(info.totalWeights.length, 0, "Should have empty total weights");
+        assertEq(info.aggregatePubkey.X, 0, "Aggregate pubkey X should be 0");
+        assertEq(info.aggregatePubkey.Y, 0, "Aggregate pubkey Y should be 0");
+    }
+
+    function test_operatorsWithNoRegisteredKeys() public {
+        // Set operators without registering their keys
+        address[] memory operators = new address[](2);
+        operators[0] = operator1;
+        operators[1] = operator2;
+
+        uint[][] memory weights = new uint[][](2);
+        weights[0] = _createSingleWeightArray(100)[0];
+        weights[1] = _createSingleWeightArray(200)[0];
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        BN254OperatorSetInfo memory info = calculator.calculateOperatorTable(defaultOperatorSet);
+
+        // When no operators have registered keys, operatorCount should be 0 and return empty table
+        assertEq(info.numOperators, 0, "Should have 0 operators when none are registered");
+        assertEq(info.totalWeights.length, 0, "Should have empty total weights when no operators registered");
+        assertEq(info.operatorInfoTreeRoot, bytes32(0), "Should have zero tree root");
+        assertEq(info.aggregatePubkey.X, 0, "Aggregate pubkey X should be 0");
+        assertEq(info.aggregatePubkey.Y, 0, "Aggregate pubkey Y should be 0");
+    }
+
+    function test_allOperatorsRegistered() public {
+        // Register operators
+        _registerOperatorKey(operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
+        _registerOperatorKey(operator2, defaultOperatorSet, bn254G1Key2, bn254G2Key2, BN254_PRIV_KEY_2);
+
+        // Set operators and weights
+        address[] memory operators = new address[](2);
+        operators[0] = operator1;
+        operators[1] = operator2;
+
+        uint[][] memory weights = new uint[][](2);
+        weights[0] = _createSingleWeightArray(100)[0];
+        weights[1] = _createSingleWeightArray(200)[0];
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        BN254OperatorSetInfo memory info = calculator.calculateOperatorTable(defaultOperatorSet);
+
+        assertEq(info.numOperators, 2, "Should have 2 operators");
+        assertEq(info.totalWeights.length, 1, "Should have 1 weight type");
+        assertEq(info.totalWeights[0], 300, "Total weight should be 300");
+
+        // Verify aggregate pubkey is correct (sum of G1 points)
+        BN254.G1Point memory expectedAggregate = _addG1Points(bn254G1Key1, bn254G1Key2);
+        assertEq(info.aggregatePubkey.X, expectedAggregate.X, "Aggregate pubkey X mismatch");
+        assertEq(info.aggregatePubkey.Y, expectedAggregate.Y, "Aggregate pubkey Y mismatch");
+    }
+
+    function test_multipleWeightTypes() public {
+        // Register operators
+        _registerOperatorKey(operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
+        _registerOperatorKey(operator2, defaultOperatorSet, bn254G1Key2, bn254G2Key2, BN254_PRIV_KEY_2);
+
+        // Set operators and weights with multiple types
+        address[] memory operators = new address[](2);
+        operators[0] = operator1;
+        operators[1] = operator2;
+
+        uint[][] memory weights = new uint[][](2);
+        uint[] memory op1Weights = new uint[](3);
+        op1Weights[0] = 100;
+        op1Weights[1] = 150;
+        op1Weights[2] = 50;
+        weights[0] = op1Weights;
+
+        uint[] memory op2Weights = new uint[](3);
+        op2Weights[0] = 200;
+        op2Weights[1] = 250;
+        op2Weights[2] = 100;
+        weights[1] = op2Weights;
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        BN254OperatorSetInfo memory info = calculator.calculateOperatorTable(defaultOperatorSet);
+
+        assertEq(info.totalWeights.length, 3, "Should have 3 weight types");
+        assertEq(info.totalWeights[0], 300, "Total weight[0] should be 300");
+        assertEq(info.totalWeights[1], 400, "Total weight[1] should be 400");
+        assertEq(info.totalWeights[2], 150, "Total weight[2] should be 150");
+    }
+
+    function test_mixedRegistrationStatus() public {
+        // Register only operator1
+        _registerOperatorKey(operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
+
+        // Set operators and weights
+        address[] memory operators = new address[](3);
+        operators[0] = operator1; // registered
+        operators[1] = operator2; // not registered
+        operators[2] = operator3; // not registered
+
+        uint[][] memory weights = new uint[][](3);
+        weights[0] = _createSingleWeightArray(100)[0];
+        weights[1] = _createSingleWeightArray(200)[0];
+        weights[2] = _createSingleWeightArray(300)[0];
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        BN254OperatorSetInfo memory info = calculator.calculateOperatorTable(defaultOperatorSet);
+
+        assertEq(info.numOperators, 1, "Should have 1 operator (only registered ones count)");
+        assertEq(info.totalWeights[0], 100, "Total weight should be 100 (only operator1)");
+        assertEq(info.aggregatePubkey.X, bn254G1Key1.X, "Aggregate pubkey X should be operator1's");
+        assertEq(info.aggregatePubkey.Y, bn254G1Key1.Y, "Aggregate pubkey Y should be operator1's");
+    }
+
+    function test_singleOperatorRegistered() public {
+        // Test with 1 operator, 1 registered
+        address newOperator = address(uint160(100));
+
+        address[] memory operators = new address[](1);
+        operators[0] = newOperator;
+        uint[][] memory weights = new uint[][](1);
+        weights[0] = _createSingleWeightArray(100)[0];
+
+        _registerOperatorKey(newOperator, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        BN254OperatorSetInfo memory info = calculator.calculateOperatorTable(defaultOperatorSet);
+        assertEq(info.numOperators, 1, "Should have 1 operator");
+        assertEq(info.totalWeights[0], 100, "Total weight should be 100");
+        assertEq(info.aggregatePubkey.X, bn254G1Key1.X, "Aggregate pubkey X mismatch");
+        assertEq(info.aggregatePubkey.Y, bn254G1Key1.Y, "Aggregate pubkey Y mismatch");
+    }
+
+    function test_subsetOfOperatorsRegistered() public {
+        // Register operator1 and operator3, but not operator2
+        _registerOperatorKey(operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
+
+        // Set operators and weights
+        address[] memory operators = new address[](3);
+        operators[0] = operator1; // registered
+        operators[1] = operator2; // not registered
+
+        uint[][] memory weights = new uint[][](3);
+        weights[0] = _createSingleWeightArray(100)[0];
+        weights[1] = _createSingleWeightArray(200)[0]; // This weight won't be included
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        BN254OperatorSetInfo memory info = calculator.calculateOperatorTable(defaultOperatorSet);
+
+        assertEq(info.numOperators, 1, "Should have 1 operator (only registered ones)");
+        assertEq(info.totalWeights[0], 100, "Total weight should be 100 (100 + 300)");
+
+        // Verify aggregate pubkey is sum of registered operators' keys
+        BN254.G1Point memory expectedAggregate = bn254G1Key1;
+        assertEq(info.aggregatePubkey.X, expectedAggregate.X, "Aggregate pubkey X mismatch");
+        assertEq(info.aggregatePubkey.Y, expectedAggregate.Y, "Aggregate pubkey Y mismatch");
+
+        // Verify merkle root is non-zero
+        assertTrue(info.operatorInfoTreeRoot != bytes32(0), "Merkle root should be non-zero");
+    }
+
+    function test_emptyOperatorSetReturnsZeroValues() public {
+        // Test with operators that exist but none registered
+        address[] memory operators = new address[](3);
+        operators[0] = operator1;
+        operators[1] = operator2;
+        operators[2] = operator3;
+
+        uint[][] memory weights = new uint[][](3);
+        weights[0] = _createSingleWeightArray(100)[0];
+        weights[1] = _createSingleWeightArray(200)[0];
+        weights[2] = _createSingleWeightArray(300)[0];
+
+        // Don't register any operators
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        BN254OperatorSetInfo memory info = calculator.calculateOperatorTable(defaultOperatorSet);
+
+        // Verify all values are zero/empty when no operators are registered
+        assertEq(info.operatorInfoTreeRoot, bytes32(0), "Tree root should be zero");
+        assertEq(info.numOperators, 0, "Should have 0 operators");
+        assertEq(info.aggregatePubkey.X, 0, "Aggregate pubkey X should be 0");
+        assertEq(info.aggregatePubkey.Y, 0, "Aggregate pubkey Y should be 0");
+        assertEq(info.totalWeights.length, 0, "Total weights should be empty array");
+    }
+}
+
+/**
+ * @title BN254TableCalculatorBaseUnitTests_calculateOperatorTableBytes
+ * @notice Unit tests for BN254TableCalculatorBase.calculateOperatorTableBytes
+ */
+contract BN254TableCalculatorBaseUnitTests_calculateOperatorTableBytes is BN254TableCalculatorBaseUnitTests {
+    function test_encodesCorrectly() public {
+        // Register operator
+        _registerOperatorKey(operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
+
+        // Set operators and weights
+        address[] memory operators = new address[](1);
+        operators[0] = operator1;
+        uint[][] memory weights = _createSingleWeightArray(100);
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        bytes memory tableBytes = calculator.calculateOperatorTableBytes(defaultOperatorSet);
+
+        // Decode and verify
+        BN254OperatorSetInfo memory decodedInfo = abi.decode(tableBytes, (BN254OperatorSetInfo));
+
+        assertEq(decodedInfo.numOperators, 1, "Should have 1 operator");
+        assertEq(decodedInfo.totalWeights[0], 100, "Total weight should be 100");
+        assertEq(decodedInfo.aggregatePubkey.X, bn254G1Key1.X, "Aggregate pubkey X mismatch");
+        assertEq(decodedInfo.aggregatePubkey.Y, bn254G1Key1.Y, "Aggregate pubkey Y mismatch");
+    }
+
+    function testFuzz_encodesCorrectly(uint weight) public {
+        weight = bound(weight, 1, 1e18);
+
+        // Register operator
+        _registerOperatorKey(operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
+
+        // Set operators and weights
+        address[] memory operators = new address[](1);
+        operators[0] = operator1;
+        uint[][] memory weights = _createSingleWeightArray(weight);
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        bytes memory tableBytes = calculator.calculateOperatorTableBytes(defaultOperatorSet);
+
+        // Decode and verify
+        BN254OperatorSetInfo memory decodedInfo = abi.decode(tableBytes, (BN254OperatorSetInfo));
+
+        assertEq(decodedInfo.totalWeights[0], weight, "Weight mismatch");
+    }
+}
+
+/**
+ * @title BN254TableCalculatorBaseUnitTests_getOperatorWeights
+ * @notice Unit tests for BN254TableCalculatorBase.getOperatorWeights
+ */
+contract BN254TableCalculatorBaseUnitTests_getOperatorWeights is BN254TableCalculatorBaseUnitTests {
+    function test_returnsImplementationResult() public {
+        // Set mock weights
+        address[] memory expectedOperators = new address[](2);
+        expectedOperators[0] = operator1;
+        expectedOperators[1] = operator2;
+
+        uint[][] memory expectedWeights = new uint[][](2);
+        expectedWeights[0] = _createSingleWeightArray(100)[0];
+        expectedWeights[1] = _createSingleWeightArray(200)[0];
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, expectedOperators, expectedWeights);
+
+        (address[] memory operators, uint[][] memory weights) = calculator.getOperatorWeights(defaultOperatorSet);
+
+        assertEq(operators.length, expectedOperators.length, "Operators length mismatch");
+        assertEq(weights.length, expectedWeights.length, "Weights length mismatch");
+
+        for (uint i = 0; i < operators.length; i++) {
+            assertEq(operators[i], expectedOperators[i], "Operator address mismatch");
+            assertEq(weights[i][0], expectedWeights[i][0], "Weight value mismatch");
+        }
+    }
+
+    function testFuzz_returnsImplementationResult(uint8 numOperators) public {
+        numOperators = uint8(bound(numOperators, 0, 20));
+
+        address[] memory expectedOperators = new address[](numOperators);
+        uint[][] memory expectedWeights = new uint[][](numOperators);
+
+        for (uint i = 0; i < numOperators; i++) {
+            expectedOperators[i] = address(uint160(i + 100));
+            expectedWeights[i] = _createSingleWeightArray((i + 1) * 100)[0];
+        }
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, expectedOperators, expectedWeights);
+
+        (address[] memory operators, uint[][] memory weights) = calculator.getOperatorWeights(defaultOperatorSet);
+
+        assertEq(operators.length, numOperators, "Operators length mismatch");
+        assertEq(weights.length, numOperators, "Weights length mismatch");
+    }
+}
+
+/**
+ * @title BN254TableCalculatorBaseUnitTests_getOperatorWeight
+ * @notice Unit tests for BN254TableCalculatorBase.getOperatorWeight
+ */
+contract BN254TableCalculatorBaseUnitTests_getOperatorWeight is BN254TableCalculatorBaseUnitTests {
+    function test_operatorExists() public {
+        // Set operators and weights
+        address[] memory operators = new address[](3);
+        operators[0] = operator1;
+        operators[1] = operator2;
+        operators[2] = operator3;
+
+        uint[][] memory weights = new uint[][](3);
+        weights[0] = _createSingleWeightArray(100)[0];
+        weights[1] = _createSingleWeightArray(200)[0];
+        weights[2] = _createSingleWeightArray(300)[0];
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator1), 100, "Operator1 weight mismatch");
+        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator2), 200, "Operator2 weight mismatch");
+        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator3), 300, "Operator3 weight mismatch");
+    }
+
+    function test_operatorDoesNotExist() public {
+        // Set operators and weights
+        address[] memory operators = new address[](2);
+        operators[0] = operator1;
+        operators[1] = operator2;
+
+        uint[][] memory weights = new uint[][](2);
+        weights[0] = _createSingleWeightArray(100)[0];
+        weights[1] = _createSingleWeightArray(200)[0];
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator3), 0, "Non-existent operator should return 0");
+        assertEq(calculator.getOperatorWeight(defaultOperatorSet, address(0xdead)), 0, "Random address should return 0");
+    }
+
+    function test_emptyOperatorSet() public {
+        // Set empty operators and weights
+        address[] memory operators = new address[](0);
+        uint[][] memory weights = new uint[][](0);
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator1), 0, "Should return 0 for empty set");
+    }
+
+    function testFuzz_getOperatorWeight(address operator, uint weight) public {
+        weight = bound(weight, 0, 1e18);
+
+        // Set single operator
+        address[] memory operators = new address[](1);
+        operators[0] = operator;
+
+        uint[][] memory weights = _createSingleWeightArray(weight);
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator), weight, "Weight mismatch");
+
+        // Different operator should return 0
+        address differentOperator = address(uint160(uint(uint160(operator)) + 1));
+        assertEq(calculator.getOperatorWeight(defaultOperatorSet, differentOperator), 0, "Different operator should return 0");
+    }
+}
+
+/**
+ * @title BN254TableCalculatorBaseUnitTests_getOperatorInfos
+ * @notice Unit tests for BN254TableCalculatorBase.getOperatorInfos
+ */
+contract BN254TableCalculatorBaseUnitTests_getOperatorInfos is BN254TableCalculatorBaseUnitTests {
+    function test_noOperatorsRegistered() public {
+        // Set operators without registering keys
+        address[] memory operators = new address[](2);
+        operators[0] = operator1;
+        operators[1] = operator2;
+
+        uint[][] memory weights = new uint[][](2);
+        weights[0] = _createSingleWeightArray(100)[0];
+        weights[1] = _createSingleWeightArray(200)[0];
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        BN254OperatorInfo[] memory infos = calculator.getOperatorInfos(defaultOperatorSet);
+
+        assertEq(infos.length, 2, "Should have 2 operator infos");
+
+        // Both should have zero pubkeys since not registered
+        for (uint i = 0; i < infos.length; i++) {
+            assertEq(infos[i].pubkey.X, 0, "Unregistered operator pubkey X should be 0");
+            assertEq(infos[i].pubkey.Y, 0, "Unregistered operator pubkey Y should be 0");
+            assertEq(infos[i].weights.length, 0, "Unregistered operator weights should be empty");
+        }
+    }
+
+    function test_someOperatorsNotRegistered() public {
+        // Register only operator1 (skip operator3 to avoid pairing issues)
+        _registerOperatorKey(operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
+
+        // Set operators and weights
+        address[] memory operators = new address[](3);
+        operators[0] = operator1; // registered
+        operators[1] = operator2; // not registered
+        operators[2] = operator3; // not registered
+
+        uint[][] memory weights = new uint[][](3);
+        weights[0] = _createSingleWeightArray(100)[0];
+        weights[1] = _createSingleWeightArray(200)[0];
+        weights[2] = _createSingleWeightArray(300)[0];
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        BN254OperatorInfo[] memory infos = calculator.getOperatorInfos(defaultOperatorSet);
+
+        assertEq(infos.length, 3, "Should have 3 operator infos");
+
+        // Check operator1 (registered)
+        assertEq(infos[0].pubkey.X, bn254G1Key1.X, "Operator1 pubkey X mismatch");
+        assertEq(infos[0].pubkey.Y, bn254G1Key1.Y, "Operator1 pubkey Y mismatch");
+        assertEq(infos[0].weights[0], 100, "Operator1 weight mismatch");
+
+        // Check operator2 (not registered)
+        assertEq(infos[1].pubkey.X, 0, "Operator2 pubkey X should be 0");
+        assertEq(infos[1].pubkey.Y, 0, "Operator2 pubkey Y should be 0");
+        assertEq(infos[1].weights.length, 0, "Operator2 weights should be empty");
+
+        // Check operator3 (not registered)
+        assertEq(infos[2].pubkey.X, 0, "Operator3 pubkey X should be 0");
+        assertEq(infos[2].pubkey.Y, 0, "Operator3 pubkey Y should be 0");
+        assertEq(infos[2].weights.length, 0, "Operator3 weights should be empty");
+    }
+
+    function test_allOperatorsRegistered() public {
+        // Register all operators
+        _registerOperatorKey(operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
+        _registerOperatorKey(operator2, defaultOperatorSet, bn254G1Key2, bn254G2Key2, BN254_PRIV_KEY_2);
+
+        // Set operators and weights
+        address[] memory operators = new address[](2);
+        operators[0] = operator1;
+        operators[1] = operator2;
+
+        uint[][] memory weights = new uint[][](2);
+        weights[0] = _createSingleWeightArray(100)[0];
+        weights[1] = _createSingleWeightArray(200)[0];
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        BN254OperatorInfo[] memory infos = calculator.getOperatorInfos(defaultOperatorSet);
+
+        assertEq(infos.length, 2, "Should have 2 operator infos");
+
+        // Check operator1
+        assertEq(infos[0].pubkey.X, bn254G1Key1.X, "Operator1 pubkey X mismatch");
+        assertEq(infos[0].pubkey.Y, bn254G1Key1.Y, "Operator1 pubkey Y mismatch");
+        assertEq(infos[0].weights[0], 100, "Operator1 weight mismatch");
+
+        // Check operator2
+        assertEq(infos[1].pubkey.X, bn254G1Key2.X, "Operator2 pubkey X mismatch");
+        assertEq(infos[1].pubkey.Y, bn254G1Key2.Y, "Operator2 pubkey Y mismatch");
+        assertEq(infos[1].weights[0], 200, "Operator2 weight mismatch");
+    }
+
+    function test_multipleWeightTypes() public {
+        // Register operator
+        _registerOperatorKey(operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
+
+        // Set operators and weights with multiple types
+        address[] memory operators = new address[](1);
+        operators[0] = operator1;
+
+        uint[][] memory weights = new uint[][](1);
+        uint[] memory multiWeights = new uint[](3);
+        multiWeights[0] = 100;
+        multiWeights[1] = 200;
+        multiWeights[2] = 300;
+        weights[0] = multiWeights;
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        BN254OperatorInfo[] memory infos = calculator.getOperatorInfos(defaultOperatorSet);
+
+        assertEq(infos.length, 1, "Should have 1 operator info");
+        assertEq(infos[0].weights.length, 3, "Should have 3 weight types");
+        assertEq(infos[0].weights[0], 100, "Weight[0] mismatch");
+        assertEq(infos[0].weights[1], 200, "Weight[1] mismatch");
+        assertEq(infos[0].weights[2], 300, "Weight[2] mismatch");
+    }
+
+    function testFuzz_getOperatorInfos(uint8 numOperators) public {
+        numOperators = uint8(bound(numOperators, 1, 5));
+
+        address[] memory operators = new address[](numOperators);
+        uint[][] memory weights = new uint[][](numOperators);
+
+        // Generate operators and weights
+        for (uint i = 0; i < numOperators; i++) {
+            operators[i] = address(uint160(i + 100));
+            weights[i] = _createSingleWeightArray((i + 1) * 100)[0];
+        }
+
+        // Register some operators with valid keys
+        if (numOperators >= 1) _registerOperatorKey(operators[0], defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
+        if (numOperators >= 3) _registerOperatorKey(operators[2], defaultOperatorSet, bn254G1Key2, bn254G2Key2, BN254_PRIV_KEY_2);
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        BN254OperatorInfo[] memory infos = calculator.getOperatorInfos(defaultOperatorSet);
+
+        assertEq(infos.length, numOperators, "Operator info count mismatch");
+
+        for (uint i = 0; i < numOperators; i++) {
+            if ((i == 0 && numOperators >= 1) || (i == 2 && numOperators >= 3)) {
+                // Registered operators should have weights
+                assertEq(infos[i].weights.length, 1, "Registered operator should have weights");
+                assertEq(infos[i].weights[0], (i + 1) * 100, "Weight value mismatch");
+                assertTrue(infos[i].pubkey.X != 0 || infos[i].pubkey.Y != 0, "Registered operator should have pubkey");
+            } else {
+                // Unregistered operators should have empty weights
+                assertEq(infos[i].weights.length, 0, "Unregistered operator should have empty weights");
+                assertEq(infos[i].pubkey.X, 0, "Unregistered operator pubkey X should be 0");
+                assertEq(infos[i].pubkey.Y, 0, "Unregistered operator pubkey Y should be 0");
+            }
+        }
+    }
+}

--- a/test/unit/middlewareV2/BN254TableCalculatorBaseUnit.t.sol
+++ b/test/unit/middlewareV2/BN254TableCalculatorBaseUnit.t.sol
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {KeyRegistrar, IKeyRegistrarTypes} from "eigenlayer-contracts/src/contracts/permissions/KeyRegistrar.sol";
+import {
+    KeyRegistrar,
+    IKeyRegistrarTypes
+} from "eigenlayer-contracts/src/contracts/permissions/KeyRegistrar.sol";
 import {IKeyRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
-import {IOperatorTableCalculatorTypes} from "eigenlayer-contracts/src/contracts/interfaces/IOperatorTableCalculator.sol";
+import {IOperatorTableCalculatorTypes} from
+    "eigenlayer-contracts/src/contracts/interfaces/IOperatorTableCalculator.sol";
 import {IBN254TableCalculator} from "../../../src/interfaces/IBN254TableCalculator.sol";
 import {
     OperatorSet,
@@ -11,7 +15,8 @@ import {
 } from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
 import {BN254} from "eigenlayer-contracts/src/contracts/libraries/BN254.sol";
 
-import {BN254TableCalculatorBase} from "../../../src/middlewareV2/tableCalculator/BN254TableCalculatorBase.sol";
+import {BN254TableCalculatorBase} from
+    "../../../src/middlewareV2/tableCalculator/BN254TableCalculatorBase.sol";
 import {MockEigenLayerDeployer} from "./MockDeployer.sol";
 import "test/utils/Random.sol";
 
@@ -19,22 +24,25 @@ import "test/utils/Random.sol";
 contract BN254TableCalculatorBaseHarness is BN254TableCalculatorBase {
     // Storage for mock weights
     mapping(bytes32 => address[]) internal _mockOperators;
-    mapping(bytes32 => uint[][]) internal _mockWeights;
+    mapping(bytes32 => uint256[][]) internal _mockWeights;
 
-    constructor(IKeyRegistrar _keyRegistrar) BN254TableCalculatorBase(_keyRegistrar) {}
+    constructor(
+        IKeyRegistrar _keyRegistrar
+    ) BN254TableCalculatorBase(_keyRegistrar) {}
 
-    function setMockOperatorWeights(OperatorSet calldata operatorSet, address[] memory operators, uint[][] memory weights) external {
+    function setMockOperatorWeights(
+        OperatorSet calldata operatorSet,
+        address[] memory operators,
+        uint256[][] memory weights
+    ) external {
         bytes32 key = operatorSet.key();
         _mockOperators[key] = operators;
         _mockWeights[key] = weights;
     }
 
-    function _getOperatorWeights(OperatorSet calldata operatorSet)
-        internal
-        view
-        override
-        returns (address[] memory operators, uint[][] memory weights)
-    {
+    function _getOperatorWeights(
+        OperatorSet calldata operatorSet
+    ) internal view override returns (address[] memory operators, uint256[][] memory weights) {
         bytes32 key = operatorSet.key();
         operators = _mockOperators[key];
         weights = _mockWeights[key];
@@ -45,7 +53,11 @@ contract BN254TableCalculatorBaseHarness is BN254TableCalculatorBase {
  * @title BN254TableCalculatorBaseUnitTests
  * @notice Base contract for all BN254TableCalculatorBase unit tests
  */
-contract BN254TableCalculatorBaseUnitTests is MockEigenLayerDeployer, IOperatorTableCalculatorTypes, IKeyRegistrarTypes {
+contract BN254TableCalculatorBaseUnitTests is
+    MockEigenLayerDeployer,
+    IOperatorTableCalculatorTypes,
+    IKeyRegistrarTypes
+{
     using BN254 for BN254.G1Point;
     using OperatorSetLib for OperatorSet;
 
@@ -64,9 +76,9 @@ contract BN254TableCalculatorBaseUnitTests is MockEigenLayerDeployer, IOperatorT
     OperatorSet alternativeOperatorSet;
 
     // BN254 test keys
-    uint constant BN254_PRIV_KEY_1 = 69;
-    uint constant BN254_PRIV_KEY_2 = 123;
-    uint constant BN254_PRIV_KEY_3 = 456;
+    uint256 constant BN254_PRIV_KEY_1 = 69;
+    uint256 constant BN254_PRIV_KEY_2 = 123;
+    uint256 constant BN254_PRIV_KEY_3 = 456;
 
     BN254.G1Point bn254G1Key1;
     BN254.G1Point bn254G1Key2;
@@ -90,15 +102,23 @@ contract BN254TableCalculatorBaseUnitTests is MockEigenLayerDeployer, IOperatorT
         bn254G1Key2 = BN254.generatorG1().scalar_mul(BN254_PRIV_KEY_2);
 
         // Valid G2 points that correspond to the private keys
-        bn254G2Key1.X[1] = 19_101_821_850_089_705_274_637_533_855_249_918_363_070_101_489_527_618_151_493_230_256_975_900_223_847;
-        bn254G2Key1.X[0] = 5_334_410_886_741_819_556_325_359_147_377_682_006_012_228_123_419_628_681_352_847_439_302_316_235_957;
-        bn254G2Key1.Y[1] = 354_176_189_041_917_478_648_604_979_334_478_067_325_821_134_838_555_150_300_539_079_146_482_658_331;
-        bn254G2Key1.Y[0] = 4_185_483_097_059_047_421_902_184_823_581_361_466_320_657_066_600_218_863_748_375_739_772_335_928_910;
+        bn254G2Key1.X[1] =
+            19101821850089705274637533855249918363070101489527618151493230256975900223847;
+        bn254G2Key1.X[0] =
+            5334410886741819556325359147377682006012228123419628681352847439302316235957;
+        bn254G2Key1.Y[1] =
+            354176189041917478648604979334478067325821134838555150300539079146482658331;
+        bn254G2Key1.Y[0] =
+            4185483097059047421902184823581361466320657066600218863748375739772335928910;
 
-        bn254G2Key2.X[1] = 19_276_105_129_625_393_659_655_050_515_259_006_463_014_579_919_681_138_299_520_812_914_148_935_621_072;
-        bn254G2Key2.X[0] = 14_066_454_060_412_929_535_985_836_631_817_650_877_381_034_334_390_275_410_072_431_082_437_297_539_867;
-        bn254G2Key2.Y[1] = 12_642_665_914_920_339_463_975_152_321_804_664_028_480_770_144_655_934_937_445_922_690_262_428_344_269;
-        bn254G2Key2.Y[0] = 10_109_651_107_942_685_361_120_988_628_892_759_706_059_655_669_161_016_107_907_096_760_613_704_453_218;
+        bn254G2Key2.X[1] =
+            19276105129625393659655050515259006463014579919681138299520812914148935621072;
+        bn254G2Key2.X[0] =
+            14066454060412929535985836631817650877381034334390275410072431082437297539867;
+        bn254G2Key2.Y[1] =
+            12642665914920339463975152321804664028480770144655934937445922690262428344269;
+        bn254G2Key2.Y[0] =
+            10109651107942685361120988628892759706059655669161016107907096760613704453218;
 
         // Configure operator sets in AllocationManager
         allocationManagerMock.setAVSRegistrar(avs1, avs1);
@@ -109,7 +129,9 @@ contract BN254TableCalculatorBaseUnitTests is MockEigenLayerDeployer, IOperatorT
         keyRegistrar.configureOperatorSet(defaultOperatorSet, IKeyRegistrarTypes.CurveType.BN254);
 
         vm.prank(avs2);
-        keyRegistrar.configureOperatorSet(alternativeOperatorSet, IKeyRegistrarTypes.CurveType.BN254);
+        keyRegistrar.configureOperatorSet(
+            alternativeOperatorSet, IKeyRegistrarTypes.CurveType.BN254
+        );
     }
 
     // Helper functions
@@ -118,7 +140,7 @@ contract BN254TableCalculatorBaseUnitTests is MockEigenLayerDeployer, IOperatorT
         OperatorSet memory operatorSet,
         BN254.G1Point memory g1Key,
         BN254.G2Point memory g2Key,
-        uint privKey
+        uint256 privKey
     ) internal {
         bytes memory pubkey = abi.encode(g1Key.X, g1Key.Y, g2Key.X, g2Key.Y);
         bytes memory signature = _generateBN254Signature(operator, operatorSet, pubkey, privKey);
@@ -127,13 +149,20 @@ contract BN254TableCalculatorBaseUnitTests is MockEigenLayerDeployer, IOperatorT
         keyRegistrar.registerKey(operator, operatorSet, pubkey, signature);
     }
 
-    function _generateBN254Signature(address operator, OperatorSet memory operatorSet, bytes memory pubkey, uint privKey)
-        internal
-        view
-        returns (bytes memory)
-    {
+    function _generateBN254Signature(
+        address operator,
+        OperatorSet memory operatorSet,
+        bytes memory pubkey,
+        uint256 privKey
+    ) internal view returns (bytes memory) {
         bytes32 structHash = keccak256(
-            abi.encode(keyRegistrar.BN254_KEY_REGISTRATION_TYPEHASH(), operator, operatorSet.avs, operatorSet.id, keccak256(pubkey))
+            abi.encode(
+                keyRegistrar.BN254_KEY_REGISTRATION_TYPEHASH(),
+                operator,
+                operatorSet.avs,
+                operatorSet.id,
+                keccak256(pubkey)
+            )
         );
         bytes32 messageHash = keyRegistrar.domainSeparator();
         messageHash = keccak256(abi.encodePacked("\x19\x01", messageHash, structHash));
@@ -144,20 +173,27 @@ contract BN254TableCalculatorBaseUnitTests is MockEigenLayerDeployer, IOperatorT
         return abi.encode(signature.X, signature.Y);
     }
 
-    function _createSingleWeightArray(uint weight) internal pure returns (uint[][] memory) {
-        uint[][] memory weights = new uint[][](1);
-        weights[0] = new uint[](1);
+    function _createSingleWeightArray(
+        uint256 weight
+    ) internal pure returns (uint256[][] memory) {
+        uint256[][] memory weights = new uint256[][](1);
+        weights[0] = new uint256[](1);
         weights[0][0] = weight;
         return weights;
     }
 
-    function _createMultiWeightArray(uint[] memory weightValues) internal pure returns (uint[][] memory) {
-        uint[][] memory weights = new uint[][](1);
+    function _createMultiWeightArray(
+        uint256[] memory weightValues
+    ) internal pure returns (uint256[][] memory) {
+        uint256[][] memory weights = new uint256[][](1);
         weights[0] = weightValues;
         return weights;
     }
 
-    function _addG1Points(BN254.G1Point memory p1, BN254.G1Point memory p2) internal view returns (BN254.G1Point memory) {
+    function _addG1Points(
+        BN254.G1Point memory p1,
+        BN254.G1Point memory p2
+    ) internal view returns (BN254.G1Point memory) {
         if (p1.X == 0 && p1.Y == 0) return p2;
         if (p2.X == 0 && p2.Y == 0) return p1;
         return BN254.plus(p1, p2);
@@ -168,11 +204,13 @@ contract BN254TableCalculatorBaseUnitTests is MockEigenLayerDeployer, IOperatorT
  * @title BN254TableCalculatorBaseUnitTests_calculateOperatorTable
  * @notice Unit tests for BN254TableCalculatorBase.calculateOperatorTable
  */
-contract BN254TableCalculatorBaseUnitTests_calculateOperatorTable is BN254TableCalculatorBaseUnitTests {
+contract BN254TableCalculatorBaseUnitTests_calculateOperatorTable is
+    BN254TableCalculatorBaseUnitTests
+{
     function test_noOperators() public {
         // Set empty operators and weights
         address[] memory operators = new address[](0);
-        uint[][] memory weights = new uint[][](0);
+        uint256[][] memory weights = new uint256[][](0);
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
 
         BN254OperatorSetInfo memory info = calculator.calculateOperatorTable(defaultOperatorSet);
@@ -189,7 +227,7 @@ contract BN254TableCalculatorBaseUnitTests_calculateOperatorTable is BN254TableC
         operators[0] = operator1;
         operators[1] = operator2;
 
-        uint[][] memory weights = new uint[][](2);
+        uint256[][] memory weights = new uint256[][](2);
         weights[0] = _createSingleWeightArray(100)[0];
         weights[1] = _createSingleWeightArray(200)[0];
 
@@ -199,7 +237,11 @@ contract BN254TableCalculatorBaseUnitTests_calculateOperatorTable is BN254TableC
 
         // When no operators have registered keys, operatorCount should be 0 and return empty table
         assertEq(info.numOperators, 0, "Should have 0 operators when none are registered");
-        assertEq(info.totalWeights.length, 0, "Should have empty total weights when no operators registered");
+        assertEq(
+            info.totalWeights.length,
+            0,
+            "Should have empty total weights when no operators registered"
+        );
         assertEq(info.operatorInfoTreeRoot, bytes32(0), "Should have zero tree root");
         assertEq(info.aggregatePubkey.X, 0, "Aggregate pubkey X should be 0");
         assertEq(info.aggregatePubkey.Y, 0, "Aggregate pubkey Y should be 0");
@@ -207,15 +249,19 @@ contract BN254TableCalculatorBaseUnitTests_calculateOperatorTable is BN254TableC
 
     function test_allOperatorsRegistered() public {
         // Register operators
-        _registerOperatorKey(operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
-        _registerOperatorKey(operator2, defaultOperatorSet, bn254G1Key2, bn254G2Key2, BN254_PRIV_KEY_2);
+        _registerOperatorKey(
+            operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1
+        );
+        _registerOperatorKey(
+            operator2, defaultOperatorSet, bn254G1Key2, bn254G2Key2, BN254_PRIV_KEY_2
+        );
 
         // Set operators and weights
         address[] memory operators = new address[](2);
         operators[0] = operator1;
         operators[1] = operator2;
 
-        uint[][] memory weights = new uint[][](2);
+        uint256[][] memory weights = new uint256[][](2);
         weights[0] = _createSingleWeightArray(100)[0];
         weights[1] = _createSingleWeightArray(200)[0];
 
@@ -235,22 +281,26 @@ contract BN254TableCalculatorBaseUnitTests_calculateOperatorTable is BN254TableC
 
     function test_multipleWeightTypes() public {
         // Register operators
-        _registerOperatorKey(operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
-        _registerOperatorKey(operator2, defaultOperatorSet, bn254G1Key2, bn254G2Key2, BN254_PRIV_KEY_2);
+        _registerOperatorKey(
+            operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1
+        );
+        _registerOperatorKey(
+            operator2, defaultOperatorSet, bn254G1Key2, bn254G2Key2, BN254_PRIV_KEY_2
+        );
 
         // Set operators and weights with multiple types
         address[] memory operators = new address[](2);
         operators[0] = operator1;
         operators[1] = operator2;
 
-        uint[][] memory weights = new uint[][](2);
-        uint[] memory op1Weights = new uint[](3);
+        uint256[][] memory weights = new uint256[][](2);
+        uint256[] memory op1Weights = new uint256[](3);
         op1Weights[0] = 100;
         op1Weights[1] = 150;
         op1Weights[2] = 50;
         weights[0] = op1Weights;
 
-        uint[] memory op2Weights = new uint[](3);
+        uint256[] memory op2Weights = new uint256[](3);
         op2Weights[0] = 200;
         op2Weights[1] = 250;
         op2Weights[2] = 100;
@@ -268,7 +318,9 @@ contract BN254TableCalculatorBaseUnitTests_calculateOperatorTable is BN254TableC
 
     function test_mixedRegistrationStatus() public {
         // Register only operator1
-        _registerOperatorKey(operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
+        _registerOperatorKey(
+            operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1
+        );
 
         // Set operators and weights
         address[] memory operators = new address[](3);
@@ -276,7 +328,7 @@ contract BN254TableCalculatorBaseUnitTests_calculateOperatorTable is BN254TableC
         operators[1] = operator2; // not registered
         operators[2] = operator3; // not registered
 
-        uint[][] memory weights = new uint[][](3);
+        uint256[][] memory weights = new uint256[][](3);
         weights[0] = _createSingleWeightArray(100)[0];
         weights[1] = _createSingleWeightArray(200)[0];
         weights[2] = _createSingleWeightArray(300)[0];
@@ -297,10 +349,12 @@ contract BN254TableCalculatorBaseUnitTests_calculateOperatorTable is BN254TableC
 
         address[] memory operators = new address[](1);
         operators[0] = newOperator;
-        uint[][] memory weights = new uint[][](1);
+        uint256[][] memory weights = new uint256[][](1);
         weights[0] = _createSingleWeightArray(100)[0];
 
-        _registerOperatorKey(newOperator, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
+        _registerOperatorKey(
+            newOperator, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1
+        );
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
 
         BN254OperatorSetInfo memory info = calculator.calculateOperatorTable(defaultOperatorSet);
@@ -312,14 +366,16 @@ contract BN254TableCalculatorBaseUnitTests_calculateOperatorTable is BN254TableC
 
     function test_subsetOfOperatorsRegistered() public {
         // Register operator1 and operator3, but not operator2
-        _registerOperatorKey(operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
+        _registerOperatorKey(
+            operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1
+        );
 
         // Set operators and weights
         address[] memory operators = new address[](3);
         operators[0] = operator1; // registered
         operators[1] = operator2; // not registered
 
-        uint[][] memory weights = new uint[][](3);
+        uint256[][] memory weights = new uint256[][](3);
         weights[0] = _createSingleWeightArray(100)[0];
         weights[1] = _createSingleWeightArray(200)[0]; // This weight won't be included
 
@@ -346,7 +402,7 @@ contract BN254TableCalculatorBaseUnitTests_calculateOperatorTable is BN254TableC
         operators[1] = operator2;
         operators[2] = operator3;
 
-        uint[][] memory weights = new uint[][](3);
+        uint256[][] memory weights = new uint256[][](3);
         weights[0] = _createSingleWeightArray(100)[0];
         weights[1] = _createSingleWeightArray(200)[0];
         weights[2] = _createSingleWeightArray(300)[0];
@@ -369,15 +425,19 @@ contract BN254TableCalculatorBaseUnitTests_calculateOperatorTable is BN254TableC
  * @title BN254TableCalculatorBaseUnitTests_calculateOperatorTableBytes
  * @notice Unit tests for BN254TableCalculatorBase.calculateOperatorTableBytes
  */
-contract BN254TableCalculatorBaseUnitTests_calculateOperatorTableBytes is BN254TableCalculatorBaseUnitTests {
+contract BN254TableCalculatorBaseUnitTests_calculateOperatorTableBytes is
+    BN254TableCalculatorBaseUnitTests
+{
     function test_encodesCorrectly() public {
         // Register operator
-        _registerOperatorKey(operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
+        _registerOperatorKey(
+            operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1
+        );
 
         // Set operators and weights
         address[] memory operators = new address[](1);
         operators[0] = operator1;
-        uint[][] memory weights = _createSingleWeightArray(100);
+        uint256[][] memory weights = _createSingleWeightArray(100);
 
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
 
@@ -392,16 +452,20 @@ contract BN254TableCalculatorBaseUnitTests_calculateOperatorTableBytes is BN254T
         assertEq(decodedInfo.aggregatePubkey.Y, bn254G1Key1.Y, "Aggregate pubkey Y mismatch");
     }
 
-    function testFuzz_encodesCorrectly(uint weight) public {
+    function testFuzz_encodesCorrectly(
+        uint256 weight
+    ) public {
         weight = bound(weight, 1, 1e18);
 
         // Register operator
-        _registerOperatorKey(operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
+        _registerOperatorKey(
+            operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1
+        );
 
         // Set operators and weights
         address[] memory operators = new address[](1);
         operators[0] = operator1;
-        uint[][] memory weights = _createSingleWeightArray(weight);
+        uint256[][] memory weights = _createSingleWeightArray(weight);
 
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
 
@@ -418,44 +482,50 @@ contract BN254TableCalculatorBaseUnitTests_calculateOperatorTableBytes is BN254T
  * @title BN254TableCalculatorBaseUnitTests_getOperatorWeights
  * @notice Unit tests for BN254TableCalculatorBase.getOperatorWeights
  */
-contract BN254TableCalculatorBaseUnitTests_getOperatorWeights is BN254TableCalculatorBaseUnitTests {
+contract BN254TableCalculatorBaseUnitTests_getOperatorWeights is
+    BN254TableCalculatorBaseUnitTests
+{
     function test_returnsImplementationResult() public {
         // Set mock weights
         address[] memory expectedOperators = new address[](2);
         expectedOperators[0] = operator1;
         expectedOperators[1] = operator2;
 
-        uint[][] memory expectedWeights = new uint[][](2);
+        uint256[][] memory expectedWeights = new uint256[][](2);
         expectedWeights[0] = _createSingleWeightArray(100)[0];
         expectedWeights[1] = _createSingleWeightArray(200)[0];
 
         calculator.setMockOperatorWeights(defaultOperatorSet, expectedOperators, expectedWeights);
 
-        (address[] memory operators, uint[][] memory weights) = calculator.getOperatorWeights(defaultOperatorSet);
+        (address[] memory operators, uint256[][] memory weights) =
+            calculator.getOperatorWeights(defaultOperatorSet);
 
         assertEq(operators.length, expectedOperators.length, "Operators length mismatch");
         assertEq(weights.length, expectedWeights.length, "Weights length mismatch");
 
-        for (uint i = 0; i < operators.length; i++) {
+        for (uint256 i = 0; i < operators.length; i++) {
             assertEq(operators[i], expectedOperators[i], "Operator address mismatch");
             assertEq(weights[i][0], expectedWeights[i][0], "Weight value mismatch");
         }
     }
 
-    function testFuzz_returnsImplementationResult(uint8 numOperators) public {
+    function testFuzz_returnsImplementationResult(
+        uint8 numOperators
+    ) public {
         numOperators = uint8(bound(numOperators, 0, 20));
 
         address[] memory expectedOperators = new address[](numOperators);
-        uint[][] memory expectedWeights = new uint[][](numOperators);
+        uint256[][] memory expectedWeights = new uint256[][](numOperators);
 
-        for (uint i = 0; i < numOperators; i++) {
+        for (uint256 i = 0; i < numOperators; i++) {
             expectedOperators[i] = address(uint160(i + 100));
             expectedWeights[i] = _createSingleWeightArray((i + 1) * 100)[0];
         }
 
         calculator.setMockOperatorWeights(defaultOperatorSet, expectedOperators, expectedWeights);
 
-        (address[] memory operators, uint[][] memory weights) = calculator.getOperatorWeights(defaultOperatorSet);
+        (address[] memory operators, uint256[][] memory weights) =
+            calculator.getOperatorWeights(defaultOperatorSet);
 
         assertEq(operators.length, numOperators, "Operators length mismatch");
         assertEq(weights.length, numOperators, "Weights length mismatch");
@@ -466,7 +536,9 @@ contract BN254TableCalculatorBaseUnitTests_getOperatorWeights is BN254TableCalcu
  * @title BN254TableCalculatorBaseUnitTests_getOperatorWeight
  * @notice Unit tests for BN254TableCalculatorBase.getOperatorWeight
  */
-contract BN254TableCalculatorBaseUnitTests_getOperatorWeight is BN254TableCalculatorBaseUnitTests {
+contract BN254TableCalculatorBaseUnitTests_getOperatorWeight is
+    BN254TableCalculatorBaseUnitTests
+{
     function test_operatorExists() public {
         // Set operators and weights
         address[] memory operators = new address[](3);
@@ -474,16 +546,28 @@ contract BN254TableCalculatorBaseUnitTests_getOperatorWeight is BN254TableCalcul
         operators[1] = operator2;
         operators[2] = operator3;
 
-        uint[][] memory weights = new uint[][](3);
+        uint256[][] memory weights = new uint256[][](3);
         weights[0] = _createSingleWeightArray(100)[0];
         weights[1] = _createSingleWeightArray(200)[0];
         weights[2] = _createSingleWeightArray(300)[0];
 
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
 
-        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator1), 100, "Operator1 weight mismatch");
-        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator2), 200, "Operator2 weight mismatch");
-        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator3), 300, "Operator3 weight mismatch");
+        assertEq(
+            calculator.getOperatorWeight(defaultOperatorSet, operator1),
+            100,
+            "Operator1 weight mismatch"
+        );
+        assertEq(
+            calculator.getOperatorWeight(defaultOperatorSet, operator2),
+            200,
+            "Operator2 weight mismatch"
+        );
+        assertEq(
+            calculator.getOperatorWeight(defaultOperatorSet, operator3),
+            300,
+            "Operator3 weight mismatch"
+        );
     }
 
     function test_operatorDoesNotExist() public {
@@ -492,42 +576,60 @@ contract BN254TableCalculatorBaseUnitTests_getOperatorWeight is BN254TableCalcul
         operators[0] = operator1;
         operators[1] = operator2;
 
-        uint[][] memory weights = new uint[][](2);
+        uint256[][] memory weights = new uint256[][](2);
         weights[0] = _createSingleWeightArray(100)[0];
         weights[1] = _createSingleWeightArray(200)[0];
 
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
 
-        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator3), 0, "Non-existent operator should return 0");
-        assertEq(calculator.getOperatorWeight(defaultOperatorSet, address(0xdead)), 0, "Random address should return 0");
+        assertEq(
+            calculator.getOperatorWeight(defaultOperatorSet, operator3),
+            0,
+            "Non-existent operator should return 0"
+        );
+        assertEq(
+            calculator.getOperatorWeight(defaultOperatorSet, address(0xdead)),
+            0,
+            "Random address should return 0"
+        );
     }
 
     function test_emptyOperatorSet() public {
         // Set empty operators and weights
         address[] memory operators = new address[](0);
-        uint[][] memory weights = new uint[][](0);
+        uint256[][] memory weights = new uint256[][](0);
 
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
 
-        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator1), 0, "Should return 0 for empty set");
+        assertEq(
+            calculator.getOperatorWeight(defaultOperatorSet, operator1),
+            0,
+            "Should return 0 for empty set"
+        );
     }
 
-    function testFuzz_getOperatorWeight(address operator, uint weight) public {
+    function testFuzz_getOperatorWeight(address operator, uint256 weight) public {
         weight = bound(weight, 0, 1e18);
 
         // Set single operator
         address[] memory operators = new address[](1);
         operators[0] = operator;
 
-        uint[][] memory weights = _createSingleWeightArray(weight);
+        uint256[][] memory weights = _createSingleWeightArray(weight);
 
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
 
-        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator), weight, "Weight mismatch");
+        assertEq(
+            calculator.getOperatorWeight(defaultOperatorSet, operator), weight, "Weight mismatch"
+        );
 
         // Different operator should return 0
-        address differentOperator = address(uint160(uint(uint160(operator)) + 1));
-        assertEq(calculator.getOperatorWeight(defaultOperatorSet, differentOperator), 0, "Different operator should return 0");
+        address differentOperator = address(uint160(uint256(uint160(operator)) + 1));
+        assertEq(
+            calculator.getOperatorWeight(defaultOperatorSet, differentOperator),
+            0,
+            "Different operator should return 0"
+        );
     }
 }
 
@@ -542,7 +644,7 @@ contract BN254TableCalculatorBaseUnitTests_getOperatorInfos is BN254TableCalcula
         operators[0] = operator1;
         operators[1] = operator2;
 
-        uint[][] memory weights = new uint[][](2);
+        uint256[][] memory weights = new uint256[][](2);
         weights[0] = _createSingleWeightArray(100)[0];
         weights[1] = _createSingleWeightArray(200)[0];
 
@@ -553,7 +655,7 @@ contract BN254TableCalculatorBaseUnitTests_getOperatorInfos is BN254TableCalcula
         assertEq(infos.length, 2, "Should have 2 operator infos");
 
         // Both should have zero pubkeys since not registered
-        for (uint i = 0; i < infos.length; i++) {
+        for (uint256 i = 0; i < infos.length; i++) {
             assertEq(infos[i].pubkey.X, 0, "Unregistered operator pubkey X should be 0");
             assertEq(infos[i].pubkey.Y, 0, "Unregistered operator pubkey Y should be 0");
             assertEq(infos[i].weights.length, 0, "Unregistered operator weights should be empty");
@@ -562,7 +664,9 @@ contract BN254TableCalculatorBaseUnitTests_getOperatorInfos is BN254TableCalcula
 
     function test_someOperatorsNotRegistered() public {
         // Register only operator1 (skip operator3 to avoid pairing issues)
-        _registerOperatorKey(operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
+        _registerOperatorKey(
+            operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1
+        );
 
         // Set operators and weights
         address[] memory operators = new address[](3);
@@ -570,7 +674,7 @@ contract BN254TableCalculatorBaseUnitTests_getOperatorInfos is BN254TableCalcula
         operators[1] = operator2; // not registered
         operators[2] = operator3; // not registered
 
-        uint[][] memory weights = new uint[][](3);
+        uint256[][] memory weights = new uint256[][](3);
         weights[0] = _createSingleWeightArray(100)[0];
         weights[1] = _createSingleWeightArray(200)[0];
         weights[2] = _createSingleWeightArray(300)[0];
@@ -599,15 +703,19 @@ contract BN254TableCalculatorBaseUnitTests_getOperatorInfos is BN254TableCalcula
 
     function test_allOperatorsRegistered() public {
         // Register all operators
-        _registerOperatorKey(operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
-        _registerOperatorKey(operator2, defaultOperatorSet, bn254G1Key2, bn254G2Key2, BN254_PRIV_KEY_2);
+        _registerOperatorKey(
+            operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1
+        );
+        _registerOperatorKey(
+            operator2, defaultOperatorSet, bn254G1Key2, bn254G2Key2, BN254_PRIV_KEY_2
+        );
 
         // Set operators and weights
         address[] memory operators = new address[](2);
         operators[0] = operator1;
         operators[1] = operator2;
 
-        uint[][] memory weights = new uint[][](2);
+        uint256[][] memory weights = new uint256[][](2);
         weights[0] = _createSingleWeightArray(100)[0];
         weights[1] = _createSingleWeightArray(200)[0];
 
@@ -630,14 +738,16 @@ contract BN254TableCalculatorBaseUnitTests_getOperatorInfos is BN254TableCalcula
 
     function test_multipleWeightTypes() public {
         // Register operator
-        _registerOperatorKey(operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
+        _registerOperatorKey(
+            operator1, defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1
+        );
 
         // Set operators and weights with multiple types
         address[] memory operators = new address[](1);
         operators[0] = operator1;
 
-        uint[][] memory weights = new uint[][](1);
-        uint[] memory multiWeights = new uint[](3);
+        uint256[][] memory weights = new uint256[][](1);
+        uint256[] memory multiWeights = new uint256[](3);
         multiWeights[0] = 100;
         multiWeights[1] = 200;
         multiWeights[2] = 300;
@@ -654,21 +764,31 @@ contract BN254TableCalculatorBaseUnitTests_getOperatorInfos is BN254TableCalcula
         assertEq(infos[0].weights[2], 300, "Weight[2] mismatch");
     }
 
-    function testFuzz_getOperatorInfos(uint8 numOperators) public {
+    function testFuzz_getOperatorInfos(
+        uint8 numOperators
+    ) public {
         numOperators = uint8(bound(numOperators, 1, 5));
 
         address[] memory operators = new address[](numOperators);
-        uint[][] memory weights = new uint[][](numOperators);
+        uint256[][] memory weights = new uint256[][](numOperators);
 
         // Generate operators and weights
-        for (uint i = 0; i < numOperators; i++) {
+        for (uint256 i = 0; i < numOperators; i++) {
             operators[i] = address(uint160(i + 100));
             weights[i] = _createSingleWeightArray((i + 1) * 100)[0];
         }
 
         // Register some operators with valid keys
-        if (numOperators >= 1) _registerOperatorKey(operators[0], defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1);
-        if (numOperators >= 3) _registerOperatorKey(operators[2], defaultOperatorSet, bn254G1Key2, bn254G2Key2, BN254_PRIV_KEY_2);
+        if (numOperators >= 1) {
+            _registerOperatorKey(
+                operators[0], defaultOperatorSet, bn254G1Key1, bn254G2Key1, BN254_PRIV_KEY_1
+            );
+        }
+        if (numOperators >= 3) {
+            _registerOperatorKey(
+                operators[2], defaultOperatorSet, bn254G1Key2, bn254G2Key2, BN254_PRIV_KEY_2
+            );
+        }
 
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
 
@@ -676,15 +796,20 @@ contract BN254TableCalculatorBaseUnitTests_getOperatorInfos is BN254TableCalcula
 
         assertEq(infos.length, numOperators, "Operator info count mismatch");
 
-        for (uint i = 0; i < numOperators; i++) {
+        for (uint256 i = 0; i < numOperators; i++) {
             if ((i == 0 && numOperators >= 1) || (i == 2 && numOperators >= 3)) {
                 // Registered operators should have weights
                 assertEq(infos[i].weights.length, 1, "Registered operator should have weights");
                 assertEq(infos[i].weights[0], (i + 1) * 100, "Weight value mismatch");
-                assertTrue(infos[i].pubkey.X != 0 || infos[i].pubkey.Y != 0, "Registered operator should have pubkey");
+                assertTrue(
+                    infos[i].pubkey.X != 0 || infos[i].pubkey.Y != 0,
+                    "Registered operator should have pubkey"
+                );
             } else {
                 // Unregistered operators should have empty weights
-                assertEq(infos[i].weights.length, 0, "Unregistered operator should have empty weights");
+                assertEq(
+                    infos[i].weights.length, 0, "Unregistered operator should have empty weights"
+                );
                 assertEq(infos[i].pubkey.X, 0, "Unregistered operator pubkey X should be 0");
                 assertEq(infos[i].pubkey.Y, 0, "Unregistered operator pubkey Y should be 0");
             }

--- a/test/unit/middlewareV2/ECDSATableCalculatorBaseUnit.t.sol
+++ b/test/unit/middlewareV2/ECDSATableCalculatorBaseUnit.t.sol
@@ -1,0 +1,745 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {KeyRegistrar, IKeyRegistrarTypes} from "eigenlayer-contracts/src/contracts/permissions/KeyRegistrar.sol";
+import {IKeyRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
+import {IOperatorTableCalculatorTypes} from "eigenlayer-contracts/src/contracts/interfaces/IOperatorTableCalculator.sol";
+import {IECDSATableCalculator} from "../../../src/interfaces/IECDSATableCalculator.sol";
+import {
+    OperatorSet,
+    OperatorSetLib
+} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+import {SlashingLib} from "eigenlayer-contracts/src/contracts/libraries/SlashingLib.sol";
+import {AllocationManagerMock} from "eigenlayer-contracts/src/test/mocks/AllocationManagerMock.sol";
+import {ECDSATableCalculatorBase} from "../../../src/middlewareV2/tableCalculator/ECDSATableCalculatorBase.sol";
+import {MockEigenLayerDeployer} from "./MockDeployer.sol";
+import "test/utils/Random.sol";
+
+
+// Mock implementation for testing abstract contract
+contract ECDSATableCalculatorBaseHarness is ECDSATableCalculatorBase {
+    // Storage for mock weights
+    mapping(bytes32 => address[]) internal _mockOperators;
+    mapping(bytes32 => uint[][]) internal _mockWeights;
+
+    constructor(IKeyRegistrar _keyRegistrar) ECDSATableCalculatorBase(_keyRegistrar) {}
+
+    function setMockOperatorWeights(OperatorSet calldata operatorSet, address[] memory operators, uint[][] memory weights) external {
+        bytes32 key = operatorSet.key();
+        _mockOperators[key] = operators;
+        _mockWeights[key] = weights;
+    }
+
+    function _getOperatorWeights(OperatorSet calldata operatorSet)
+        internal
+        view
+        override
+        returns (address[] memory operators, uint[][] memory weights)
+    {
+        bytes32 key = operatorSet.key();
+        operators = _mockOperators[key];
+        weights = _mockWeights[key];
+    }
+}
+
+/**
+ * @title ECDSATableCalculatorBaseUnitTests
+ * @notice Base contract for all ECDSATableCalculatorBase unit tests
+ */
+contract ECDSATableCalculatorBaseUnitTests is MockEigenLayerDeployer, IOperatorTableCalculatorTypes, IKeyRegistrarTypes {
+    using OperatorSetLib for OperatorSet;
+
+    // Test contracts
+    ECDSATableCalculatorBaseHarness public calculator;
+
+    // Test addresses
+    address public avs1 = address(0x1);
+    address public avs2 = address(0x2);
+    address public operator1 = address(0x3);
+    address public operator2 = address(0x4);
+    address public operator3 = address(0x5);
+
+    // Test operator sets
+    OperatorSet defaultOperatorSet;
+    OperatorSet alternativeOperatorSet;
+
+    // ECDSA test keys (private keys for signature generation)
+    uint constant ECDSA_PRIV_KEY_1 = 0x1234567890123456789012345678901234567890123456789012345678901234;
+    uint constant ECDSA_PRIV_KEY_2 = 0x9876543210987654321098765432109876543210987654321098765432109876;
+    uint constant ECDSA_PRIV_KEY_3 = 0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890;
+
+    // ECDSA addresses (public keys)
+    address public ecdsaAddress1;
+    address public ecdsaAddress2;
+    address public ecdsaAddress3;
+
+    // ECDSA key data (20-byte addresses)
+    bytes public ecdsaKey1;
+    bytes public ecdsaKey2;
+    bytes public ecdsaKey3;
+
+    function setUp() public virtual {
+        _deployMockEigenLayer();
+
+        // Deploy calculator with KeyRegistrar
+        calculator = new ECDSATableCalculatorBaseHarness(keyRegistrar);
+
+        // Set up operator sets
+        defaultOperatorSet = OperatorSet({avs: avs1, id: 0});
+        alternativeOperatorSet = OperatorSet({avs: avs2, id: 1});
+
+        // Set up ECDSA addresses that correspond to the private keys
+        ecdsaAddress1 = vm.addr(ECDSA_PRIV_KEY_1);
+        ecdsaAddress2 = vm.addr(ECDSA_PRIV_KEY_2);
+        ecdsaAddress3 = vm.addr(ECDSA_PRIV_KEY_3);
+
+        // Set up ECDSA key data (20-byte addresses)
+        ecdsaKey1 = abi.encodePacked(ecdsaAddress1);
+        ecdsaKey2 = abi.encodePacked(ecdsaAddress2);
+        ecdsaKey3 = abi.encodePacked(ecdsaAddress3);
+
+        // Configure operator sets in AllocationManager
+        allocationManagerMock.setAVSRegistrar(avs1, avs1);
+        allocationManagerMock.setAVSRegistrar(avs2, avs2);
+
+        // Configure operator sets for ECDSA
+        vm.prank(avs1);
+        keyRegistrar.configureOperatorSet(defaultOperatorSet, IKeyRegistrarTypes.CurveType.ECDSA);
+
+        vm.prank(avs2);
+        keyRegistrar.configureOperatorSet(alternativeOperatorSet, IKeyRegistrarTypes.CurveType.ECDSA);
+    }
+
+    // Helper functions
+    function _registerOperatorKey(address operator, OperatorSet memory operatorSet, address ecdsaAddress, uint privKey) internal {
+        bytes memory signature = _generateECDSASignature(operator, operatorSet, ecdsaAddress, privKey);
+
+        vm.prank(operator);
+        keyRegistrar.registerKey(operator, operatorSet, abi.encodePacked(ecdsaAddress), signature);
+    }
+
+    function _generateECDSASignature(address operator, OperatorSet memory operatorSet, address ecdsaAddress, uint privKey)
+        internal
+        view
+        returns (bytes memory)
+    {
+        bytes32 messageHash = keyRegistrar.getECDSAKeyRegistrationMessageHash(operator, operatorSet, ecdsaAddress);
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privKey, messageHash);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _createSingleWeightArray(uint weight) internal pure returns (uint[][] memory) {
+        uint[][] memory weights = new uint[][](1);
+        weights[0] = new uint[](1);
+        weights[0][0] = weight;
+        return weights;
+    }
+
+    function _createMultiWeightArray(uint[] memory weightValues) internal pure returns (uint[][] memory) {
+        uint[][] memory weights = new uint[][](1);
+        weights[0] = weightValues;
+        return weights;
+    }
+}
+
+/**
+ * @title ECDSATableCalculatorBaseUnitTests_calculateOperatorTable
+ * @notice Unit tests for ECDSATableCalculatorBase.calculateOperatorTable
+ */
+contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTable is ECDSATableCalculatorBaseUnitTests {
+    function test_noOperators() public {
+        // Set empty operators and weights
+        address[] memory operators = new address[](0);
+        uint[][] memory weights = new uint[][](0);
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        ECDSAOperatorInfo[] memory infos = calculator.calculateOperatorTable(defaultOperatorSet);
+
+        assertEq(infos.length, 0, "Should have 0 operators");
+    }
+
+    function test_operatorsWithNoRegisteredKeys() public {
+        // Set operators without registering their keys
+        address[] memory operators = new address[](2);
+        operators[0] = operator1;
+        operators[1] = operator2;
+
+        uint[][] memory weights = new uint[][](2);
+        weights[0] = _createSingleWeightArray(100)[0];
+        weights[1] = _createSingleWeightArray(200)[0];
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        ECDSAOperatorInfo[] memory infos = calculator.calculateOperatorTable(defaultOperatorSet);
+
+        // When no operators have registered keys, should return empty array
+        assertEq(infos.length, 0, "Should have 0 operators when none are registered");
+    }
+
+    function test_allOperatorsRegistered() public {
+        // Register operators
+        _registerOperatorKey(operator1, defaultOperatorSet, ecdsaAddress1, ECDSA_PRIV_KEY_1);
+        _registerOperatorKey(operator2, defaultOperatorSet, ecdsaAddress2, ECDSA_PRIV_KEY_2);
+
+        // Set operators and weights
+        address[] memory operators = new address[](2);
+        operators[0] = operator1;
+        operators[1] = operator2;
+
+        uint[][] memory weights = new uint[][](2);
+        weights[0] = _createSingleWeightArray(100)[0];
+        weights[1] = _createSingleWeightArray(200)[0];
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        ECDSAOperatorInfo[] memory infos = calculator.calculateOperatorTable(defaultOperatorSet);
+
+        assertEq(infos.length, 2, "Should have 2 operators");
+        assertEq(infos[0].pubkey, ecdsaAddress1, "Operator1 pubkey mismatch");
+        assertEq(infos[0].weights[0], 100, "Operator1 weight mismatch");
+        assertEq(infos[1].pubkey, ecdsaAddress2, "Operator2 pubkey mismatch");
+        assertEq(infos[1].weights[0], 200, "Operator2 weight mismatch");
+    }
+
+    function test_multipleWeightTypes() public {
+        // Register operators
+        _registerOperatorKey(operator1, defaultOperatorSet, ecdsaAddress1, ECDSA_PRIV_KEY_1);
+        _registerOperatorKey(operator2, defaultOperatorSet, ecdsaAddress2, ECDSA_PRIV_KEY_2);
+
+        // Set operators and weights with multiple types
+        address[] memory operators = new address[](2);
+        operators[0] = operator1;
+        operators[1] = operator2;
+
+        uint[][] memory weights = new uint[][](2);
+        uint[] memory op1Weights = new uint[](3);
+        op1Weights[0] = 100;
+        op1Weights[1] = 150;
+        op1Weights[2] = 50;
+        weights[0] = op1Weights;
+
+        uint[] memory op2Weights = new uint[](3);
+        op2Weights[0] = 200;
+        op2Weights[1] = 250;
+        op2Weights[2] = 100;
+        weights[1] = op2Weights;
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        ECDSAOperatorInfo[] memory infos = calculator.calculateOperatorTable(defaultOperatorSet);
+
+        assertEq(infos.length, 2, "Should have 2 operators");
+        assertEq(infos[0].weights.length, 3, "Operator1 should have 3 weight types");
+        assertEq(infos[0].weights[0], 100, "Operator1 weight[0] mismatch");
+        assertEq(infos[0].weights[1], 150, "Operator1 weight[1] mismatch");
+        assertEq(infos[0].weights[2], 50, "Operator1 weight[2] mismatch");
+        assertEq(infos[1].weights.length, 3, "Operator2 should have 3 weight types");
+        assertEq(infos[1].weights[0], 200, "Operator2 weight[0] mismatch");
+        assertEq(infos[1].weights[1], 250, "Operator2 weight[1] mismatch");
+        assertEq(infos[1].weights[2], 100, "Operator2 weight[2] mismatch");
+    }
+
+    function test_mixedRegistrationStatus() public {
+        // Register only operator1
+        _registerOperatorKey(operator1, defaultOperatorSet, ecdsaAddress1, ECDSA_PRIV_KEY_1);
+
+        // Set operators and weights
+        address[] memory operators = new address[](3);
+        operators[0] = operator1; // registered
+        operators[1] = operator2; // not registered
+        operators[2] = operator3; // not registered
+
+        uint[][] memory weights = new uint[][](3);
+        weights[0] = _createSingleWeightArray(100)[0];
+        weights[1] = _createSingleWeightArray(200)[0];
+        weights[2] = _createSingleWeightArray(300)[0];
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        ECDSAOperatorInfo[] memory infos = calculator.calculateOperatorTable(defaultOperatorSet);
+
+        assertEq(infos.length, 1, "Should have 1 operator (only registered ones count)");
+        assertEq(infos[0].pubkey, ecdsaAddress1, "Operator1 pubkey mismatch");
+        assertEq(infos[0].weights[0], 100, "Operator1 weight mismatch");
+    }
+
+    function test_singleOperatorRegistered() public {
+        // Test with 1 operator, 1 registered
+        address newOperator = address(uint160(100));
+
+        address[] memory operators = new address[](1);
+        operators[0] = newOperator;
+        uint[][] memory weights = new uint[][](1);
+        weights[0] = _createSingleWeightArray(100)[0];
+
+        _registerOperatorKey(newOperator, defaultOperatorSet, ecdsaAddress1, ECDSA_PRIV_KEY_1);
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        ECDSAOperatorInfo[] memory infos = calculator.calculateOperatorTable(defaultOperatorSet);
+        assertEq(infos.length, 1, "Should have 1 operator");
+        assertEq(infos[0].pubkey, ecdsaAddress1, "Operator pubkey mismatch");
+        assertEq(infos[0].weights[0], 100, "Operator weight mismatch");
+    }
+
+    function test_subsetRegisteredToAVS() public {
+        // Register all operator keys
+        _registerOperatorKey(operator1, defaultOperatorSet, ecdsaAddress1, ECDSA_PRIV_KEY_1);
+        _registerOperatorKey(operator2, defaultOperatorSet, ecdsaAddress2, ECDSA_PRIV_KEY_2);
+        _registerOperatorKey(operator3, defaultOperatorSet, ecdsaAddress3, ECDSA_PRIV_KEY_3); // Not in actual operator set
+
+        // Set operators and weights
+        address[] memory operators = new address[](2);
+        operators[0] = operator1; // registered
+        operators[1] = operator2; // registered
+
+        uint[][] memory weights = new uint[][](2);
+        weights[0] = _createSingleWeightArray(100)[0];
+        weights[1] = _createSingleWeightArray(200)[0];
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        ECDSAOperatorInfo[] memory infos = calculator.calculateOperatorTable(defaultOperatorSet);
+
+        assertEq(infos.length, 2, "Should have 2 operators");
+        assertEq(infos[0].pubkey, ecdsaAddress1, "Operator1 pubkey mismatch");
+        assertEq(infos[0].weights[0], 100, "Operator1 weight mismatch");
+        assertEq(infos[1].pubkey, ecdsaAddress2, "Operator2 pubkey mismatch");
+        assertEq(infos[1].weights[0], 200, "Operator2 weight mismatch");
+    }
+
+    function test_subsetRegisteredKey() public {
+        // Register operator1 and operator3, but not operator2
+        _registerOperatorKey(operator1, defaultOperatorSet, ecdsaAddress1, ECDSA_PRIV_KEY_1);
+        _registerOperatorKey(operator3, defaultOperatorSet, ecdsaAddress3, ECDSA_PRIV_KEY_3);
+
+        // Set operators and weights
+        address[] memory operators = new address[](3);
+        operators[0] = operator1; // registered
+        operators[1] = operator2; // not registered
+        operators[2] = operator3; // registered
+
+        uint[][] memory weights = new uint[][](3);
+        weights[0] = _createSingleWeightArray(100)[0];
+        weights[1] = _createSingleWeightArray(200)[0]; // This weight won't be included
+        weights[2] = _createSingleWeightArray(300)[0];
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        ECDSAOperatorInfo[] memory infos = calculator.calculateOperatorTable(defaultOperatorSet);
+
+        assertEq(infos.length, 2, "Should have 2 operators (only registered ones)");
+        assertEq(infos[0].pubkey, ecdsaAddress1, "Operator1 pubkey mismatch");
+        assertEq(infos[0].weights[0], 100, "Operator1 weight mismatch");
+        assertEq(infos[1].pubkey, ecdsaAddress3, "Operator3 pubkey mismatch");
+        assertEq(infos[1].weights[0], 300, "Operator3 weight mismatch");
+    }
+
+    function test_emptyOperatorSetReturnsEmptyArray() public {
+        // Test with operators that exist but none registered
+        address[] memory operators = new address[](3);
+        operators[0] = operator1;
+        operators[1] = operator2;
+        operators[2] = operator3;
+
+        uint[][] memory weights = new uint[][](3);
+        weights[0] = _createSingleWeightArray(100)[0];
+        weights[1] = _createSingleWeightArray(200)[0];
+        weights[2] = _createSingleWeightArray(300)[0];
+
+        // Don't register any operators
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        ECDSAOperatorInfo[] memory infos = calculator.calculateOperatorTable(defaultOperatorSet);
+
+        // Verify empty array when no operators are registered
+        assertEq(infos.length, 0, "Should have 0 operators when none are registered");
+    }
+
+    function testFuzz_calculateOperatorTable(Randomness r, uint8 numOperators, uint8 numRegistered) public rand(r) {
+        numOperators = uint8(r.Uint256() % 10 + 1); // 1-10 operators
+        numRegistered = uint8(r.Uint256() % (numOperators + 1)); // 0 to numOperators registered
+
+        address[] memory operators = new address[](numOperators);
+        uint[][] memory weights = new uint[][](numOperators);
+
+        // Generate random operators and weights
+        for (uint i = 0; i < numOperators; i++) {
+            operators[i] = address(uint160(r.Uint256()));
+            weights[i] = _createSingleWeightArray(r.Uint256() % 1000 + 1)[0];
+        }
+
+        // Register random subset of operators
+        uint[] memory registeredIndices = new uint[](numRegistered);
+        for (uint i = 0; i < numRegistered; i++) {
+            uint idx = r.Uint256() % numOperators;
+            // Ensure unique indices
+            bool unique = true;
+            for (uint j = 0; j < i; j++) {
+                if (registeredIndices[j] == idx) {
+                    unique = false;
+                    break;
+                }
+            }
+            if (unique) {
+                registeredIndices[i] = idx;
+                address ecdsaAddr = vm.addr(uint(keccak256(abi.encode(operators[idx], i))));
+                _registerOperatorKey(operators[idx], defaultOperatorSet, ecdsaAddr, uint(keccak256(abi.encode(operators[idx], i))));
+            }
+        }
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+        ECDSAOperatorInfo[] memory infos = calculator.calculateOperatorTable(defaultOperatorSet);
+
+        // Count actual registered operators
+        uint actualRegistered = 0;
+        for (uint i = 0; i < numOperators; i++) {
+            if (keyRegistrar.isRegistered(defaultOperatorSet, operators[i])) actualRegistered++;
+        }
+
+        assertEq(infos.length, actualRegistered, "Should have correct number of registered operators");
+    }
+}
+
+/**
+ * @title ECDSATableCalculatorBaseUnitTests_calculateOperatorTableBytes
+ * @notice Unit tests for ECDSATableCalculatorBase.calculateOperatorTableBytes
+ */
+contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTableBytes is ECDSATableCalculatorBaseUnitTests {
+    function test_encodesCorrectly() public {
+        // Register operator
+        _registerOperatorKey(operator1, defaultOperatorSet, ecdsaAddress1, ECDSA_PRIV_KEY_1);
+
+        // Set operators and weights
+        address[] memory operators = new address[](1);
+        operators[0] = operator1;
+        uint[][] memory weights = _createSingleWeightArray(100);
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        bytes memory tableBytes = calculator.calculateOperatorTableBytes(defaultOperatorSet);
+
+        // Decode and verify
+        ECDSAOperatorInfo[] memory decodedInfos = abi.decode(tableBytes, (ECDSAOperatorInfo[]));
+
+        assertEq(decodedInfos.length, 1, "Should have 1 operator");
+        assertEq(decodedInfos[0].weights[0], 100, "Total weight should be 100");
+        assertEq(decodedInfos[0].pubkey, ecdsaAddress1, "Pubkey mismatch");
+    }
+
+    function test_multipleOperatorsEncodedCorrectly() public {
+        // Register multiple operators
+        _registerOperatorKey(operator1, defaultOperatorSet, ecdsaAddress1, ECDSA_PRIV_KEY_1);
+        _registerOperatorKey(operator2, defaultOperatorSet, ecdsaAddress2, ECDSA_PRIV_KEY_2);
+        _registerOperatorKey(operator3, defaultOperatorSet, ecdsaAddress3, ECDSA_PRIV_KEY_3);
+
+        // Set operators and weights
+        address[] memory operators = new address[](3);
+        operators[0] = operator1;
+        operators[1] = operator2;
+        operators[2] = operator3;
+
+        uint[][] memory weights = new uint[][](3);
+        weights[0] = _createSingleWeightArray(100)[0];
+        weights[1] = _createSingleWeightArray(200)[0];
+        weights[2] = _createSingleWeightArray(300)[0];
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        bytes memory tableBytes = calculator.calculateOperatorTableBytes(defaultOperatorSet);
+
+        // Decode and verify
+        ECDSAOperatorInfo[] memory decodedInfos = abi.decode(tableBytes, (ECDSAOperatorInfo[]));
+
+        assertEq(decodedInfos.length, 3, "Should have 3 operators");
+        assertEq(decodedInfos[0].pubkey, ecdsaAddress1, "Operator1 pubkey mismatch");
+        assertEq(decodedInfos[0].weights[0], 100, "Operator1 weight mismatch");
+        assertEq(decodedInfos[1].pubkey, ecdsaAddress2, "Operator2 pubkey mismatch");
+        assertEq(decodedInfos[1].weights[0], 200, "Operator2 weight mismatch");
+        assertEq(decodedInfos[2].pubkey, ecdsaAddress3, "Operator3 pubkey mismatch");
+        assertEq(decodedInfos[2].weights[0], 300, "Operator3 weight mismatch");
+    }
+
+    function test_emptyOperatorSetEncodesEmptyArray() public {
+        // Don't register any operators
+        address[] memory operators = new address[](0);
+        uint[][] memory weights = new uint[][](0);
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        bytes memory tableBytes = calculator.calculateOperatorTableBytes(defaultOperatorSet);
+
+        // Decode and verify
+        ECDSAOperatorInfo[] memory decodedInfos = abi.decode(tableBytes, (ECDSAOperatorInfo[]));
+
+        assertEq(decodedInfos.length, 0, "Should encode empty array");
+    }
+
+    function testFuzz_encodesCorrectly(Randomness r, uint weight) public rand(r) {
+        weight = r.Uint256() % 1e18 + 1; // 1 to 1e18
+
+        // Register operator
+        _registerOperatorKey(operator1, defaultOperatorSet, ecdsaAddress1, ECDSA_PRIV_KEY_1);
+
+        // Set operators and weights
+        address[] memory operators = new address[](1);
+        operators[0] = operator1;
+        uint[][] memory weights = _createSingleWeightArray(weight);
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        bytes memory tableBytes = calculator.calculateOperatorTableBytes(defaultOperatorSet);
+
+        // Decode and verify
+        ECDSAOperatorInfo[] memory decodedInfos = abi.decode(tableBytes, (ECDSAOperatorInfo[]));
+
+        assertEq(decodedInfos[0].weights[0], weight, "Weight mismatch");
+    }
+
+    function testFuzz_multipleWeightTypesEncoded(Randomness r, uint8 numWeightTypes) public rand(r) {
+        numWeightTypes = uint8(r.Uint256() % 5 + 1); // 1-5 weight types
+
+        // Register operator
+        _registerOperatorKey(operator1, defaultOperatorSet, ecdsaAddress1, ECDSA_PRIV_KEY_1);
+
+        // Create random weights
+        uint[] memory weightValues = new uint[](numWeightTypes);
+        for (uint i = 0; i < numWeightTypes; i++) {
+            weightValues[i] = r.Uint256() % 1000 + 1;
+        }
+
+        address[] memory operators = new address[](1);
+        operators[0] = operator1;
+        uint[][] memory weights = new uint[][](1);
+        weights[0] = weightValues;
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        bytes memory tableBytes = calculator.calculateOperatorTableBytes(defaultOperatorSet);
+
+        // Decode and verify
+        ECDSAOperatorInfo[] memory decodedInfos = abi.decode(tableBytes, (ECDSAOperatorInfo[]));
+
+        assertEq(decodedInfos.length, 1, "Should have 1 operator");
+        assertEq(decodedInfos[0].weights.length, numWeightTypes, "Weight types mismatch");
+
+        for (uint i = 0; i < numWeightTypes; i++) {
+            assertEq(decodedInfos[0].weights[i], weightValues[i], "Weight value mismatch");
+        }
+    }
+}
+
+/**
+ * @title ECDSATableCalculatorBaseUnitTests_getOperatorWeights
+ * @notice Unit tests for ECDSATableCalculatorBase.getOperatorWeights
+ */
+contract ECDSATableCalculatorBaseUnitTests_getOperatorWeights is ECDSATableCalculatorBaseUnitTests {
+    function test_returnsImplementationResult() public {
+        // Set mock weights
+        address[] memory expectedOperators = new address[](2);
+        expectedOperators[0] = operator1;
+        expectedOperators[1] = operator2;
+
+        uint[][] memory expectedWeights = new uint[][](2);
+        expectedWeights[0] = _createSingleWeightArray(100)[0];
+        expectedWeights[1] = _createSingleWeightArray(200)[0];
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, expectedOperators, expectedWeights);
+
+        (address[] memory operators, uint[][] memory weights) = calculator.getOperatorWeights(defaultOperatorSet);
+
+        assertEq(operators.length, expectedOperators.length, "Operators length mismatch");
+        assertEq(weights.length, expectedWeights.length, "Weights length mismatch");
+
+        for (uint i = 0; i < operators.length; i++) {
+            assertEq(operators[i], expectedOperators[i], "Operator address mismatch");
+            assertEq(weights[i][0], expectedWeights[i][0], "Weight value mismatch");
+        }
+    }
+
+    function test_emptyOperatorSet() public {
+        // Set empty operators and weights
+        address[] memory expectedOperators = new address[](0);
+        uint[][] memory expectedWeights = new uint[][](0);
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, expectedOperators, expectedWeights);
+
+        (address[] memory operators, uint[][] memory weights) = calculator.getOperatorWeights(defaultOperatorSet);
+
+        assertEq(operators.length, 0, "Should return empty operators array");
+        assertEq(weights.length, 0, "Should return empty weights array");
+    }
+
+    function test_alternativeOperatorSet() public {
+        // Set weights for alternative operator set
+        address[] memory expectedOperators = new address[](1);
+        expectedOperators[0] = operator3;
+
+        uint[][] memory expectedWeights = new uint[][](1);
+        expectedWeights[0] = _createSingleWeightArray(500)[0];
+
+        calculator.setMockOperatorWeights(alternativeOperatorSet, expectedOperators, expectedWeights);
+
+        (address[] memory operators, uint[][] memory weights) = calculator.getOperatorWeights(alternativeOperatorSet);
+
+        assertEq(operators.length, 1, "Operators length mismatch");
+        assertEq(operators[0], operator3, "Operator address mismatch");
+        assertEq(weights[0][0], 500, "Weight value mismatch");
+    }
+
+    function testFuzz_returnsImplementationResult(Randomness r, uint8 numOperators) public rand(r) {
+        numOperators = uint8(r.Uint256() % 20); // 0-19 operators
+
+        address[] memory expectedOperators = new address[](numOperators);
+        uint[][] memory expectedWeights = new uint[][](numOperators);
+
+        for (uint i = 0; i < numOperators; i++) {
+            expectedOperators[i] = address(uint160(r.Uint256()));
+            expectedWeights[i] = _createSingleWeightArray(r.Uint256() % 1000 + 1)[0];
+        }
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, expectedOperators, expectedWeights);
+
+        (address[] memory operators, uint[][] memory weights) = calculator.getOperatorWeights(defaultOperatorSet);
+
+        assertEq(operators.length, numOperators, "Operators length mismatch");
+        assertEq(weights.length, numOperators, "Weights length mismatch");
+
+        for (uint i = 0; i < numOperators; i++) {
+            assertEq(operators[i], expectedOperators[i], "Operator address mismatch");
+            assertEq(weights[i][0], expectedWeights[i][0], "Weight value mismatch");
+        }
+    }
+}
+
+/**
+ * @title ECDSATableCalculatorBaseUnitTests_getOperatorWeight
+ * @notice Unit tests for ECDSATableCalculatorBase.getOperatorWeight
+ */
+contract ECDSATableCalculatorBaseUnitTests_getOperatorWeight is ECDSATableCalculatorBaseUnitTests {
+    function test_operatorExists() public {
+        // Set operators and weights
+        address[] memory operators = new address[](3);
+        operators[0] = operator1;
+        operators[1] = operator2;
+        operators[2] = operator3;
+
+        uint[][] memory weights = new uint[][](3);
+        weights[0] = _createSingleWeightArray(100)[0];
+        weights[1] = _createSingleWeightArray(200)[0];
+        weights[2] = _createSingleWeightArray(300)[0];
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator1), 100, "Operator1 weight mismatch");
+        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator2), 200, "Operator2 weight mismatch");
+        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator3), 300, "Operator3 weight mismatch");
+    }
+
+    function test_operatorDoesNotExist() public {
+        // Set operators and weights
+        address[] memory operators = new address[](2);
+        operators[0] = operator1;
+        operators[1] = operator2;
+
+        uint[][] memory weights = new uint[][](2);
+        weights[0] = _createSingleWeightArray(100)[0];
+        weights[1] = _createSingleWeightArray(200)[0];
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator3), 0, "Non-existent operator should return 0");
+        assertEq(calculator.getOperatorWeight(defaultOperatorSet, address(0xdead)), 0, "Random address should return 0");
+    }
+
+    function test_emptyOperatorSet() public {
+        // Set empty operators and weights
+        address[] memory operators = new address[](0);
+        uint[][] memory weights = new uint[][](0);
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator1), 0, "Should return 0 for empty set");
+    }
+
+    function test_zeroWeight() public {
+        // Set operator with zero weight
+        address[] memory operators = new address[](1);
+        operators[0] = operator1;
+
+        uint[][] memory weights = new uint[][](1);
+        weights[0] = _createSingleWeightArray(0)[0];
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator1), 0, "Should return 0 for zero weight");
+    }
+
+    function test_multipleWeightTypes() public {
+        // Set operator with multiple weight types
+        address[] memory operators = new address[](1);
+        operators[0] = operator1;
+
+        uint[][] memory weights = new uint[][](1);
+        uint[] memory multiWeights = new uint[](3);
+        multiWeights[0] = 100;
+        multiWeights[1] = 200;
+        multiWeights[2] = 300;
+        weights[0] = multiWeights;
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        // getOperatorWeight returns first weight type
+        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator1), 100, "Should return first weight type");
+    }
+
+    function testFuzz_getOperatorWeight(Randomness r, address operator, uint weight) public rand(r) {
+        weight = r.Uint256() % 1e18; // 0 to 1e18
+
+        // Set single operator
+        address[] memory operators = new address[](1);
+        operators[0] = operator;
+
+        uint[][] memory weights = _createSingleWeightArray(weight);
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator), weight, "Weight mismatch");
+
+        // Different operator should return 0
+        address differentOperator = address(uint160(uint(uint160(operator)) + 1));
+        assertEq(calculator.getOperatorWeight(defaultOperatorSet, differentOperator), 0, "Different operator should return 0");
+    }
+
+    function testFuzz_multipleOperators(Randomness r, uint8 numOperators) public rand(r) {
+        numOperators = uint8(r.Uint256() % 10 + 1); // 1-10 operators
+
+        address[] memory operators = new address[](numOperators);
+        uint[][] memory weights = new uint[][](numOperators);
+        uint[] memory expectedWeights = new uint[](numOperators);
+
+        for (uint i = 0; i < numOperators; i++) {
+            operators[i] = address(uint160(r.Uint256()));
+            expectedWeights[i] = r.Uint256() % 1000 + 1;
+            weights[i] = _createSingleWeightArray(expectedWeights[i])[0];
+        }
+
+        calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
+
+        // Verify each operator's weight
+        for (uint i = 0; i < numOperators; i++) {
+            assertEq(calculator.getOperatorWeight(defaultOperatorSet, operators[i]), expectedWeights[i], "Weight mismatch");
+        }
+
+        // Non-existent operator should return 0
+        address nonExistent = address(uint160(r.Uint256()));
+        bool exists = false;
+        for (uint i = 0; i < numOperators; i++) {
+            if (operators[i] == nonExistent) {
+                exists = true;
+                break;
+            }
+        }
+        if (!exists) assertEq(calculator.getOperatorWeight(defaultOperatorSet, nonExistent), 0, "Non-existent operator should return 0");
+    }
+}

--- a/test/unit/middlewareV2/ECDSATableCalculatorBaseUnit.t.sol
+++ b/test/unit/middlewareV2/ECDSATableCalculatorBaseUnit.t.sol
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {KeyRegistrar, IKeyRegistrarTypes} from "eigenlayer-contracts/src/contracts/permissions/KeyRegistrar.sol";
+import {
+    KeyRegistrar,
+    IKeyRegistrarTypes
+} from "eigenlayer-contracts/src/contracts/permissions/KeyRegistrar.sol";
 import {IKeyRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
-import {IOperatorTableCalculatorTypes} from "eigenlayer-contracts/src/contracts/interfaces/IOperatorTableCalculator.sol";
+import {IOperatorTableCalculatorTypes} from
+    "eigenlayer-contracts/src/contracts/interfaces/IOperatorTableCalculator.sol";
 import {IECDSATableCalculator} from "../../../src/interfaces/IECDSATableCalculator.sol";
 import {
     OperatorSet,
@@ -11,31 +15,34 @@ import {
 } from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
 import {SlashingLib} from "eigenlayer-contracts/src/contracts/libraries/SlashingLib.sol";
 import {AllocationManagerMock} from "eigenlayer-contracts/src/test/mocks/AllocationManagerMock.sol";
-import {ECDSATableCalculatorBase} from "../../../src/middlewareV2/tableCalculator/ECDSATableCalculatorBase.sol";
+import {ECDSATableCalculatorBase} from
+    "../../../src/middlewareV2/tableCalculator/ECDSATableCalculatorBase.sol";
 import {MockEigenLayerDeployer} from "./MockDeployer.sol";
 import "test/utils/Random.sol";
-
 
 // Mock implementation for testing abstract contract
 contract ECDSATableCalculatorBaseHarness is ECDSATableCalculatorBase {
     // Storage for mock weights
     mapping(bytes32 => address[]) internal _mockOperators;
-    mapping(bytes32 => uint[][]) internal _mockWeights;
+    mapping(bytes32 => uint256[][]) internal _mockWeights;
 
-    constructor(IKeyRegistrar _keyRegistrar) ECDSATableCalculatorBase(_keyRegistrar) {}
+    constructor(
+        IKeyRegistrar _keyRegistrar
+    ) ECDSATableCalculatorBase(_keyRegistrar) {}
 
-    function setMockOperatorWeights(OperatorSet calldata operatorSet, address[] memory operators, uint[][] memory weights) external {
+    function setMockOperatorWeights(
+        OperatorSet calldata operatorSet,
+        address[] memory operators,
+        uint256[][] memory weights
+    ) external {
         bytes32 key = operatorSet.key();
         _mockOperators[key] = operators;
         _mockWeights[key] = weights;
     }
 
-    function _getOperatorWeights(OperatorSet calldata operatorSet)
-        internal
-        view
-        override
-        returns (address[] memory operators, uint[][] memory weights)
-    {
+    function _getOperatorWeights(
+        OperatorSet calldata operatorSet
+    ) internal view override returns (address[] memory operators, uint256[][] memory weights) {
         bytes32 key = operatorSet.key();
         operators = _mockOperators[key];
         weights = _mockWeights[key];
@@ -46,7 +53,11 @@ contract ECDSATableCalculatorBaseHarness is ECDSATableCalculatorBase {
  * @title ECDSATableCalculatorBaseUnitTests
  * @notice Base contract for all ECDSATableCalculatorBase unit tests
  */
-contract ECDSATableCalculatorBaseUnitTests is MockEigenLayerDeployer, IOperatorTableCalculatorTypes, IKeyRegistrarTypes {
+contract ECDSATableCalculatorBaseUnitTests is
+    MockEigenLayerDeployer,
+    IOperatorTableCalculatorTypes,
+    IKeyRegistrarTypes
+{
     using OperatorSetLib for OperatorSet;
 
     // Test contracts
@@ -64,9 +75,12 @@ contract ECDSATableCalculatorBaseUnitTests is MockEigenLayerDeployer, IOperatorT
     OperatorSet alternativeOperatorSet;
 
     // ECDSA test keys (private keys for signature generation)
-    uint constant ECDSA_PRIV_KEY_1 = 0x1234567890123456789012345678901234567890123456789012345678901234;
-    uint constant ECDSA_PRIV_KEY_2 = 0x9876543210987654321098765432109876543210987654321098765432109876;
-    uint constant ECDSA_PRIV_KEY_3 = 0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890;
+    uint256 constant ECDSA_PRIV_KEY_1 =
+        0x1234567890123456789012345678901234567890123456789012345678901234;
+    uint256 constant ECDSA_PRIV_KEY_2 =
+        0x9876543210987654321098765432109876543210987654321098765432109876;
+    uint256 constant ECDSA_PRIV_KEY_3 =
+        0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890;
 
     // ECDSA addresses (public keys)
     address public ecdsaAddress1;
@@ -107,37 +121,51 @@ contract ECDSATableCalculatorBaseUnitTests is MockEigenLayerDeployer, IOperatorT
         keyRegistrar.configureOperatorSet(defaultOperatorSet, IKeyRegistrarTypes.CurveType.ECDSA);
 
         vm.prank(avs2);
-        keyRegistrar.configureOperatorSet(alternativeOperatorSet, IKeyRegistrarTypes.CurveType.ECDSA);
+        keyRegistrar.configureOperatorSet(
+            alternativeOperatorSet, IKeyRegistrarTypes.CurveType.ECDSA
+        );
     }
 
     // Helper functions
-    function _registerOperatorKey(address operator, OperatorSet memory operatorSet, address ecdsaAddress, uint privKey) internal {
-        bytes memory signature = _generateECDSASignature(operator, operatorSet, ecdsaAddress, privKey);
+    function _registerOperatorKey(
+        address operator,
+        OperatorSet memory operatorSet,
+        address ecdsaAddress,
+        uint256 privKey
+    ) internal {
+        bytes memory signature =
+            _generateECDSASignature(operator, operatorSet, ecdsaAddress, privKey);
 
         vm.prank(operator);
         keyRegistrar.registerKey(operator, operatorSet, abi.encodePacked(ecdsaAddress), signature);
     }
 
-    function _generateECDSASignature(address operator, OperatorSet memory operatorSet, address ecdsaAddress, uint privKey)
-        internal
-        view
-        returns (bytes memory)
-    {
-        bytes32 messageHash = keyRegistrar.getECDSAKeyRegistrationMessageHash(operator, operatorSet, ecdsaAddress);
+    function _generateECDSASignature(
+        address operator,
+        OperatorSet memory operatorSet,
+        address ecdsaAddress,
+        uint256 privKey
+    ) internal view returns (bytes memory) {
+        bytes32 messageHash =
+            keyRegistrar.getECDSAKeyRegistrationMessageHash(operator, operatorSet, ecdsaAddress);
 
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privKey, messageHash);
         return abi.encodePacked(r, s, v);
     }
 
-    function _createSingleWeightArray(uint weight) internal pure returns (uint[][] memory) {
-        uint[][] memory weights = new uint[][](1);
-        weights[0] = new uint[](1);
+    function _createSingleWeightArray(
+        uint256 weight
+    ) internal pure returns (uint256[][] memory) {
+        uint256[][] memory weights = new uint256[][](1);
+        weights[0] = new uint256[](1);
         weights[0][0] = weight;
         return weights;
     }
 
-    function _createMultiWeightArray(uint[] memory weightValues) internal pure returns (uint[][] memory) {
-        uint[][] memory weights = new uint[][](1);
+    function _createMultiWeightArray(
+        uint256[] memory weightValues
+    ) internal pure returns (uint256[][] memory) {
+        uint256[][] memory weights = new uint256[][](1);
         weights[0] = weightValues;
         return weights;
     }
@@ -147,11 +175,13 @@ contract ECDSATableCalculatorBaseUnitTests is MockEigenLayerDeployer, IOperatorT
  * @title ECDSATableCalculatorBaseUnitTests_calculateOperatorTable
  * @notice Unit tests for ECDSATableCalculatorBase.calculateOperatorTable
  */
-contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTable is ECDSATableCalculatorBaseUnitTests {
+contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTable is
+    ECDSATableCalculatorBaseUnitTests
+{
     function test_noOperators() public {
         // Set empty operators and weights
         address[] memory operators = new address[](0);
-        uint[][] memory weights = new uint[][](0);
+        uint256[][] memory weights = new uint256[][](0);
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
 
         ECDSAOperatorInfo[] memory infos = calculator.calculateOperatorTable(defaultOperatorSet);
@@ -165,7 +195,7 @@ contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTable is ECDSATableC
         operators[0] = operator1;
         operators[1] = operator2;
 
-        uint[][] memory weights = new uint[][](2);
+        uint256[][] memory weights = new uint256[][](2);
         weights[0] = _createSingleWeightArray(100)[0];
         weights[1] = _createSingleWeightArray(200)[0];
 
@@ -187,7 +217,7 @@ contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTable is ECDSATableC
         operators[0] = operator1;
         operators[1] = operator2;
 
-        uint[][] memory weights = new uint[][](2);
+        uint256[][] memory weights = new uint256[][](2);
         weights[0] = _createSingleWeightArray(100)[0];
         weights[1] = _createSingleWeightArray(200)[0];
 
@@ -212,14 +242,14 @@ contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTable is ECDSATableC
         operators[0] = operator1;
         operators[1] = operator2;
 
-        uint[][] memory weights = new uint[][](2);
-        uint[] memory op1Weights = new uint[](3);
+        uint256[][] memory weights = new uint256[][](2);
+        uint256[] memory op1Weights = new uint256[](3);
         op1Weights[0] = 100;
         op1Weights[1] = 150;
         op1Weights[2] = 50;
         weights[0] = op1Weights;
 
-        uint[] memory op2Weights = new uint[](3);
+        uint256[] memory op2Weights = new uint256[](3);
         op2Weights[0] = 200;
         op2Weights[1] = 250;
         op2Weights[2] = 100;
@@ -250,7 +280,7 @@ contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTable is ECDSATableC
         operators[1] = operator2; // not registered
         operators[2] = operator3; // not registered
 
-        uint[][] memory weights = new uint[][](3);
+        uint256[][] memory weights = new uint256[][](3);
         weights[0] = _createSingleWeightArray(100)[0];
         weights[1] = _createSingleWeightArray(200)[0];
         weights[2] = _createSingleWeightArray(300)[0];
@@ -270,7 +300,7 @@ contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTable is ECDSATableC
 
         address[] memory operators = new address[](1);
         operators[0] = newOperator;
-        uint[][] memory weights = new uint[][](1);
+        uint256[][] memory weights = new uint256[][](1);
         weights[0] = _createSingleWeightArray(100)[0];
 
         _registerOperatorKey(newOperator, defaultOperatorSet, ecdsaAddress1, ECDSA_PRIV_KEY_1);
@@ -293,7 +323,7 @@ contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTable is ECDSATableC
         operators[0] = operator1; // registered
         operators[1] = operator2; // registered
 
-        uint[][] memory weights = new uint[][](2);
+        uint256[][] memory weights = new uint256[][](2);
         weights[0] = _createSingleWeightArray(100)[0];
         weights[1] = _createSingleWeightArray(200)[0];
 
@@ -319,7 +349,7 @@ contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTable is ECDSATableC
         operators[1] = operator2; // not registered
         operators[2] = operator3; // registered
 
-        uint[][] memory weights = new uint[][](3);
+        uint256[][] memory weights = new uint256[][](3);
         weights[0] = _createSingleWeightArray(100)[0];
         weights[1] = _createSingleWeightArray(200)[0]; // This weight won't be included
         weights[2] = _createSingleWeightArray(300)[0];
@@ -342,7 +372,7 @@ contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTable is ECDSATableC
         operators[1] = operator2;
         operators[2] = operator3;
 
-        uint[][] memory weights = new uint[][](3);
+        uint256[][] memory weights = new uint256[][](3);
         weights[0] = _createSingleWeightArray(100)[0];
         weights[1] = _createSingleWeightArray(200)[0];
         weights[2] = _createSingleWeightArray(300)[0];
@@ -356,26 +386,30 @@ contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTable is ECDSATableC
         assertEq(infos.length, 0, "Should have 0 operators when none are registered");
     }
 
-    function testFuzz_calculateOperatorTable(Randomness r, uint8 numOperators, uint8 numRegistered) public rand(r) {
+    function testFuzz_calculateOperatorTable(
+        Randomness r,
+        uint8 numOperators,
+        uint8 numRegistered
+    ) public rand(r) {
         numOperators = uint8(r.Uint256() % 10 + 1); // 1-10 operators
         numRegistered = uint8(r.Uint256() % (numOperators + 1)); // 0 to numOperators registered
 
         address[] memory operators = new address[](numOperators);
-        uint[][] memory weights = new uint[][](numOperators);
+        uint256[][] memory weights = new uint256[][](numOperators);
 
         // Generate random operators and weights
-        for (uint i = 0; i < numOperators; i++) {
+        for (uint256 i = 0; i < numOperators; i++) {
             operators[i] = address(uint160(r.Uint256()));
             weights[i] = _createSingleWeightArray(r.Uint256() % 1000 + 1)[0];
         }
 
         // Register random subset of operators
-        uint[] memory registeredIndices = new uint[](numRegistered);
-        for (uint i = 0; i < numRegistered; i++) {
-            uint idx = r.Uint256() % numOperators;
+        uint256[] memory registeredIndices = new uint256[](numRegistered);
+        for (uint256 i = 0; i < numRegistered; i++) {
+            uint256 idx = r.Uint256() % numOperators;
             // Ensure unique indices
             bool unique = true;
-            for (uint j = 0; j < i; j++) {
+            for (uint256 j = 0; j < i; j++) {
                 if (registeredIndices[j] == idx) {
                     unique = false;
                     break;
@@ -383,8 +417,13 @@ contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTable is ECDSATableC
             }
             if (unique) {
                 registeredIndices[i] = idx;
-                address ecdsaAddr = vm.addr(uint(keccak256(abi.encode(operators[idx], i))));
-                _registerOperatorKey(operators[idx], defaultOperatorSet, ecdsaAddr, uint(keccak256(abi.encode(operators[idx], i))));
+                address ecdsaAddr = vm.addr(uint256(keccak256(abi.encode(operators[idx], i))));
+                _registerOperatorKey(
+                    operators[idx],
+                    defaultOperatorSet,
+                    ecdsaAddr,
+                    uint256(keccak256(abi.encode(operators[idx], i)))
+                );
             }
         }
 
@@ -392,12 +431,14 @@ contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTable is ECDSATableC
         ECDSAOperatorInfo[] memory infos = calculator.calculateOperatorTable(defaultOperatorSet);
 
         // Count actual registered operators
-        uint actualRegistered = 0;
-        for (uint i = 0; i < numOperators; i++) {
+        uint256 actualRegistered = 0;
+        for (uint256 i = 0; i < numOperators; i++) {
             if (keyRegistrar.isRegistered(defaultOperatorSet, operators[i])) actualRegistered++;
         }
 
-        assertEq(infos.length, actualRegistered, "Should have correct number of registered operators");
+        assertEq(
+            infos.length, actualRegistered, "Should have correct number of registered operators"
+        );
     }
 }
 
@@ -405,7 +446,9 @@ contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTable is ECDSATableC
  * @title ECDSATableCalculatorBaseUnitTests_calculateOperatorTableBytes
  * @notice Unit tests for ECDSATableCalculatorBase.calculateOperatorTableBytes
  */
-contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTableBytes is ECDSATableCalculatorBaseUnitTests {
+contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTableBytes is
+    ECDSATableCalculatorBaseUnitTests
+{
     function test_encodesCorrectly() public {
         // Register operator
         _registerOperatorKey(operator1, defaultOperatorSet, ecdsaAddress1, ECDSA_PRIV_KEY_1);
@@ -413,7 +456,7 @@ contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTableBytes is ECDSAT
         // Set operators and weights
         address[] memory operators = new address[](1);
         operators[0] = operator1;
-        uint[][] memory weights = _createSingleWeightArray(100);
+        uint256[][] memory weights = _createSingleWeightArray(100);
 
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
 
@@ -439,7 +482,7 @@ contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTableBytes is ECDSAT
         operators[1] = operator2;
         operators[2] = operator3;
 
-        uint[][] memory weights = new uint[][](3);
+        uint256[][] memory weights = new uint256[][](3);
         weights[0] = _createSingleWeightArray(100)[0];
         weights[1] = _createSingleWeightArray(200)[0];
         weights[2] = _createSingleWeightArray(300)[0];
@@ -463,7 +506,7 @@ contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTableBytes is ECDSAT
     function test_emptyOperatorSetEncodesEmptyArray() public {
         // Don't register any operators
         address[] memory operators = new address[](0);
-        uint[][] memory weights = new uint[][](0);
+        uint256[][] memory weights = new uint256[][](0);
 
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
 
@@ -475,7 +518,7 @@ contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTableBytes is ECDSAT
         assertEq(decodedInfos.length, 0, "Should encode empty array");
     }
 
-    function testFuzz_encodesCorrectly(Randomness r, uint weight) public rand(r) {
+    function testFuzz_encodesCorrectly(Randomness r, uint256 weight) public rand(r) {
         weight = r.Uint256() % 1e18 + 1; // 1 to 1e18
 
         // Register operator
@@ -484,7 +527,7 @@ contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTableBytes is ECDSAT
         // Set operators and weights
         address[] memory operators = new address[](1);
         operators[0] = operator1;
-        uint[][] memory weights = _createSingleWeightArray(weight);
+        uint256[][] memory weights = _createSingleWeightArray(weight);
 
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
 
@@ -496,21 +539,24 @@ contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTableBytes is ECDSAT
         assertEq(decodedInfos[0].weights[0], weight, "Weight mismatch");
     }
 
-    function testFuzz_multipleWeightTypesEncoded(Randomness r, uint8 numWeightTypes) public rand(r) {
+    function testFuzz_multipleWeightTypesEncoded(
+        Randomness r,
+        uint8 numWeightTypes
+    ) public rand(r) {
         numWeightTypes = uint8(r.Uint256() % 5 + 1); // 1-5 weight types
 
         // Register operator
         _registerOperatorKey(operator1, defaultOperatorSet, ecdsaAddress1, ECDSA_PRIV_KEY_1);
 
         // Create random weights
-        uint[] memory weightValues = new uint[](numWeightTypes);
-        for (uint i = 0; i < numWeightTypes; i++) {
+        uint256[] memory weightValues = new uint256[](numWeightTypes);
+        for (uint256 i = 0; i < numWeightTypes; i++) {
             weightValues[i] = r.Uint256() % 1000 + 1;
         }
 
         address[] memory operators = new address[](1);
         operators[0] = operator1;
-        uint[][] memory weights = new uint[][](1);
+        uint256[][] memory weights = new uint256[][](1);
         weights[0] = weightValues;
 
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
@@ -523,7 +569,7 @@ contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTableBytes is ECDSAT
         assertEq(decodedInfos.length, 1, "Should have 1 operator");
         assertEq(decodedInfos[0].weights.length, numWeightTypes, "Weight types mismatch");
 
-        for (uint i = 0; i < numWeightTypes; i++) {
+        for (uint256 i = 0; i < numWeightTypes; i++) {
             assertEq(decodedInfos[0].weights[i], weightValues[i], "Weight value mismatch");
         }
     }
@@ -533,25 +579,28 @@ contract ECDSATableCalculatorBaseUnitTests_calculateOperatorTableBytes is ECDSAT
  * @title ECDSATableCalculatorBaseUnitTests_getOperatorWeights
  * @notice Unit tests for ECDSATableCalculatorBase.getOperatorWeights
  */
-contract ECDSATableCalculatorBaseUnitTests_getOperatorWeights is ECDSATableCalculatorBaseUnitTests {
+contract ECDSATableCalculatorBaseUnitTests_getOperatorWeights is
+    ECDSATableCalculatorBaseUnitTests
+{
     function test_returnsImplementationResult() public {
         // Set mock weights
         address[] memory expectedOperators = new address[](2);
         expectedOperators[0] = operator1;
         expectedOperators[1] = operator2;
 
-        uint[][] memory expectedWeights = new uint[][](2);
+        uint256[][] memory expectedWeights = new uint256[][](2);
         expectedWeights[0] = _createSingleWeightArray(100)[0];
         expectedWeights[1] = _createSingleWeightArray(200)[0];
 
         calculator.setMockOperatorWeights(defaultOperatorSet, expectedOperators, expectedWeights);
 
-        (address[] memory operators, uint[][] memory weights) = calculator.getOperatorWeights(defaultOperatorSet);
+        (address[] memory operators, uint256[][] memory weights) =
+            calculator.getOperatorWeights(defaultOperatorSet);
 
         assertEq(operators.length, expectedOperators.length, "Operators length mismatch");
         assertEq(weights.length, expectedWeights.length, "Weights length mismatch");
 
-        for (uint i = 0; i < operators.length; i++) {
+        for (uint256 i = 0; i < operators.length; i++) {
             assertEq(operators[i], expectedOperators[i], "Operator address mismatch");
             assertEq(weights[i][0], expectedWeights[i][0], "Weight value mismatch");
         }
@@ -560,11 +609,12 @@ contract ECDSATableCalculatorBaseUnitTests_getOperatorWeights is ECDSATableCalcu
     function test_emptyOperatorSet() public {
         // Set empty operators and weights
         address[] memory expectedOperators = new address[](0);
-        uint[][] memory expectedWeights = new uint[][](0);
+        uint256[][] memory expectedWeights = new uint256[][](0);
 
         calculator.setMockOperatorWeights(defaultOperatorSet, expectedOperators, expectedWeights);
 
-        (address[] memory operators, uint[][] memory weights) = calculator.getOperatorWeights(defaultOperatorSet);
+        (address[] memory operators, uint256[][] memory weights) =
+            calculator.getOperatorWeights(defaultOperatorSet);
 
         assertEq(operators.length, 0, "Should return empty operators array");
         assertEq(weights.length, 0, "Should return empty weights array");
@@ -575,37 +625,44 @@ contract ECDSATableCalculatorBaseUnitTests_getOperatorWeights is ECDSATableCalcu
         address[] memory expectedOperators = new address[](1);
         expectedOperators[0] = operator3;
 
-        uint[][] memory expectedWeights = new uint[][](1);
+        uint256[][] memory expectedWeights = new uint256[][](1);
         expectedWeights[0] = _createSingleWeightArray(500)[0];
 
-        calculator.setMockOperatorWeights(alternativeOperatorSet, expectedOperators, expectedWeights);
+        calculator.setMockOperatorWeights(
+            alternativeOperatorSet, expectedOperators, expectedWeights
+        );
 
-        (address[] memory operators, uint[][] memory weights) = calculator.getOperatorWeights(alternativeOperatorSet);
+        (address[] memory operators, uint256[][] memory weights) =
+            calculator.getOperatorWeights(alternativeOperatorSet);
 
         assertEq(operators.length, 1, "Operators length mismatch");
         assertEq(operators[0], operator3, "Operator address mismatch");
         assertEq(weights[0][0], 500, "Weight value mismatch");
     }
 
-    function testFuzz_returnsImplementationResult(Randomness r, uint8 numOperators) public rand(r) {
+    function testFuzz_returnsImplementationResult(
+        Randomness r,
+        uint8 numOperators
+    ) public rand(r) {
         numOperators = uint8(r.Uint256() % 20); // 0-19 operators
 
         address[] memory expectedOperators = new address[](numOperators);
-        uint[][] memory expectedWeights = new uint[][](numOperators);
+        uint256[][] memory expectedWeights = new uint256[][](numOperators);
 
-        for (uint i = 0; i < numOperators; i++) {
+        for (uint256 i = 0; i < numOperators; i++) {
             expectedOperators[i] = address(uint160(r.Uint256()));
             expectedWeights[i] = _createSingleWeightArray(r.Uint256() % 1000 + 1)[0];
         }
 
         calculator.setMockOperatorWeights(defaultOperatorSet, expectedOperators, expectedWeights);
 
-        (address[] memory operators, uint[][] memory weights) = calculator.getOperatorWeights(defaultOperatorSet);
+        (address[] memory operators, uint256[][] memory weights) =
+            calculator.getOperatorWeights(defaultOperatorSet);
 
         assertEq(operators.length, numOperators, "Operators length mismatch");
         assertEq(weights.length, numOperators, "Weights length mismatch");
 
-        for (uint i = 0; i < numOperators; i++) {
+        for (uint256 i = 0; i < numOperators; i++) {
             assertEq(operators[i], expectedOperators[i], "Operator address mismatch");
             assertEq(weights[i][0], expectedWeights[i][0], "Weight value mismatch");
         }
@@ -616,7 +673,9 @@ contract ECDSATableCalculatorBaseUnitTests_getOperatorWeights is ECDSATableCalcu
  * @title ECDSATableCalculatorBaseUnitTests_getOperatorWeight
  * @notice Unit tests for ECDSATableCalculatorBase.getOperatorWeight
  */
-contract ECDSATableCalculatorBaseUnitTests_getOperatorWeight is ECDSATableCalculatorBaseUnitTests {
+contract ECDSATableCalculatorBaseUnitTests_getOperatorWeight is
+    ECDSATableCalculatorBaseUnitTests
+{
     function test_operatorExists() public {
         // Set operators and weights
         address[] memory operators = new address[](3);
@@ -624,16 +683,28 @@ contract ECDSATableCalculatorBaseUnitTests_getOperatorWeight is ECDSATableCalcul
         operators[1] = operator2;
         operators[2] = operator3;
 
-        uint[][] memory weights = new uint[][](3);
+        uint256[][] memory weights = new uint256[][](3);
         weights[0] = _createSingleWeightArray(100)[0];
         weights[1] = _createSingleWeightArray(200)[0];
         weights[2] = _createSingleWeightArray(300)[0];
 
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
 
-        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator1), 100, "Operator1 weight mismatch");
-        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator2), 200, "Operator2 weight mismatch");
-        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator3), 300, "Operator3 weight mismatch");
+        assertEq(
+            calculator.getOperatorWeight(defaultOperatorSet, operator1),
+            100,
+            "Operator1 weight mismatch"
+        );
+        assertEq(
+            calculator.getOperatorWeight(defaultOperatorSet, operator2),
+            200,
+            "Operator2 weight mismatch"
+        );
+        assertEq(
+            calculator.getOperatorWeight(defaultOperatorSet, operator3),
+            300,
+            "Operator3 weight mismatch"
+        );
     }
 
     function test_operatorDoesNotExist() public {
@@ -642,24 +713,36 @@ contract ECDSATableCalculatorBaseUnitTests_getOperatorWeight is ECDSATableCalcul
         operators[0] = operator1;
         operators[1] = operator2;
 
-        uint[][] memory weights = new uint[][](2);
+        uint256[][] memory weights = new uint256[][](2);
         weights[0] = _createSingleWeightArray(100)[0];
         weights[1] = _createSingleWeightArray(200)[0];
 
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
 
-        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator3), 0, "Non-existent operator should return 0");
-        assertEq(calculator.getOperatorWeight(defaultOperatorSet, address(0xdead)), 0, "Random address should return 0");
+        assertEq(
+            calculator.getOperatorWeight(defaultOperatorSet, operator3),
+            0,
+            "Non-existent operator should return 0"
+        );
+        assertEq(
+            calculator.getOperatorWeight(defaultOperatorSet, address(0xdead)),
+            0,
+            "Random address should return 0"
+        );
     }
 
     function test_emptyOperatorSet() public {
         // Set empty operators and weights
         address[] memory operators = new address[](0);
-        uint[][] memory weights = new uint[][](0);
+        uint256[][] memory weights = new uint256[][](0);
 
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
 
-        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator1), 0, "Should return 0 for empty set");
+        assertEq(
+            calculator.getOperatorWeight(defaultOperatorSet, operator1),
+            0,
+            "Should return 0 for empty set"
+        );
     }
 
     function test_zeroWeight() public {
@@ -667,12 +750,16 @@ contract ECDSATableCalculatorBaseUnitTests_getOperatorWeight is ECDSATableCalcul
         address[] memory operators = new address[](1);
         operators[0] = operator1;
 
-        uint[][] memory weights = new uint[][](1);
+        uint256[][] memory weights = new uint256[][](1);
         weights[0] = _createSingleWeightArray(0)[0];
 
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
 
-        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator1), 0, "Should return 0 for zero weight");
+        assertEq(
+            calculator.getOperatorWeight(defaultOperatorSet, operator1),
+            0,
+            "Should return 0 for zero weight"
+        );
     }
 
     function test_multipleWeightTypes() public {
@@ -680,8 +767,8 @@ contract ECDSATableCalculatorBaseUnitTests_getOperatorWeight is ECDSATableCalcul
         address[] memory operators = new address[](1);
         operators[0] = operator1;
 
-        uint[][] memory weights = new uint[][](1);
-        uint[] memory multiWeights = new uint[](3);
+        uint256[][] memory weights = new uint256[][](1);
+        uint256[] memory multiWeights = new uint256[](3);
         multiWeights[0] = 100;
         multiWeights[1] = 200;
         multiWeights[2] = 300;
@@ -690,35 +777,49 @@ contract ECDSATableCalculatorBaseUnitTests_getOperatorWeight is ECDSATableCalcul
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
 
         // getOperatorWeight returns first weight type
-        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator1), 100, "Should return first weight type");
+        assertEq(
+            calculator.getOperatorWeight(defaultOperatorSet, operator1),
+            100,
+            "Should return first weight type"
+        );
     }
 
-    function testFuzz_getOperatorWeight(Randomness r, address operator, uint weight) public rand(r) {
+    function testFuzz_getOperatorWeight(
+        Randomness r,
+        address operator,
+        uint256 weight
+    ) public rand(r) {
         weight = r.Uint256() % 1e18; // 0 to 1e18
 
         // Set single operator
         address[] memory operators = new address[](1);
         operators[0] = operator;
 
-        uint[][] memory weights = _createSingleWeightArray(weight);
+        uint256[][] memory weights = _createSingleWeightArray(weight);
 
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
 
-        assertEq(calculator.getOperatorWeight(defaultOperatorSet, operator), weight, "Weight mismatch");
+        assertEq(
+            calculator.getOperatorWeight(defaultOperatorSet, operator), weight, "Weight mismatch"
+        );
 
         // Different operator should return 0
-        address differentOperator = address(uint160(uint(uint160(operator)) + 1));
-        assertEq(calculator.getOperatorWeight(defaultOperatorSet, differentOperator), 0, "Different operator should return 0");
+        address differentOperator = address(uint160(uint256(uint160(operator)) + 1));
+        assertEq(
+            calculator.getOperatorWeight(defaultOperatorSet, differentOperator),
+            0,
+            "Different operator should return 0"
+        );
     }
 
     function testFuzz_multipleOperators(Randomness r, uint8 numOperators) public rand(r) {
         numOperators = uint8(r.Uint256() % 10 + 1); // 1-10 operators
 
         address[] memory operators = new address[](numOperators);
-        uint[][] memory weights = new uint[][](numOperators);
-        uint[] memory expectedWeights = new uint[](numOperators);
+        uint256[][] memory weights = new uint256[][](numOperators);
+        uint256[] memory expectedWeights = new uint256[](numOperators);
 
-        for (uint i = 0; i < numOperators; i++) {
+        for (uint256 i = 0; i < numOperators; i++) {
             operators[i] = address(uint160(r.Uint256()));
             expectedWeights[i] = r.Uint256() % 1000 + 1;
             weights[i] = _createSingleWeightArray(expectedWeights[i])[0];
@@ -727,19 +828,29 @@ contract ECDSATableCalculatorBaseUnitTests_getOperatorWeight is ECDSATableCalcul
         calculator.setMockOperatorWeights(defaultOperatorSet, operators, weights);
 
         // Verify each operator's weight
-        for (uint i = 0; i < numOperators; i++) {
-            assertEq(calculator.getOperatorWeight(defaultOperatorSet, operators[i]), expectedWeights[i], "Weight mismatch");
+        for (uint256 i = 0; i < numOperators; i++) {
+            assertEq(
+                calculator.getOperatorWeight(defaultOperatorSet, operators[i]),
+                expectedWeights[i],
+                "Weight mismatch"
+            );
         }
 
         // Non-existent operator should return 0
         address nonExistent = address(uint160(r.Uint256()));
         bool exists = false;
-        for (uint i = 0; i < numOperators; i++) {
+        for (uint256 i = 0; i < numOperators; i++) {
             if (operators[i] == nonExistent) {
                 exists = true;
                 break;
             }
         }
-        if (!exists) assertEq(calculator.getOperatorWeight(defaultOperatorSet, nonExistent), 0, "Non-existent operator should return 0");
+        if (!exists) {
+            assertEq(
+                calculator.getOperatorWeight(defaultOperatorSet, nonExistent),
+                0,
+                "Non-existent operator should return 0"
+            );
+        }
     }
 }

--- a/test/unit/middlewareV2/MockDeployer.sol
+++ b/test/unit/middlewareV2/MockDeployer.sol
@@ -4,8 +4,10 @@ pragma solidity ^0.8.27;
 import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 import {KeyRegistrar} from "eigenlayer-contracts/src/contracts/permissions/KeyRegistrar.sol";
-import {PermissionController} from "eigenlayer-contracts/src/contracts/permissions/PermissionController.sol";
-import {IAllocationManager} from "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {PermissionController} from
+    "eigenlayer-contracts/src/contracts/permissions/PermissionController.sol";
+import {IAllocationManager} from
+    "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 import {AllocationManagerMock} from "eigenlayer-contracts/src/test/mocks/AllocationManagerMock.sol";
 
 import "test/mocks/KeyRegistrarMock.sol";
@@ -59,9 +61,23 @@ abstract contract MockEigenLayerDeployer is Test {
 
         // Deploy the actual PermissionController & KeyRegistrar implementations
         permissionControllerImplementation = new PermissionController("9.9.9");
-        permissionController = PermissionController(address(new TransparentUpgradeableProxy(address(permissionControllerImplementation), address(proxyAdmin), "")));
+        permissionController = PermissionController(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(permissionControllerImplementation), address(proxyAdmin), ""
+                )
+            )
+        );
 
-        keyRegistrarImplementation = new KeyRegistrar(permissionController, IAllocationManager(address(allocationManagerMock)),"9.9.9");
-        keyRegistrar = KeyRegistrar(address(new TransparentUpgradeableProxy(address(keyRegistrarImplementation), address(proxyAdmin), "")));
+        keyRegistrarImplementation = new KeyRegistrar(
+            permissionController, IAllocationManager(address(allocationManagerMock)), "9.9.9"
+        );
+        keyRegistrar = KeyRegistrar(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(keyRegistrarImplementation), address(proxyAdmin), ""
+                )
+            )
+        );
     }
 }

--- a/test/unit/middlewareV2/MockDeployer.sol
+++ b/test/unit/middlewareV2/MockDeployer.sol
@@ -3,8 +3,12 @@ pragma solidity ^0.8.27;
 
 import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
+import {KeyRegistrar} from "eigenlayer-contracts/src/contracts/permissions/KeyRegistrar.sol";
+import {PermissionController} from "eigenlayer-contracts/src/contracts/permissions/PermissionController.sol";
+import {IAllocationManager} from "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {AllocationManagerMock} from "eigenlayer-contracts/src/test/mocks/AllocationManagerMock.sol";
+
 import "test/mocks/KeyRegistrarMock.sol";
-import "test/mocks/AllocationManagerMock.sol";
 import "test/utils/Random.sol";
 
 import "forge-std/Test.sol";
@@ -39,6 +43,12 @@ abstract contract MockEigenLayerDeployer is Test {
     AllocationManagerMock public allocationManagerMock;
     KeyRegistrarMock public keyRegistrarMock;
 
+    /// @dev In order to test key functionality, for the table calculators, we also deploy the actual KeyRegistrar implementation
+    PermissionController permissionController;
+    PermissionController permissionControllerImplementation;
+    KeyRegistrar keyRegistrarImplementation;
+    KeyRegistrar keyRegistrar;
+
     function _deployMockEigenLayer() internal {
         // Deploy the proxy admin
         proxyAdmin = new ProxyAdmin();
@@ -46,5 +56,12 @@ abstract contract MockEigenLayerDeployer is Test {
         // Deploy mocks
         allocationManagerMock = new AllocationManagerMock();
         keyRegistrarMock = new KeyRegistrarMock();
+
+        // Deploy the actual PermissionController & KeyRegistrar implementations
+        permissionControllerImplementation = new PermissionController("9.9.9");
+        permissionController = PermissionController(address(new TransparentUpgradeableProxy(address(permissionControllerImplementation), address(proxyAdmin), "")));
+
+        keyRegistrarImplementation = new KeyRegistrar(permissionController, IAllocationManager(address(allocationManagerMock)),"9.9.9");
+        keyRegistrar = KeyRegistrar(address(new TransparentUpgradeableProxy(address(keyRegistrarImplementation), address(proxyAdmin), "")));
     }
 }


### PR DESCRIPTION
**Motivation:**

The `BN254` and `ECDSA` table calculators are AVS-deployed contracts. They should live in the middleware repo. 

**Modifications:**

- Add `EDSATableCalculator.sol`
- Add `BN254TableCalculator.sol`
- Add tests for both & tree files

**Result:**

Proper separation of contracts