### PR TITLE
chore: remove unused imports

### DIFF
--- a/src/middlewareV2/registrar/presets/AVSRegistrarAsIdentifier.sol
+++ b/src/middlewareV2/registrar/presets/AVSRegistrarAsIdentifier.sol
@@ -8,13 +8,12 @@ import {IPermissionController} from
 import {IKeyRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
 
 import {AVSRegistrar} from "../AVSRegistrar.sol";
-import {SocketRegistry} from "../modules/SocketRegistry.sol";
 
 import {Initializable} from "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";
 
 /// @notice An AVSRegistrar that is the identifier for the AVS in EigenLayer core.
 /// @dev Once deployed, the `admin` will control other parameters of the AVS, such as creating operatorSets, slashing, etc.
-contract AVSRegistrarAsIdentifier is Initializable, AVSRegistrar, SocketRegistry {
+contract AVSRegistrarAsIdentifier is AVSRegistrar {
     /// @notice The permission controller for the AVS
     IPermissionController public immutable permissionController;
 


### PR DESCRIPTION
**Motivation:**

The `AVSRegistrarAsIdentifier` had unnecessary imports

**Modifications:**

- Remove `Initializable` and `SocketRegistry`

**Result:**

Cleaner code