### PR TITLE
fix: avs registrar as identifier

### DIFF
--- a/src/interfaces/IAVSRegistrarInternal.sol
+++ b/src/interfaces/IAVSRegistrarInternal.sol
@@ -17,4 +17,7 @@ interface IAVSRegistrarEvents {
 }
 
 /// @notice Since we have already defined a public interface, we add the events and errors here
-interface IAVSRegistrarInternal is IAVSRegistrarErrors, IAVSRegistrarEvents {}
+interface IAVSRegistrarInternal is IAVSRegistrarErrors, IAVSRegistrarEvents {
+    /// @notice Returns the address of the AVS in EigenLayer core
+    function getAVS() external view returns (address);
+}

--- a/src/middlewareV2/registrar/AVSRegistrar.sol
+++ b/src/middlewareV2/registrar/AVSRegistrar.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.27;
 
 import {IAVSRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IAVSRegistrar.sol";
+import {IAVSRegistrarInternal} from "../../interfaces/IAVSRegistrarInternal.sol";
 import {IAllocationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 import {
@@ -69,6 +70,11 @@ contract AVSRegistrar is Initializable, AVSRegistrarStorage {
         address _avs
     ) public view virtual returns (bool) {
         return _avs == avs;
+    }
+
+    /// @inheritdoc IAVSRegistrarInternal
+    function getAVS() external view virtual returns (address) {
+        return avs;
     }
 
     /*

--- a/src/middlewareV2/registrar/AVSRegistrarStorage.sol
+++ b/src/middlewareV2/registrar/AVSRegistrarStorage.sol
@@ -17,7 +17,7 @@ abstract contract AVSRegistrarStorage is IAVSRegistrar, IAVSRegistrarInternal {
 
     /// @notice The AVS that this registrar is for
     /// @dev In practice, the AVS address in EigenLayer core is address that initialized the Metadata URI.
-    address public immutable avs;
+    address internal immutable avs;
 
     /// @notice The allocation manager in EigenLayer core
     IAllocationManager public immutable allocationManager;

--- a/src/middlewareV2/registrar/presets/AVSRegistrarAsIdentifier.sol
+++ b/src/middlewareV2/registrar/presets/AVSRegistrarAsIdentifier.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
+import {IAVSRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IAVSRegistrar.sol";
+import {IAVSRegistrarInternal} from "../../../interfaces/IAVSRegistrarInternal.sol";
 import {IAllocationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 import {IPermissionController} from
@@ -17,6 +19,8 @@ contract AVSRegistrarAsIdentifier is AVSRegistrar {
     /// @notice The permission controller for the AVS
     IPermissionController public immutable permissionController;
 
+    /// @dev The immutable avs address `AVSRegistrar` is NOT the address of the AVS in EigenLayer core.
+    /// @dev The address of the AVS in EigenLayer core is the proxy contract, and it is set via the `initialize` function below.
     constructor(
         address _avs,
         IAllocationManager _allocationManager,
@@ -40,5 +44,17 @@ contract AVSRegistrarAsIdentifier is AVSRegistrar {
 
         // Set the admin for the AVS
         permissionController.addPendingAdmin(address(this), admin);
+    }
+
+    /// @inheritdoc IAVSRegistrar
+    function supportsAVS(
+        address _avs
+    ) public view override returns (bool) {
+        return _avs == address(this);
+    }
+
+    /// @inheritdoc IAVSRegistrarInternal
+    function getAVS() external view override returns (address) {
+        return address(this);
     }
 }

--- a/test/unit/middlewareV2/AVSRegistrarAllowlistUnit.t.sol
+++ b/test/unit/middlewareV2/AVSRegistrarAllowlistUnit.t.sol
@@ -219,7 +219,7 @@ contract AVSRegistrarWithAllowlistUnitTests_registerOperator is
 
     function testFuzz_revert_notAllocationManager(
         address notAllocationManager
-    ) public {
+    ) public filterFuzzedAddressInputs(notAllocationManager) {
         cheats.assume(notAllocationManager != address(allocationManagerMock));
 
         cheats.prank(notAllocationManager);

--- a/test/unit/middlewareV2/AVSRegistrarAllowlistUnit.t.sol
+++ b/test/unit/middlewareV2/AVSRegistrarAllowlistUnit.t.sol
@@ -301,3 +301,56 @@ contract AVSRegistrarWithAllowlistUnitTests_deregisterOperator is
         avsRegistrarWithAllowlist.deregisterOperator(defaultOperator, AVS, operatorSetIds);
     }
 }
+
+contract AVSRegistrarWithAllowlistUnitTests_ViewFunctions is AVSRegistrarWithAllowlistUnitTests {
+    function test_supportsAVS_true() public {
+        // Should return true when checking against the configured AVS
+        assertTrue(
+            avsRegistrarWithAllowlist.supportsAVS(AVS),
+            "supportsAVS: should return true for configured AVS"
+        );
+    }
+
+    function test_supportsAVS_false() public {
+        // Should return false for any other address
+        assertFalse(
+            avsRegistrarWithAllowlist.supportsAVS(address(0)),
+            "supportsAVS: should return false for zero address"
+        );
+        assertFalse(
+            avsRegistrarWithAllowlist.supportsAVS(address(1)),
+            "supportsAVS: should return false for random address"
+        );
+        assertFalse(
+            avsRegistrarWithAllowlist.supportsAVS(address(avsRegistrarWithAllowlist)),
+            "supportsAVS: should return false for registrar address"
+        );
+        assertFalse(
+            avsRegistrarWithAllowlist.supportsAVS(defaultOperator),
+            "supportsAVS: should return false for operator"
+        );
+    }
+
+    function testFuzz_supportsAVS(
+        address randomAddress
+    ) public {
+        if (randomAddress == AVS) {
+            assertTrue(
+                avsRegistrarWithAllowlist.supportsAVS(randomAddress),
+                "supportsAVS: should return true for configured AVS"
+            );
+        } else {
+            assertFalse(
+                avsRegistrarWithAllowlist.supportsAVS(randomAddress),
+                "supportsAVS: should return false for non-AVS address"
+            );
+        }
+    }
+
+    function test_getAVS() public {
+        // Should return the configured AVS address
+        assertEq(
+            avsRegistrarWithAllowlist.getAVS(), AVS, "getAVS: should return configured AVS address"
+        );
+    }
+}

--- a/test/unit/middlewareV2/AVSRegistrarAsIdentifierUnit.t.sol
+++ b/test/unit/middlewareV2/AVSRegistrarAsIdentifierUnit.t.sol
@@ -244,8 +244,8 @@ contract AVSRegistrarAsIdentifierUnitTests_registerOperator is AVSRegistrarAsIde
 
     function testFuzz_revert_notAllocationManager(
         address notAllocationManager
-    ) public {
-        vm.assume(notAllocationManager != address(allocationManagerMock));
+    ) public filterFuzzedAddressInputs(notAllocationManager) {
+        cheats.assume(notAllocationManager != address(allocationManagerMock));
 
         vm.prank(notAllocationManager);
         vm.expectRevert(NotAllocationManager.selector);
@@ -323,9 +323,8 @@ contract AVSRegistrarAsIdentifierUnitTests_deregisterOperator is
 
     function testFuzz_revert_notAllocationManager(
         address notAllocationManager
-    ) public {
-        vm.assume(notAllocationManager != address(allocationManagerMock));
-        vm.assume(notAllocationManager != address(proxyAdmin));
+    ) public filterFuzzedAddressInputs(notAllocationManager) {
+        cheats.assume(notAllocationManager != address(allocationManagerMock));
 
         vm.prank(notAllocationManager);
         vm.expectRevert(NotAllocationManager.selector);

--- a/test/unit/middlewareV2/AVSRegistrarAsIdentifierUnit.t.sol
+++ b/test/unit/middlewareV2/AVSRegistrarAsIdentifierUnit.t.sol
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import "./AVSRegistrarBase.t.sol";
+import {IKeyRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
+import {IPermissionController} from
+    "eigenlayer-contracts/src/contracts/interfaces/IPermissionController.sol";
+import {PermissionController} from
+    "eigenlayer-contracts/src/contracts/permissions/PermissionController.sol";
+import {AVSRegistrarAsIdentifier} from
+    "src/middlewareV2/registrar/presets/AVSRegistrarAsIdentifier.sol";
+import {IAllocationManager} from
+    "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {TransparentUpgradeableProxy} from
+    "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+contract AVSRegistrarAsIdentifierUnitTests is AVSRegistrarBase {
+    AVSRegistrarAsIdentifier public avsRegistrarAsIdentifier;
+    address public admin = address(0xAD);
+    string public constant METADATA_URI = "https://example.com/metadata";
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        // Deploy the implementation
+        avsRegistrarImplementation = new AVSRegistrarAsIdentifier(
+            AVS,
+            IAllocationManager(address(allocationManagerMock)),
+            permissionController,
+            IKeyRegistrar(address(keyRegistrarMock))
+        );
+
+        // Deploy the proxy
+        avsRegistrarAsIdentifier = AVSRegistrarAsIdentifier(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(avsRegistrarImplementation), address(proxyAdmin), ""
+                )
+            )
+        );
+    }
+}
+
+contract AVSRegistrarAsIdentifierUnitTests_constructor is AVSRegistrarAsIdentifierUnitTests {
+    function test_constructor() public {
+        // Deploy a new implementation to test constructor
+        AVSRegistrarAsIdentifier impl = new AVSRegistrarAsIdentifier(
+            AVS,
+            IAllocationManager(address(allocationManagerMock)),
+            permissionController,
+            IKeyRegistrar(address(keyRegistrarMock))
+        );
+
+        // Check that the immutable variables are set correctly
+        assertEq(
+            address(impl.permissionController()),
+            address(permissionController),
+            "Constructor: permission controller incorrect"
+        );
+        assertEq(
+            address(impl.allocationManager()),
+            address(allocationManagerMock),
+            "Constructor: allocation manager incorrect"
+        );
+        assertEq(
+            address(impl.keyRegistrar()),
+            address(keyRegistrarMock),
+            "Constructor: key registrar incorrect"
+        );
+    }
+}
+
+contract AVSRegistrarAsIdentifierUnitTests_initialize is AVSRegistrarAsIdentifierUnitTests {
+    function test_initialize() public {
+        // Mock the allocationManager calls
+        vm.mockCall(
+            address(allocationManagerMock),
+            abi.encodeWithSelector(
+                IAllocationManager.updateAVSMetadataURI.selector,
+                address(avsRegistrarAsIdentifier),
+                METADATA_URI
+            ),
+            ""
+        );
+        vm.mockCall(
+            address(allocationManagerMock),
+            abi.encodeWithSelector(
+                IAllocationManager.setAVSRegistrar.selector,
+                address(avsRegistrarAsIdentifier),
+                avsRegistrarAsIdentifier
+            ),
+            ""
+        );
+
+        // Mock the permissionController call
+        vm.mockCall(
+            address(permissionController),
+            abi.encodeWithSelector(
+                IPermissionController.addPendingAdmin.selector,
+                address(avsRegistrarAsIdentifier),
+                admin
+            ),
+            ""
+        );
+
+        // Expect the calls to be made
+        vm.expectCall(
+            address(allocationManagerMock),
+            abi.encodeWithSelector(
+                IAllocationManager.updateAVSMetadataURI.selector,
+                address(avsRegistrarAsIdentifier),
+                METADATA_URI
+            )
+        );
+        vm.expectCall(
+            address(allocationManagerMock),
+            abi.encodeWithSelector(
+                IAllocationManager.setAVSRegistrar.selector,
+                address(avsRegistrarAsIdentifier),
+                avsRegistrarAsIdentifier
+            )
+        );
+        vm.expectCall(
+            address(permissionController),
+            abi.encodeWithSelector(
+                IPermissionController.addPendingAdmin.selector,
+                address(avsRegistrarAsIdentifier),
+                admin
+            )
+        );
+
+        // Initialize
+        avsRegistrarAsIdentifier.initialize(admin, METADATA_URI);
+    }
+
+    function test_revert_alreadyInitialized() public {
+        // Initialize first
+        vm.mockCall(
+            address(allocationManagerMock),
+            abi.encodeWithSelector(IAllocationManager.updateAVSMetadataURI.selector),
+            ""
+        );
+        vm.mockCall(
+            address(allocationManagerMock),
+            abi.encodeWithSelector(IAllocationManager.setAVSRegistrar.selector),
+            ""
+        );
+        vm.mockCall(
+            address(permissionController),
+            abi.encodeWithSelector(IPermissionController.addPendingAdmin.selector),
+            ""
+        );
+
+        avsRegistrarAsIdentifier.initialize(admin, METADATA_URI);
+
+        // Try to initialize again
+        vm.expectRevert("Initializable: contract is already initialized");
+        avsRegistrarAsIdentifier.initialize(admin, METADATA_URI);
+    }
+}
+
+contract AVSRegistrarAsIdentifierUnitTests_supportsAVS is AVSRegistrarAsIdentifierUnitTests {
+    function test_supportsAVS_true() public {
+        // Should return true when checking against itself
+        assertTrue(
+            avsRegistrarAsIdentifier.supportsAVS(address(avsRegistrarAsIdentifier)),
+            "supportsAVS: should return true for self"
+        );
+    }
+
+    function test_supportsAVS_false() public {
+        // Should return false for any other address
+        assertFalse(
+            avsRegistrarAsIdentifier.supportsAVS(AVS),
+            "supportsAVS: should return false for original AVS"
+        );
+        assertFalse(
+            avsRegistrarAsIdentifier.supportsAVS(address(0)),
+            "supportsAVS: should return false for zero address"
+        );
+        assertFalse(
+            avsRegistrarAsIdentifier.supportsAVS(address(1)),
+            "supportsAVS: should return false for random address"
+        );
+        assertFalse(
+            avsRegistrarAsIdentifier.supportsAVS(admin),
+            "supportsAVS: should return false for admin"
+        );
+    }
+
+    function testFuzz_supportsAVS(
+        address randomAddress
+    ) public {
+        if (randomAddress == address(avsRegistrarAsIdentifier)) {
+            assertTrue(
+                avsRegistrarAsIdentifier.supportsAVS(randomAddress),
+                "supportsAVS: should return true for self"
+            );
+        } else {
+            assertFalse(
+                avsRegistrarAsIdentifier.supportsAVS(randomAddress),
+                "supportsAVS: should return false for non-self"
+            );
+        }
+    }
+}
+
+contract AVSRegistrarAsIdentifierUnitTests_getAVS is AVSRegistrarAsIdentifierUnitTests {
+    function test_getAVS() public {
+        // Should return the proxy address (self) since AVSRegistrarAsIdentifier overrides getAVS
+        assertEq(
+            avsRegistrarAsIdentifier.getAVS(),
+            address(avsRegistrarAsIdentifier),
+            "getAVS: should return self (proxy) address"
+        );
+    }
+}
+
+contract AVSRegistrarAsIdentifierUnitTests_registerOperator is AVSRegistrarAsIdentifierUnitTests {
+    using ArrayLib for *;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        // Initialize the contract
+        vm.mockCall(
+            address(allocationManagerMock),
+            abi.encodeWithSelector(IAllocationManager.updateAVSMetadataURI.selector),
+            ""
+        );
+        vm.mockCall(
+            address(allocationManagerMock),
+            abi.encodeWithSelector(IAllocationManager.setAVSRegistrar.selector),
+            ""
+        );
+        vm.mockCall(
+            address(permissionController),
+            abi.encodeWithSelector(IPermissionController.addPendingAdmin.selector),
+            ""
+        );
+
+        avsRegistrarAsIdentifier.initialize(admin, METADATA_URI);
+    }
+
+    function testFuzz_revert_notAllocationManager(
+        address notAllocationManager
+    ) public {
+        vm.assume(notAllocationManager != address(allocationManagerMock));
+
+        vm.prank(notAllocationManager);
+        vm.expectRevert(NotAllocationManager.selector);
+        avsRegistrarAsIdentifier.registerOperator(
+            defaultOperator,
+            address(avsRegistrarAsIdentifier),
+            defaultOperatorSetId.toArrayU32(),
+            "0x"
+        );
+    }
+
+    function test_revert_keyNotRegistered() public {
+        // Register operator without key registration
+        vm.expectRevert(KeyNotRegistered.selector);
+        vm.prank(address(allocationManagerMock));
+        avsRegistrarAsIdentifier.registerOperator(
+            defaultOperator,
+            address(avsRegistrarAsIdentifier),
+            defaultOperatorSetId.toArrayU32(),
+            "0x"
+        );
+    }
+
+    function testFuzz_correctness(
+        Randomness r
+    ) public rand(r) {
+        // Generate random operator set ids & register keys
+        uint32 numOperatorSetIds = r.Uint32(1, 50);
+        uint32[] memory operatorSetIds = r.Uint32Array(numOperatorSetIds, 0, type(uint32).max);
+
+        // Register keys for the operator - Note: using AVS as the avs address in the OperatorSet
+        for (uint32 i; i < operatorSetIds.length; ++i) {
+            keyRegistrarMock.setIsRegistered(
+                defaultOperator, OperatorSet({avs: AVS, id: operatorSetIds[i]}), true
+            );
+        }
+
+        // Register operator
+        vm.expectEmit(true, true, true, true);
+        emit OperatorRegistered(defaultOperator, operatorSetIds);
+        vm.prank(address(allocationManagerMock));
+        avsRegistrarAsIdentifier.registerOperator(
+            defaultOperator, address(avsRegistrarAsIdentifier), operatorSetIds, "0x"
+        );
+    }
+}
+
+contract AVSRegistrarAsIdentifierUnitTests_deregisterOperator is
+    AVSRegistrarAsIdentifierUnitTests
+{
+    using ArrayLib for *;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        // Initialize the contract
+        vm.mockCall(
+            address(allocationManagerMock),
+            abi.encodeWithSelector(IAllocationManager.updateAVSMetadataURI.selector),
+            ""
+        );
+        vm.mockCall(
+            address(allocationManagerMock),
+            abi.encodeWithSelector(IAllocationManager.setAVSRegistrar.selector),
+            ""
+        );
+        vm.mockCall(
+            address(permissionController),
+            abi.encodeWithSelector(IPermissionController.addPendingAdmin.selector),
+            ""
+        );
+
+        avsRegistrarAsIdentifier.initialize(admin, METADATA_URI);
+    }
+
+    function testFuzz_revert_notAllocationManager(
+        address notAllocationManager
+    ) public {
+        vm.assume(notAllocationManager != address(allocationManagerMock));
+        vm.assume(notAllocationManager != address(proxyAdmin));
+
+        vm.prank(notAllocationManager);
+        vm.expectRevert(NotAllocationManager.selector);
+        avsRegistrarAsIdentifier.deregisterOperator(
+            defaultOperator, address(avsRegistrarAsIdentifier), defaultOperatorSetId.toArrayU32()
+        );
+    }
+
+    function testFuzz_correctness(
+        Randomness r
+    ) public rand(r) {
+        // Generate random operator set ids
+        uint32 numOperatorSetIds = r.Uint32(1, 50);
+        uint32[] memory operatorSetIds = r.Uint32Array(numOperatorSetIds, 0, type(uint32).max);
+
+        // Deregister operator
+        vm.expectEmit(true, true, true, true);
+        emit OperatorDeregistered(defaultOperator, operatorSetIds);
+        vm.prank(address(allocationManagerMock));
+        avsRegistrarAsIdentifier.deregisterOperator(
+            defaultOperator, address(avsRegistrarAsIdentifier), operatorSetIds
+        );
+    }
+}

--- a/test/unit/middlewareV2/AVSRegistrarSocketUnit.t.sol
+++ b/test/unit/middlewareV2/AVSRegistrarSocketUnit.t.sol
@@ -52,7 +52,7 @@ contract AVSRegistrarSocketUnitTests_registerOperator is AVSRegistrarSocketUnitT
 
     function testFuzz_revert_notAllocationManager(
         address notAllocationManager
-    ) public {
+    ) public filterFuzzedAddressInputs(notAllocationManager) {
         cheats.assume(notAllocationManager != address(allocationManagerMock));
 
         cheats.prank(notAllocationManager);
@@ -98,7 +98,7 @@ contract AVSRegistrarSocketUnitTests_DeregisterOperator is AVSRegistrarSocketUni
 
     function testFuzz_revert_notAllocationManager(
         address notAllocationManager
-    ) public {
+    ) public filterFuzzedAddressInputs(notAllocationManager) {
         cheats.assume(notAllocationManager != address(allocationManagerMock));
 
         cheats.prank(notAllocationManager);

--- a/test/unit/middlewareV2/AVSRegistrarSocketUnit.t.sol
+++ b/test/unit/middlewareV2/AVSRegistrarSocketUnit.t.sol
@@ -158,3 +158,56 @@ contract AVSRegistrarSocketUnitTests_updateSocket is AVSRegistrarSocketUnitTests
         assertEq(socket, newSocket, "Socket mismatch");
     }
 }
+
+contract AVSRegistrarSocketUnitTests_ViewFunctions is AVSRegistrarSocketUnitTests {
+    function test_supportsAVS_true() public {
+        // Should return true when checking against the configured AVS
+        assertTrue(
+            avsRegistrarWithSocket.supportsAVS(AVS),
+            "supportsAVS: should return true for configured AVS"
+        );
+    }
+
+    function test_supportsAVS_false() public {
+        // Should return false for any other address
+        assertFalse(
+            avsRegistrarWithSocket.supportsAVS(address(0)),
+            "supportsAVS: should return false for zero address"
+        );
+        assertFalse(
+            avsRegistrarWithSocket.supportsAVS(address(1)),
+            "supportsAVS: should return false for random address"
+        );
+        assertFalse(
+            avsRegistrarWithSocket.supportsAVS(address(avsRegistrarWithSocket)),
+            "supportsAVS: should return false for registrar address"
+        );
+        assertFalse(
+            avsRegistrarWithSocket.supportsAVS(defaultOperator),
+            "supportsAVS: should return false for operator"
+        );
+    }
+
+    function testFuzz_supportsAVS(
+        address randomAddress
+    ) public {
+        if (randomAddress == AVS) {
+            assertTrue(
+                avsRegistrarWithSocket.supportsAVS(randomAddress),
+                "supportsAVS: should return true for configured AVS"
+            );
+        } else {
+            assertFalse(
+                avsRegistrarWithSocket.supportsAVS(randomAddress),
+                "supportsAVS: should return false for non-AVS address"
+            );
+        }
+    }
+
+    function test_getAVS() public {
+        // Should return the configured AVS address
+        assertEq(
+            avsRegistrarWithSocket.getAVS(), AVS, "getAVS: should return configured AVS address"
+        );
+    }
+}

--- a/test/unit/middlewareV2/AVSRegistrarUnit.t.sol
+++ b/test/unit/middlewareV2/AVSRegistrarUnit.t.sol
@@ -29,9 +29,8 @@ contract AVSRegistrarUnitTests_RegisterOperator is AVSRegistrarUnitTests {
 
     function testFuzz_revert_notAllocationManager(
         address notAllocationManager
-    ) public {
+    ) public filterFuzzedAddressInputs(notAllocationManager) {
         cheats.assume(notAllocationManager != address(allocationManagerMock));
-        cheats.assume(notAllocationManager != address(proxyAdmin));
 
         cheats.prank(notAllocationManager);
         cheats.expectRevert(NotAllocationManager.selector);
@@ -65,9 +64,8 @@ contract AVSRegistrarUnitTests_DeregisterOperator is AVSRegistrarUnitTests {
 
     function testFuzz_revert_notAllocationManager(
         address notAllocationManager
-    ) public {
+    ) public filterFuzzedAddressInputs(notAllocationManager) {
         cheats.assume(notAllocationManager != address(allocationManagerMock));
-        cheats.assume(notAllocationManager != address(proxyAdmin));
 
         cheats.prank(notAllocationManager);
         cheats.expectRevert(NotAllocationManager.selector);

--- a/test/unit/middlewareV2/AVSRegistrarUnit.t.sol
+++ b/test/unit/middlewareV2/AVSRegistrarUnit.t.sol
@@ -88,3 +88,53 @@ contract AVSRegistrarUnitTests_DeregisterOperator is AVSRegistrarUnitTests {
         avsRegistrar.deregisterOperator(defaultOperator, AVS, operatorSetIds);
     }
 }
+
+contract AVSRegistrarUnitTests_ViewFunctions is AVSRegistrarUnitTests {
+    function test_supportsAVS_true() public {
+        // Should return true when checking against the configured AVS
+        assertTrue(
+            avsRegistrar.supportsAVS(AVS), "supportsAVS: should return true for configured AVS"
+        );
+    }
+
+    function test_supportsAVS_false() public {
+        // Should return false for any other address
+        assertFalse(
+            avsRegistrar.supportsAVS(address(0)),
+            "supportsAVS: should return false for zero address"
+        );
+        assertFalse(
+            avsRegistrar.supportsAVS(address(1)),
+            "supportsAVS: should return false for random address"
+        );
+        assertFalse(
+            avsRegistrar.supportsAVS(address(avsRegistrar)),
+            "supportsAVS: should return false for registrar address"
+        );
+        assertFalse(
+            avsRegistrar.supportsAVS(defaultOperator),
+            "supportsAVS: should return false for operator"
+        );
+    }
+
+    function testFuzz_supportsAVS(
+        address randomAddress
+    ) public {
+        if (randomAddress == AVS) {
+            assertTrue(
+                avsRegistrar.supportsAVS(randomAddress),
+                "supportsAVS: should return true for configured AVS"
+            );
+        } else {
+            assertFalse(
+                avsRegistrar.supportsAVS(randomAddress),
+                "supportsAVS: should return false for non-AVS address"
+            );
+        }
+    }
+
+    function test_getAVS() public {
+        // Should return the configured AVS address
+        assertEq(avsRegistrar.getAVS(), AVS, "getAVS: should return configured AVS address");
+    }
+}

--- a/test/unit/middlewareV2/MockDeployer.sol
+++ b/test/unit/middlewareV2/MockDeployer.sol
@@ -79,5 +79,8 @@ abstract contract MockEigenLayerDeployer is Test {
                 )
             )
         );
+
+        // Filter our proxyAdmin from fuzzing
+        isExcludedFuzzAddress[address(proxyAdmin)] = true;
     }
 }


### PR DESCRIPTION
**Motivation:**

The AVS registrar was not properly initializing the AVS in core

**Modifications:**

- Made `avs` variable internal
- Update `supportAVS` in `AVSRegistrarAsIdentifier`
- Add a public view function for the avs

**Result:**

Correct code
