### PR TITLE
feat(redistribution): update slashers

### DIFF
--- a/docs/slashing/VetoableSlasher.md
+++ b/docs/slashing/VetoableSlasher.md
@@ -44,7 +44,7 @@ Creates and queues a new slashing request that will be executable after the veto
 #### `cancelSlashingRequest`
 ```solidity
 function cancelSlashingRequest(
-    uint256 requestId
+    uint256 slashId
 ) 
     external 
     virtual 
@@ -68,7 +68,7 @@ Allows the veto committee to cancel a pending slashing request within the veto w
 #### `fulfillSlashingRequest`
 ```solidity
 function fulfillSlashingRequest(
-    uint256 requestId
+    uint256 slashId
 ) 
     external 
     virtual 

--- a/src/interfaces/IInstantSlasher.sol
+++ b/src/interfaces/IInstantSlasher.sol
@@ -12,14 +12,16 @@ interface IInstantSlasher is ISlasher {
     /// @notice Immediately executes a slashing request
     /// @param params Parameters defining the slashing request including operator and amount
     /// @dev Can only be called by the authorized slasher
+    /// @return slashId The ID of the slashing request
     function fulfillSlashingRequest(
         IAllocationManager.SlashingParams memory params
-    ) external;
+    ) external returns (uint256 slashId);
 
     /// @notice Immediately executes a slashing request and burns or redistributes shares
     /// @param params Parameters defining the slashing request including operator and amount
     /// @dev Can only be called by the authorized slasher
+    /// @return slashId The ID of the slashing request
     function fulfillSlashingRequestAndBurnOrRedistribute(
         IAllocationManager.SlashingParams memory params
-    ) external;
+    ) external returns (uint256 slashId);
 }

--- a/src/interfaces/IInstantSlasher.sol
+++ b/src/interfaces/IInstantSlasher.sol
@@ -10,9 +10,16 @@ import {ISlasher} from "./ISlasher.sol";
 /// @dev Extends base interfaces to provide access controlled slashing functionality
 interface IInstantSlasher is ISlasher {
     /// @notice Immediately executes a slashing request
-    /// @param _slashingParams Parameters defining the slashing request including operator and amount
+    /// @param params Parameters defining the slashing request including operator and amount
     /// @dev Can only be called by the authorized slasher
     function fulfillSlashingRequest(
-        IAllocationManager.SlashingParams memory _slashingParams
+        IAllocationManager.SlashingParams memory params
+    ) external;
+
+    /// @notice Immediately executes a slashing request and burns or redistributes shares
+    /// @param params Parameters defining the slashing request including operator and amount
+    /// @dev Can only be called by the authorized slasher
+    function fulfillSlashingRequestAndBurnOrRedistribute(
+        IAllocationManager.SlashingParams memory params
     ) external;
 }

--- a/src/interfaces/ISlasher.sol
+++ b/src/interfaces/ISlasher.sol
@@ -20,7 +20,7 @@ interface ISlasherTypes {
 interface ISlasherEvents is ISlasherTypes {
     /// @notice Emitted when an operator is successfully slashed
     event OperatorSlashed(
-        uint256 indexed slashingRequestId,
+        uint256 indexed slashId,
         address indexed operator,
         uint32 indexed operatorSetId,
         uint256[] wadsToSlash,
@@ -33,7 +33,4 @@ interface ISlasherEvents is ISlasherTypes {
 interface ISlasher is ISlasherErrors, ISlasherEvents {
     /// @notice Returns the address authorized to create and fulfill slashing requests
     function slasher() external view returns (address);
-
-    /// @notice Returns the next slashing request ID
-    function nextRequestId() external view returns (uint256);
 }

--- a/src/interfaces/IVetoableSlasher.sol
+++ b/src/interfaces/IVetoableSlasher.sol
@@ -37,7 +37,7 @@ interface IVetoableSlasherTypes {
 interface IVetoableSlasherEvents {
     /// @notice Emitted when a new slashing request is created
     event SlashingRequested(
-        uint256 indexed requestId,
+        uint256 indexed slashId,
         address indexed operator,
         uint32 operatorSetId,
         uint256[] wadsToSlash,
@@ -45,7 +45,7 @@ interface IVetoableSlasherEvents {
     );
 
     /// @notice Emitted when a slashing request is cancelled by the veto committee
-    event SlashingRequestCancelled(uint256 indexed requestId);
+    event SlashingRequestCancelled(uint256 indexed slashId);
 }
 
 /// @title IVetoableSlasher
@@ -71,16 +71,16 @@ interface IVetoableSlasher is
     ) external;
 
     /// @notice Cancels a pending slashing request
-    /// @param requestId The ID of the slashing request to cancel
+    /// @param slashId The ID of the slashing request to cancel
     /// @dev Can only be called by the veto committee during the veto period
     function cancelSlashingRequest(
-        uint256 requestId
+        uint256 slashId
     ) external;
 
     /// @notice Executes a slashing request after the veto period has passed
-    /// @param requestId The ID of the slashing request to fulfill
+    /// @param slashId The ID of the slashing request to fulfill
     /// @dev Can only be called by the authorized slasher after the veto period
     function fulfillSlashingRequest(
-        uint256 requestId
+        uint256 slashId
     ) external;
 }

--- a/src/interfaces/IVetoableSlasher.sol
+++ b/src/interfaces/IVetoableSlasher.sol
@@ -83,4 +83,11 @@ interface IVetoableSlasher is
     function fulfillSlashingRequest(
         uint256 slashId
     ) external;
+
+    /// @notice Executes a slashing request after the veto period has passed and burns or redistributes shares
+    /// @param slashId The ID of the slashing request to fulfill
+    /// @dev Can only be called by the authorized slasher after the veto period
+    function fulfillSlashingRequestAndBurnOrRedistribute(
+        uint256 slashId
+    ) external;
 }

--- a/src/slashers/InstantSlasher.sol
+++ b/src/slashers/InstantSlasher.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.27;
 import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
 import {IAllocationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IStrategyManager} from "eigenlayer-contracts/src/contracts/interfaces/IStrategyManager.sol";
 import {SlasherBase} from "./base/SlasherBase.sol";
 import {ISlashingRegistryCoordinator} from "../interfaces/ISlashingRegistryCoordinator.sol";
 import {IInstantSlasher} from "../interfaces/IInstantSlasher.sol";
@@ -14,16 +15,16 @@ import {IInstantSlasher} from "../interfaces/IInstantSlasher.sol";
 contract InstantSlasher is IInstantSlasher, SlasherBase {
     constructor(
         IAllocationManager _allocationManager,
+        IStrategyManager _strategyManager,
         ISlashingRegistryCoordinator _slashingRegistryCoordinator,
         address _slasher
-    ) SlasherBase(_allocationManager, _slashingRegistryCoordinator, _slasher) {}
+    ) SlasherBase(_allocationManager, _strategyManager, _slashingRegistryCoordinator, _slasher) {}
 
     /// @inheritdoc IInstantSlasher
     function fulfillSlashingRequest(
         IAllocationManager.SlashingParams calldata _slashingParams
     ) external virtual override(IInstantSlasher) onlySlasher {
-        uint256 requestId = nextRequestId++;
-        _fulfillSlashingRequest(requestId, _slashingParams);
+        _fulfillSlashingRequest(_slashingParams);
 
         address[] memory operators = new address[](1);
         operators[0] = _slashingParams.operator;

--- a/src/slashers/InstantSlasher.sol
+++ b/src/slashers/InstantSlasher.sol
@@ -23,14 +23,14 @@ contract InstantSlasher is IInstantSlasher, SlasherBase {
     /// @inheritdoc IInstantSlasher
     function fulfillSlashingRequest(
         IAllocationManager.SlashingParams calldata params
-    ) external virtual override(IInstantSlasher) onlySlasher {
-        _fulfillSlashingRequest(params);
+    ) external virtual override(IInstantSlasher) onlySlasher returns (uint256 slashId) {
+        slashId = _fulfillSlashingRequest(params);
     }
 
     /// @inheritdoc IInstantSlasher
     function fulfillSlashingRequestAndBurnOrRedistribute(
         IAllocationManager.SlashingParams calldata params
-    ) external virtual override onlySlasher {
-        _fulfillSlashingRequestAndBurnOrRedistribute(params);
+    ) external virtual override onlySlasher returns (uint256 slashId) {
+        slashId = _fulfillSlashingRequestAndBurnOrRedistribute(params);
     }
 }

--- a/src/slashers/InstantSlasher.sol
+++ b/src/slashers/InstantSlasher.sol
@@ -25,9 +25,6 @@ contract InstantSlasher is IInstantSlasher, SlasherBase {
         IAllocationManager.SlashingParams calldata _slashingParams
     ) external virtual override(IInstantSlasher) onlySlasher {
         _fulfillSlashingRequest(_slashingParams);
-
-        address[] memory operators = new address[](1);
-        operators[0] = _slashingParams.operator;
-        slashingRegistryCoordinator.updateOperators(operators);
+        _updateOperatorStakeWeights(_slashingParams.operator);
     }
 }

--- a/src/slashers/InstantSlasher.sol
+++ b/src/slashers/InstantSlasher.sol
@@ -22,9 +22,15 @@ contract InstantSlasher is IInstantSlasher, SlasherBase {
 
     /// @inheritdoc IInstantSlasher
     function fulfillSlashingRequest(
-        IAllocationManager.SlashingParams calldata _slashingParams
+        IAllocationManager.SlashingParams calldata params
     ) external virtual override(IInstantSlasher) onlySlasher {
-        _fulfillSlashingRequest(_slashingParams);
-        _updateOperatorStakeWeights(_slashingParams.operator);
+        _fulfillSlashingRequest(params);
+    }
+
+    /// @inheritdoc IInstantSlasher
+    function fulfillSlashingRequestAndBurnOrRedistribute(
+        IAllocationManager.SlashingParams calldata params
+    ) external virtual override onlySlasher {
+        _fulfillSlashingRequestAndBurnOrRedistribute(params);
     }
 }

--- a/src/slashers/VetoableSlasher.sol
+++ b/src/slashers/VetoableSlasher.sol
@@ -2,8 +2,11 @@
 pragma solidity ^0.8.27;
 
 import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
-import {IAllocationManager} from
-    "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {
+    IAllocationManager,
+    OperatorSet
+} from "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IStrategyManager} from "eigenlayer-contracts/src/contracts/interfaces/IStrategyManager.sol";
 import {SlasherBase} from "./base/SlasherBase.sol";
 import {ISlashingRegistryCoordinator} from "../interfaces/ISlashingRegistryCoordinator.sol";
 import {IVetoableSlasher, IVetoableSlasherTypes} from "../interfaces/IVetoableSlasher.sol";
@@ -29,11 +32,12 @@ contract VetoableSlasher is IVetoableSlasher, SlasherBase {
 
     constructor(
         IAllocationManager _allocationManager,
+        IStrategyManager _strategyManager,
         ISlashingRegistryCoordinator _slashingRegistryCoordinator,
         address _slasher,
         address _vetoCommittee,
         uint32 _vetoWindowBlocks
-    ) SlasherBase(_allocationManager, _slashingRegistryCoordinator, _slasher) {
+    ) SlasherBase(_allocationManager, _strategyManager, _slashingRegistryCoordinator, _slasher) {
         vetoWindowBlocks = _vetoWindowBlocks;
         vetoCommittee = _vetoCommittee;
     }
@@ -47,16 +51,16 @@ contract VetoableSlasher is IVetoableSlasher, SlasherBase {
 
     /// @inheritdoc IVetoableSlasher
     function cancelSlashingRequest(
-        uint256 requestId
+        uint256 slashId
     ) external virtual override onlyVetoCommittee {
-        _cancelSlashingRequest(requestId);
+        _cancelSlashingRequest(slashId);
     }
 
     /// @inheritdoc IVetoableSlasher
     function fulfillSlashingRequest(
-        uint256 requestId
+        uint256 slashId
     ) external virtual override onlySlasher {
-        _fulfillSlashingRequestAndMarkAsCompleted(requestId);
+        _fulfillSlashingRequestAndMarkAsCompleted(slashId);
     }
 
     /// @notice Internal function to create and store a new slashing request
@@ -64,42 +68,48 @@ contract VetoableSlasher is IVetoableSlasher, SlasherBase {
     function _queueSlashingRequest(
         IAllocationManager.SlashingParams memory params
     ) internal virtual {
-        uint256 requestId = nextRequestId++;
-        slashingRequests[requestId] = IVetoableSlasherTypes.VetoableSlashingRequest({
+        uint256 nextSlashId = allocationManager.getSlashCount(
+            OperatorSet({avs: slashingRegistryCoordinator.avs(), id: params.operatorSetId})
+        );
+        slashingRequests[nextSlashId] = IVetoableSlasherTypes.VetoableSlashingRequest({
             params: params,
             requestBlock: block.number,
             status: IVetoableSlasherTypes.SlashingStatus.Requested
         });
 
         emit SlashingRequested(
-            requestId, params.operator, params.operatorSetId, params.wadsToSlash, params.description
+            nextSlashId,
+            params.operator,
+            params.operatorSetId,
+            params.wadsToSlash,
+            params.description
         );
     }
 
     /// @notice Internal function to mark a slashing request as cancelled
-    /// @param requestId The ID of the slashing request to cancel
+    /// @param slashId The ID of the slashing request to cancel
     function _cancelSlashingRequest(
-        uint256 requestId
+        uint256 slashId
     ) internal virtual {
         require(
-            block.number < slashingRequests[requestId].requestBlock + vetoWindowBlocks,
+            block.number < slashingRequests[slashId].requestBlock + vetoWindowBlocks,
             VetoPeriodPassed()
         );
         require(
-            slashingRequests[requestId].status == IVetoableSlasherTypes.SlashingStatus.Requested,
+            slashingRequests[slashId].status == IVetoableSlasherTypes.SlashingStatus.Requested,
             SlashingRequestNotRequested()
         );
 
-        slashingRequests[requestId].status = IVetoableSlasherTypes.SlashingStatus.Cancelled;
-        emit SlashingRequestCancelled(requestId);
+        slashingRequests[slashId].status = IVetoableSlasherTypes.SlashingStatus.Cancelled;
+        emit SlashingRequestCancelled(slashId);
     }
 
     /// @notice Internal function to fulfill a slashing request and mark it as completed
-    /// @param requestId The ID of the slashing request to fulfill
+    /// @param slashId The ID of the slashing request to fulfill
     function _fulfillSlashingRequestAndMarkAsCompleted(
-        uint256 requestId
+        uint256 slashId
     ) internal virtual {
-        IVetoableSlasherTypes.VetoableSlashingRequest storage request = slashingRequests[requestId];
+        IVetoableSlasherTypes.VetoableSlashingRequest storage request = slashingRequests[slashId];
         require(block.number >= request.requestBlock + vetoWindowBlocks, VetoPeriodNotPassed());
         require(
             request.status == IVetoableSlasherTypes.SlashingStatus.Requested,
@@ -108,7 +118,7 @@ contract VetoableSlasher is IVetoableSlasher, SlasherBase {
 
         request.status = IVetoableSlasherTypes.SlashingStatus.Completed;
 
-        _fulfillSlashingRequest(requestId, request.params);
+        _fulfillSlashingRequest(request.params);
 
         address[] memory operators = new address[](1);
         operators[0] = request.params.operator;

--- a/src/slashers/VetoableSlasher.sol
+++ b/src/slashers/VetoableSlasher.sol
@@ -60,7 +60,18 @@ contract VetoableSlasher is IVetoableSlasher, SlasherBase {
     function fulfillSlashingRequest(
         uint256 slashId
     ) external virtual override onlySlasher {
-        _fulfillSlashingRequestAndMarkAsCompleted(slashId);
+        IVetoableSlasherTypes.VetoableSlashingRequest storage request = slashingRequests[slashId];
+        _markAsCompleted(request);
+        _fulfillSlashingRequest(request.params);
+    }
+
+    /// @inheritdoc IVetoableSlasher
+    function fulfillSlashingRequestAndBurnOrRedistribute(
+        uint256 slashId
+    ) external virtual override onlySlasher {
+        IVetoableSlasherTypes.VetoableSlashingRequest storage request = slashingRequests[slashId];
+        _markAsCompleted(request);
+        _fulfillSlashingRequestAndBurnOrRedistribute(request.params);
     }
 
     /// @notice Internal function to create and store a new slashing request
@@ -104,12 +115,11 @@ contract VetoableSlasher is IVetoableSlasher, SlasherBase {
         emit SlashingRequestCancelled(slashId);
     }
 
-    /// @notice Internal function to fulfill a slashing request and mark it as completed
-    /// @param slashId The ID of the slashing request to fulfill
-    function _fulfillSlashingRequestAndMarkAsCompleted(
-        uint256 slashId
+    /// @notice Internal function to mark a slashing request as completed
+    /// @param request The request to mark as completed
+    function _markAsCompleted(
+        IVetoableSlasherTypes.VetoableSlashingRequest storage request
     ) internal virtual {
-        IVetoableSlasherTypes.VetoableSlashingRequest storage request = slashingRequests[slashId];
         require(block.number >= request.requestBlock + vetoWindowBlocks, VetoPeriodNotPassed());
         require(
             request.status == IVetoableSlasherTypes.SlashingStatus.Requested,
@@ -117,9 +127,6 @@ contract VetoableSlasher is IVetoableSlasher, SlasherBase {
         );
 
         request.status = IVetoableSlasherTypes.SlashingStatus.Completed;
-
-        _fulfillSlashingRequest(request.params);
-        _updateOperatorStakeWeights(request.params.operator);
     }
 
     /// @notice Internal function to verify if an account is the veto committee

--- a/src/slashers/VetoableSlasher.sol
+++ b/src/slashers/VetoableSlasher.sol
@@ -119,10 +119,7 @@ contract VetoableSlasher is IVetoableSlasher, SlasherBase {
         request.status = IVetoableSlasherTypes.SlashingStatus.Completed;
 
         _fulfillSlashingRequest(request.params);
-
-        address[] memory operators = new address[](1);
-        operators[0] = request.params.operator;
-        slashingRegistryCoordinator.updateOperators(operators);
+        _updateOperatorStakeWeights(request.params.operator);
     }
 
     /// @notice Internal function to verify if an account is the veto committee

--- a/src/slashers/base/SlasherBase.sol
+++ b/src/slashers/base/SlasherBase.sol
@@ -74,4 +74,14 @@ abstract contract SlasherBase is SlasherStorage {
     ) internal view virtual {
         require(account == slasher, OnlySlasher());
     }
+
+    /// @notice Internal function to update stake weights for the given operator
+    /// @param operator The operator to update
+    function _updateOperatorStakeWeights(
+        address operator
+    ) internal virtual {
+        address[] memory operators = new address[](1);
+        operators[0] = operator;
+        slashingRegistryCoordinator.updateOperators(operators);
+    }
 }

--- a/src/slashers/base/SlasherBase.sol
+++ b/src/slashers/base/SlasherBase.sol
@@ -3,9 +3,11 @@ pragma solidity ^0.8.27;
 
 import {SlasherStorage, ISlashingRegistryCoordinator} from "./SlasherStorage.sol";
 import {
+    OperatorSet,
     IAllocationManagerTypes,
     IAllocationManager
 } from "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IStrategyManager} from "eigenlayer-contracts/src/contracts/interfaces/IStrategyManager.sol";
 import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
 
 /// @title SlasherBase
@@ -24,26 +26,44 @@ abstract contract SlasherBase is SlasherStorage {
     /// @param _slasher The address of the slasher
     constructor(
         IAllocationManager _allocationManager,
+        IStrategyManager _strategyManager,
         ISlashingRegistryCoordinator _registryCoordinator,
         address _slasher
-    ) SlasherStorage(_allocationManager, _registryCoordinator, _slasher) {}
+    ) SlasherStorage(_allocationManager, _strategyManager, _registryCoordinator, _slasher) {}
 
     /// @notice Internal function to execute a slashing request
-    /// @param _requestId The ID of the slashing request to fulfill
     /// @param _params Parameters defining the slashing request including operator, strategies, and amounts
     /// @dev Calls AllocationManager.slashOperator to perform the actual slashing
     function _fulfillSlashingRequest(
-        uint256 _requestId,
         IAllocationManager.SlashingParams memory _params
-    ) internal virtual {
-        allocationManager.slashOperator({avs: slashingRegistryCoordinator.avs(), params: _params});
+    ) internal virtual returns (uint256 slashId) {
+        (slashId,) = allocationManager.slashOperator({
+            avs: slashingRegistryCoordinator.avs(),
+            params: _params
+        });
         emit OperatorSlashed(
-            _requestId,
+            slashId,
             _params.operator,
             _params.operatorSetId,
             _params.wadsToSlash,
             _params.description
         );
+    }
+
+    /// @notice Internal function to optionally fulfill burn or redistribution instead of waiting for cron job
+    function _fulfillBurnOrRedistribution(uint32 operatorSetId, uint256 slashId) internal virtual {
+        strategyManager.clearBurnOrRedistributableShares({
+            operatorSet: OperatorSet({avs: slashingRegistryCoordinator.avs(), id: operatorSetId}),
+            slashId: slashId
+        });
+    }
+
+    /// @notice Internal function to fulfill a slashing request and burn or redistribute shares
+    function _fulfillSlashingRequestAndBurnOrRedistribute(
+        IAllocationManager.SlashingParams memory _params
+    ) internal virtual returns (uint256 slashId) {
+        slashId = _fulfillSlashingRequest(_params);
+        _fulfillBurnOrRedistribution(_params.operatorSetId, slashId);
     }
 
     /// @notice Internal function to verify if an account is the authorized slasher

--- a/src/slashers/base/SlasherBase.sol
+++ b/src/slashers/base/SlasherBase.sol
@@ -32,22 +32,23 @@ abstract contract SlasherBase is SlasherStorage {
     ) SlasherStorage(_allocationManager, _strategyManager, _registryCoordinator, _slasher) {}
 
     /// @notice Internal function to execute a slashing request
-    /// @param _params Parameters defining the slashing request including operator, strategies, and amounts
+    /// @param params Parameters defining the slashing request including operator, strategies, and amounts
     /// @dev Calls AllocationManager.slashOperator to perform the actual slashing
     function _fulfillSlashingRequest(
-        IAllocationManager.SlashingParams memory _params
+        IAllocationManager.SlashingParams memory params
     ) internal virtual returns (uint256 slashId) {
         (slashId,) = allocationManager.slashOperator({
             avs: slashingRegistryCoordinator.avs(),
-            params: _params
+            params: params
         });
         emit OperatorSlashed(
-            slashId,
-            _params.operator,
-            _params.operatorSetId,
-            _params.wadsToSlash,
-            _params.description
+            slashId, params.operator, params.operatorSetId, params.wadsToSlash, params.description
         );
+
+        // Update operator stake weights
+        address[] memory operators = new address[](1);
+        operators[0] = params.operator;
+        slashingRegistryCoordinator.updateOperators(operators);
     }
 
     /// @notice Internal function to optionally fulfill burn or redistribution instead of waiting for cron job
@@ -60,10 +61,10 @@ abstract contract SlasherBase is SlasherStorage {
 
     /// @notice Internal function to fulfill a slashing request and burn or redistribute shares
     function _fulfillSlashingRequestAndBurnOrRedistribute(
-        IAllocationManager.SlashingParams memory _params
+        IAllocationManager.SlashingParams memory params
     ) internal virtual returns (uint256 slashId) {
-        slashId = _fulfillSlashingRequest(_params);
-        _fulfillBurnOrRedistribution(_params.operatorSetId, slashId);
+        slashId = _fulfillSlashingRequest(params);
+        _fulfillBurnOrRedistribution(params.operatorSetId, slashId);
     }
 
     /// @notice Internal function to verify if an account is the authorized slasher
@@ -73,15 +74,5 @@ abstract contract SlasherBase is SlasherStorage {
         address account
     ) internal view virtual {
         require(account == slasher, OnlySlasher());
-    }
-
-    /// @notice Internal function to update stake weights for the given operator
-    /// @param operator The operator to update
-    function _updateOperatorStakeWeights(
-        address operator
-    ) internal virtual {
-        address[] memory operators = new address[](1);
-        operators[0] = operator;
-        slashingRegistryCoordinator.updateOperators(operators);
     }
 }

--- a/src/slashers/base/SlasherStorage.sol
+++ b/src/slashers/base/SlasherStorage.sol
@@ -27,6 +27,7 @@ abstract contract SlasherStorage is ISlasher {
     /// @notice the address of the slasher
     address public immutable slasher;
 
+    /// @dev DEPRECATED -- `AllocationManager` now tracks monotonically increasing `slashId`.
     uint256 private __deprecated_nextRequestId;
 
     constructor(

--- a/src/slashers/base/SlasherStorage.sol
+++ b/src/slashers/base/SlasherStorage.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.27;
 
 import {IAllocationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IStrategyManager} from "eigenlayer-contracts/src/contracts/interfaces/IStrategyManager.sol";
 import {ISlashingRegistryCoordinator} from "../../interfaces/ISlashingRegistryCoordinator.sol";
 import {ISlasher} from "../../interfaces/ISlasher.sol";
 
@@ -16,21 +17,26 @@ abstract contract SlasherStorage is ISlasher {
      *
      */
 
-    /// @notice the AllocationManager that tracks OperatorSets and Slashing in EigenLayer
+    /// @notice The `AllocationManager` tracks operator sets, operator set allocations, and slashing in EigenLayer.
     IAllocationManager public immutable allocationManager;
-    /// @notice the SlashingRegistryCoordinator for this AVS
+    /// @notice The `StrategyManager` handles strategy inflows/outflows.
+    IStrategyManager public immutable strategyManager;
+    /// @notice The `SlashingRegistryCoordinator` for this AVS.
     ISlashingRegistryCoordinator public immutable slashingRegistryCoordinator;
+
     /// @notice the address of the slasher
     address public immutable slasher;
 
-    uint256 public nextRequestId;
+    uint256 private __deprecated_nextRequestId;
 
     constructor(
         IAllocationManager _allocationManager,
+        IStrategyManager _strategyManager,
         ISlashingRegistryCoordinator _slashingRegistryCoordinator,
         address _slasher
     ) {
         allocationManager = _allocationManager;
+        strategyManager = _strategyManager;
         slashingRegistryCoordinator = _slashingRegistryCoordinator;
         slasher = _slasher;
     }

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -22,6 +22,7 @@ import "eigenlayer-contracts/src/contracts/core/AllocationManager.sol";
 import "eigenlayer-contracts/src/contracts/strategies/StrategyBase.sol";
 import "eigenlayer-contracts/src/contracts/pods/EigenPodManager.sol";
 import "eigenlayer-contracts/src/contracts/pods/EigenPod.sol";
+import "eigenlayer-contracts/src/contracts/strategies/EigenStrategy.sol";
 import "eigenlayer-contracts/src/contracts/permissions/PauserRegistry.sol";
 import "eigenlayer-contracts/src/contracts/permissions/PermissionController.sol";
 import "eigenlayer-contracts/src/test/mocks/ETHDepositMock.sol";
@@ -229,9 +230,12 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
             })
         );
 
+        IStrategy eigenStrategy =
+            IStrategy(new EigenStrategy(strategyManager, pauserRegistry, "v0.0.1"));
+
         AllocationManager allocationManagerImplementation = new AllocationManager(
             delegationManager,
-            IStrategy(address(0)), // TODO: update this to the eigenStrategy,
+            eigenStrategy,
             pauserRegistry,
             permissionController,
             uint32(7 days), // DEALLOCATION_DELAY

--- a/test/mocks/AllocationManagerMock.sol
+++ b/test/mocks/AllocationManagerMock.sol
@@ -11,14 +11,14 @@ import {IPauserRegistry} from "eigenlayer-contracts/src/contracts/interfaces/IPa
 import {ISemVerMixin} from "eigenlayer-contracts/src/contracts/interfaces/ISemVerMixin.sol";
 
 contract AllocationManagerIntermediate is IAllocationManager {
-    mapping(address avs => address avsRegistrar) internal _avsRegistrar;
-
-    function initialize(address initialOwner, uint256 initialPausedStatus) external virtual {}
+    function initialize(
+        uint256 initialPausedStatus
+    ) external virtual {}
 
     function slashOperator(
         address avs,
         SlashingParams calldata params
-    ) external virtual returns (uint256 slashId, uint256[] memory shares) {}
+    ) external virtual returns (uint256, uint256[] memory) {}
 
     function modifyAllocations(
         address operator,
@@ -55,6 +55,12 @@ contract AllocationManagerIntermediate is IAllocationManager {
     function updateAVSMetadataURI(address avs, string calldata metadataURI) external virtual {}
 
     function createOperatorSets(address avs, CreateSetParams[] calldata params) external virtual {}
+
+    function createRedistributingOperatorSets(
+        address avs,
+        CreateSetParams[] calldata params,
+        address[] calldata redistributionRecipients
+    ) external virtual {}
 
     function addStrategiesToOperatorSet(
         address avs,

--- a/test/mocks/AllocationManagerMock.sol
+++ b/test/mocks/AllocationManagerMock.sol
@@ -11,6 +11,8 @@ import {IPauserRegistry} from "eigenlayer-contracts/src/contracts/interfaces/IPa
 import {ISemVerMixin} from "eigenlayer-contracts/src/contracts/interfaces/ISemVerMixin.sol";
 
 contract AllocationManagerIntermediate is IAllocationManager {
+    mapping(address avs => address avsRegistrar) internal _avsRegistrar;
+
     function initialize(
         uint256 initialPausedStatus
     ) external virtual {}
@@ -201,12 +203,6 @@ contract AllocationManagerIntermediate is IAllocationManager {
 
     function DEALLOCATION_DELAY() external pure virtual returns (uint32) {}
 
-    function createRedistributingOperatorSets(
-        address avs,
-        CreateSetParams[] calldata params,
-        address[] calldata redistributionRecipients
-    ) external virtual {}
-
     function getRedistributionRecipient(
         OperatorSet memory operatorSet
     ) external pure virtual returns (address) {}
@@ -214,10 +210,6 @@ contract AllocationManagerIntermediate is IAllocationManager {
     function getSlashCount(
         OperatorSet memory operatorSet
     ) external pure virtual returns (uint256) {}
-
-    function initialize(
-        uint256 initialPausedStatus
-    ) external virtual {}
 
     function isOperatorRedistributable(
         address operator
@@ -243,12 +235,6 @@ contract AllocationManagerMock is AllocationManagerIntermediate {
     function DEALLOCATION_DELAY() external pure override returns (uint32) {
         return _DEALLOCATION_DELAY;
     }
-
-    function createRedistributingOperatorSets(
-        address avs,
-        CreateSetParams[] calldata params,
-        address[] calldata redistributionRecipients
-    ) external override {}
 
     function getRedistributionRecipient(
         OperatorSet memory /* operatorSet */

--- a/test/mocks/DelegationMock.sol
+++ b/test/mocks/DelegationMock.sol
@@ -4,10 +4,11 @@ pragma solidity ^0.8.27;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {console2 as console} from "forge-std/Test.sol";
 
-import {IDelegationManager} from
-    "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
-import {IDelegationManagerTypes} from
-    "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
+import {
+    OperatorSet,
+    IDelegationManager,
+    IDelegationManagerTypes
+} from "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
 import {IStrategyManager} from "eigenlayer-contracts/src/contracts/interfaces/IStrategyManager.sol";
 import {StrategyManager} from "eigenlayer-contracts/src/contracts/core/StrategyManager.sol";
 import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
@@ -21,7 +22,9 @@ import {SlashingLib} from "eigenlayer-contracts/src/contracts/libraries/Slashing
 import {OperatorSet} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
 
 contract DelegationIntermediate is IDelegationManager {
-    function initialize(address initialOwner, uint256 initialPausedStatus) external virtual {}
+    function initialize(
+        uint256 initialPausedStatus
+    ) external virtual {}
 
     function initialize(
         uint256 initialPausedStatus
@@ -301,6 +304,15 @@ contract DelegationIntermediate is IDelegationManager {
         IStrategy[] memory strategies,
         uint256[] memory withdrawableShares
     ) external view override returns (uint256[] memory) {}
+
+    function slashOperatorShares(
+        address operator,
+        OperatorSet calldata operatorSet,
+        uint256 slashId,
+        IStrategy strategy,
+        uint64 prevMaxMagnitude,
+        uint64 newMaxMagnitude
+    ) external virtual returns (uint256 totalDepositSharesToSlash) {}
 
     /**
      * @notice Returns the domain separator used for EIP-712 signatures

--- a/test/mocks/DelegationMock.sol
+++ b/test/mocks/DelegationMock.sol
@@ -26,10 +26,6 @@ contract DelegationIntermediate is IDelegationManager {
         uint256 initialPausedStatus
     ) external virtual {}
 
-    function initialize(
-        uint256 initialPausedStatus
-    ) external virtual {}
-
     function registerAsOperator(
         OperatorDetails calldata registeringOperatorDetails,
         uint32 allocationDelay,
@@ -243,13 +239,6 @@ contract DelegationIntermediate is IDelegationManager {
 
     function slashOperatorShares(
         address operator,
-        IStrategy strategy,
-        uint64 prevMaxMagnitude,
-        uint64 newMaxMagnitude
-    ) external {}
-
-    function slashOperatorShares(
-        address operator,
         OperatorSet calldata operatorSet,
         uint256 slashId,
         IStrategy strategy,
@@ -304,15 +293,6 @@ contract DelegationIntermediate is IDelegationManager {
         IStrategy[] memory strategies,
         uint256[] memory withdrawableShares
     ) external view override returns (uint256[] memory) {}
-
-    function slashOperatorShares(
-        address operator,
-        OperatorSet calldata operatorSet,
-        uint256 slashId,
-        IStrategy strategy,
-        uint64 prevMaxMagnitude,
-        uint64 newMaxMagnitude
-    ) external virtual returns (uint256 totalDepositSharesToSlash) {}
 
     /**
      * @notice Returns the domain separator used for EIP-712 signatures

--- a/test/mocks/EigenPodManagerMock.sol
+++ b/test/mocks/EigenPodManagerMock.sol
@@ -128,9 +128,9 @@ contract EigenPodManagerMock is Test, Pausable, IEigenPodManager {
     function increaseBurnableShares(IStrategy strategy, uint256 addedSharesToBurn) external {}
 
     function increaseBurnOrRedistributableShares(
-        OperatorSet calldata operatorSet,
-        uint256 slashId,
-        IStrategy strategy,
+        OperatorSet calldata,
+        uint256,
+        IStrategy,
         uint256 addedSharesToBurn
     ) external {}
 

--- a/test/unit/InstantSlasher.t.sol
+++ b/test/unit/InstantSlasher.t.sol
@@ -101,14 +101,12 @@ contract InstantSlasherTest is Test {
         configData.strategyManager.initialStrategyWhitelister = proxyAdminOwner;
         configData.strategyManager.initPausedStatus = 0;
 
-        configData.delegationManager.initialOwner = proxyAdminOwner;
         configData.delegationManager.minWithdrawalDelayBlocks = 50400;
         configData.delegationManager.initPausedStatus = 0;
 
         configData.eigenPodManager.initialOwner = proxyAdminOwner;
         configData.eigenPodManager.initPausedStatus = 0;
 
-        configData.allocationManager.initialOwner = proxyAdminOwner;
         configData.allocationManager.deallocationDelay = DEALLOCATION_DELAY;
         configData.allocationManager.allocationConfigurationDelay = ALLOCATION_CONFIGURATION_DELAY;
         configData.allocationManager.initPausedStatus = 0;
@@ -184,6 +182,7 @@ contract InstantSlasherTest is Test {
             .deployMiddleware(
             address(proxyAdmin),
             coreDeployment.allocationManager,
+            coreDeployment.strategyManager,
             address(pauserRegistry),
             middlewareConfig
         );

--- a/test/unit/SlashingRegistryCoordinatorUnit.t.sol
+++ b/test/unit/SlashingRegistryCoordinatorUnit.t.sol
@@ -181,14 +181,12 @@ contract SlashingRegistryCoordinatorUnitTestSetup is
         configData.strategyManager.initialStrategyWhitelister = proxyAdminOwner;
         configData.strategyManager.initPausedStatus = 0;
 
-        configData.delegationManager.initialOwner = proxyAdminOwner;
         configData.delegationManager.minWithdrawalDelayBlocks = 100800;
         configData.delegationManager.initPausedStatus = 0;
 
         configData.eigenPodManager.initialOwner = proxyAdminOwner;
         configData.eigenPodManager.initPausedStatus = 0;
 
-        configData.allocationManager.initialOwner = proxyAdminOwner;
         configData.allocationManager.deallocationDelay = DEALLOCATION_DELAY;
         configData.allocationManager.allocationConfigurationDelay = ALLOCATION_CONFIGURATION_DELAY;
         configData.allocationManager.initPausedStatus = 0;
@@ -254,6 +252,7 @@ contract SlashingRegistryCoordinatorUnitTestSetup is
             .deployMiddleware(
             address(proxyAdmin),
             coreDeployment.allocationManager,
+            coreDeployment.strategyManager,
             address(pauserRegistry),
             middlewareConfig
         );

--- a/test/unit/VetoableSlasher.t.sol
+++ b/test/unit/VetoableSlasher.t.sol
@@ -108,14 +108,12 @@ contract VetoableSlasherTest is Test {
         configData.strategyManager.initialStrategyWhitelister = proxyAdminOwner;
         configData.strategyManager.initPausedStatus = 0;
 
-        configData.delegationManager.initialOwner = proxyAdminOwner;
         configData.delegationManager.minWithdrawalDelayBlocks = 50400;
         configData.delegationManager.initPausedStatus = 0;
 
         configData.eigenPodManager.initialOwner = proxyAdminOwner;
         configData.eigenPodManager.initPausedStatus = 0;
 
-        configData.allocationManager.initialOwner = proxyAdminOwner;
         configData.allocationManager.deallocationDelay = DEALLOCATION_DELAY;
         configData.allocationManager.allocationConfigurationDelay = ALLOCATION_CONFIGURATION_DELAY;
         configData.allocationManager.initPausedStatus = 0;
@@ -188,6 +186,7 @@ contract VetoableSlasherTest is Test {
             .deployMiddleware(
             address(proxyAdmin),
             coreDeployment.allocationManager,
+            coreDeployment.strategyManager,
             address(pauserRegistry),
             middlewareConfig
         );
@@ -203,6 +202,7 @@ contract VetoableSlasherTest is Test {
 
         vetoableSlasherImplementation = new VetoableSlasher(
             IAllocationManager(coreDeployment.allocationManager),
+            IStrategyManager(coreDeployment.strategyManager),
             ISlashingRegistryCoordinator(slashingRegistryCoordinator),
             slasher,
             vetoCommittee,

--- a/test/utils/CoreDeployLib.sol
+++ b/test/utils/CoreDeployLib.sol
@@ -127,6 +127,7 @@ library CoreDeployLib {
         address strategyBeacon;
         address rewardsCoordinator;
         address permissionController;
+        address eigenStrategy;
     }
 
     function deployContracts(
@@ -178,7 +179,7 @@ library CoreDeployLib {
         address allocationManagerImpl = address(
             new AllocationManager(
                 IDelegationManager(deployments.delegationManager),
-                IStrategy(address(0)), // TODO: update this to the eigenStrategy,
+                IStrategy(deployments.eigenStrategy),
                 IPauserRegistry(deployments.pauserRegistry),
                 IPermissionController(deployments.permissionController),
                 config.allocationManager.deallocationDelay,

--- a/test/utils/CoreDeployLib.sol
+++ b/test/utils/CoreDeployLib.sol
@@ -127,7 +127,7 @@ library CoreDeployLib {
         address strategyBeacon;
         address rewardsCoordinator;
         address permissionController;
-        address eigenStrategy;
+        address eigenStrategy; // TODO: initialize
     }
 
     function deployContracts(

--- a/test/utils/CoreDeployLib.sol
+++ b/test/utils/CoreDeployLib.sol
@@ -58,7 +58,6 @@ library CoreDeployLib {
 
     struct DelegationManagerConfig {
         uint256 initPausedStatus;
-        address initialOwner;
         uint32 minWithdrawalDelayBlocks;
     }
 
@@ -69,7 +68,6 @@ library CoreDeployLib {
 
     struct AllocationManagerConfig {
         uint256 initPausedStatus;
-        address initialOwner;
         uint32 deallocationDelay;
         uint32 allocationConfigurationDelay;
     }

--- a/test/utils/MiddlewareDeployLib.sol
+++ b/test/utils/MiddlewareDeployLib.sol
@@ -7,6 +7,7 @@ import {TransparentUpgradeableProxy} from
 import {UpgradeableBeacon} from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import {IAllocationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IStrategyManager} from "eigenlayer-contracts/src/contracts/interfaces/IStrategyManager.sol";
 import {IPauserRegistry} from "eigenlayer-contracts/src/contracts/interfaces/IPauserRegistry.sol";
 import {IDelegationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
@@ -109,6 +110,7 @@ library MiddlewareDeployLib {
     function deployMiddleware(
         address proxyAdmin,
         address allocationManager,
+        address strategyManager,
         address pauserRegistry,
         MiddlewareDeployConfig memory config
     ) internal returns (MiddlewareDeployData memory result) {
@@ -118,7 +120,7 @@ library MiddlewareDeployLib {
         upgradeCoordinator(
             result, allocationManager, pauserRegistry, config.slashingRegistryCoordinator
         );
-        upgradeInstantSlasher(result, allocationManager, config.instantSlasher);
+        upgradeInstantSlasher(result, allocationManager, strategyManager, config.instantSlasher);
 
         return result;
     }
@@ -319,11 +321,13 @@ library MiddlewareDeployLib {
     function upgradeInstantSlasher(
         MiddlewareDeployData memory deployments,
         address allocationManager,
+        address strategyManager,
         InstantSlasherConfig memory slasherConfig
     ) internal {
         address instantSlasherImpl = address(
             new InstantSlasher(
                 IAllocationManager(allocationManager),
+                IStrategyManager(strategyManager),
                 ISlashingRegistryCoordinator(deployments.slashingRegistryCoordinator),
                 slasherConfig.slasher
             )

--- a/test/utils/MockAVSDeployer.sol
+++ b/test/utils/MockAVSDeployer.sol
@@ -6,6 +6,8 @@ import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.so
 import {ITransparentUpgradeableProxy} from
     "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
+import {EigenStrategy} from "eigenlayer-contracts/src/contracts/strategies/EigenStrategy.sol";
+import {IStrategyManager} from "eigenlayer-contracts/src/contracts/interfaces/IStrategyManager.sol";
 import {PauserRegistry} from "eigenlayer-contracts/src/contracts/permissions/PauserRegistry.sol";
 import {IStrategy} from "eigenlayer-contracts/src/contracts/interfaces/IStrategy.sol";
 import {
@@ -273,9 +275,15 @@ contract MockAVSDeployer is Test {
             address(serviceManagerImplementation)
         );
 
+        IStrategy eigenStrategy = IStrategy(
+            new EigenStrategy(
+                IStrategyManager(address(strategyManagerMock)), pauserRegistry, "v0.0.1"
+            )
+        );
+
         allocationManagerImplementation = new AllocationManager(
             delegationMock,
-            IStrategy(address(0)), // TODO: update this to the eigenStrategy
+            eigenStrategy,
             pauserRegistry,
             permissionControllerMock,
             uint32(7 days), // DEALLOCATION_DELAY


### PR DESCRIPTION
**Motivation:**

We want our slasher examples to support the redistribution release.

**Modifications:**

- Bumped `eigenlayer-contracts` -> `v1.7.0-rc.3`.
- Bumped `forge-std` -> `v1.9.7`.
- Added `fulfillSlashingRequestAndBurnOrRedistribute` to `InstantSlasher` + `VetoableSlasher`.
- Deprecated `requestId` (we now track this in core as `slashId`).

**Result:**

MW supports redistribution.
