### PR TITLE
chore: update `AVSRegistrar` for new `KeyRegistrar` interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ forge test
 The contracts in this repo are meant to be deployed by each AVS that wants to use them. The addresses listed below refer to EigenDA's deployment, and are included as an example.
 
 ### Current MiddlewareV2 Testnet Deployment
-The following testnet deployment is for our MiddlewareV2 release. The below table calculators calculate slashable stake for an operatorSet and value all strategies equally. For example, or example, if an operator allocates 100 stETH, 100 wETH, and 100 DAI the calculator would return 300 for the stake weight of the operator.  See our [docs](./docs/middlewareV2/README.md) for more information. 
+The following testnet deployment is for our MiddlewareV2 release, deployed on Sepolia. The below table calculators calculate slashable stake for an operatorSet and value all strategies equally. For example, or example, if an operator allocates 100 stETH, 100 wETH, and 100 DAI the calculator would return 300 for the stake weight of the operator.  See our [docs](./docs/middlewareV2/README.md) for more information. 
 
 | Name | Proxy | Implementation | Notes |
 | -------- | -------- | -------- | -------- |

--- a/README.md
+++ b/README.md
@@ -68,7 +68,16 @@ forge test
 
 The contracts in this repo are meant to be deployed by each AVS that wants to use them. The addresses listed below refer to EigenDA's deployment, and are included as an example.
 
-### Current Mainnet Deployment
+### Current MiddlewareV2 Testnet Deployment
+The following testnet deployment is for our MiddlewareV2 release. The below table calculators calculate slashable stake for an operatorSet and value all strategies equally. For example, or example, if an operator allocates 100 stETH, 100 wETH, and 100 DAI the calculator would return 300 for the stake weight of the operator.  See our [docs](./docs/middlewareV2/README.md) for more information. 
+
+| Name | Proxy | Implementation | Notes |
+| -------- | -------- | -------- | -------- |
+[`BN254TableCalculator`](./src/middlewareV2/tableCalculator/BN254TableCalculator.sol)| N/A | [`0xc2c0bc13571aC5115709C332dc7AE666606b08E8`](https://sepolia.etherscan.io/address/0xc2c0bc13571aC5115709C332dc7AE666606b08E8#code) | Singleton non-upgradeable |
+[`ECDSATableCalculator`](./src/middlewareV2/tableCalculator/ECDSATableCalculator.sol)| N/A | [`0x5612Fd146C2d40f1269E0e73945A534ec706dCDc`](https://sepolia.etherscan.io/address/0x5612Fd146C2d40f1269E0e73945A534ec706dCDc#code) | Singleton non-upgradeable |
+
+
+### Current AVS Mainnet Deployment
 
 The current mainnet deployment is from our M2 mainnet release. You can view the deployed contract addresses below, or check out the code itself on the [`mainnet`](https://github.com/Layr-Labs/eigenlayer-middleware/tree/mainnet) branch.
 
@@ -83,7 +92,7 @@ The current mainnet deployment is from our M2 mainnet release. You can view the 
 [`ProxyAdmin`](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.7.1/contracts/proxy/transparent/ProxyAdmin.sol) | - | [`0x8247...2E99`](https://etherscan.io/address/0x8247ef5705d3345516286b72bfe6d690197c2e99#code) | |
 [`eigenda/EigenDAServiceManager`](https://github.com/Layr-Labs/eigenda/blob/08d8781a2165c159ac9bb502dd61ed6ed340601c/contracts/src/core/EigenDAServiceManager.sol) | [`0x870679e138bcdf293b7ff14dd44b70fc97e12fc0`](https://etherscan.io/address/0x870679e138bcdf293b7ff14dd44b70fc97e12fc0#readProxyContract) | [`0xF5fD...899e`](https://etherscan.io/address/0xf5fd25a90902c27068cf5ebe53be8da693ac899e#code) | Proxy: [`TUP@4.7.1`](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.7.1/contracts/proxy/transparent/TransparentUpgradeableProxy.sol) |
 
-### Current Testnet Deployment
+### Current AVS Testnet Deployment
 
 The current testnet deployment is on holesky, is from our M2 beta release. You can view the deployed contract addresses below, or check out the code itself on the [`testnet-holesky`](https://github.com/Layr-Labs/eigenlayer-middleware/tree/testnet-holesky) branch.
 

--- a/docs/middlewareV2/AVSRegistrar.md
+++ b/docs/middlewareV2/AVSRegistrar.md
@@ -20,7 +20,7 @@ Interfaces:
 
 ## Overview
 
-The AVSRegistrar is the interface between AVSs and the EigenLayer core protocol for managing operator registration. It enforces that operators have valid keys registered in the `KeyRegistrar` for a given `operatorSet` before allowing them to register. The `AVSRegistrar` manages multiple operatorSets for a single AVS. 
+The AVSRegistrar is the interface between AVSs and the EigenLayer core protocol for managing operator registration. It enforces that operators have valid keys registered in the `KeyRegistrar` for a given `operatorSet` before allowing them to register. The `AVSRegistrar` manages multiple operatorSets for a single AVS.  
 
 ### Key Features
 
@@ -36,32 +36,45 @@ The below system diagrams assume the *basic* interaction with the AVSRegistrar. 
 3. Gating operator registration based on custom stake-weighted parameters
 
 #### Initialization
+
 ```mermaid
 sequenceDiagram
     participant AVSAdmin as AVS Admin
-    participant AllocationManager
     participant AVSRegistrar
+    participant OperatorTableCalculator
+    participant AllocationManager
+    participant KeyRegistrar
+    participant CrossChainRegistry
 
-    AVSAdmin->>AllocationManager: Tx1: set metadataURI
-    AVSAdmin->>AVSRegistrar: Tx2: deploy AVSRegistrar
-    AVSAdmin->>AllocationManager: Tx3: set AVSRegistrar
-    AllocationManager->>AVSRegistrar: Tx3: check supportsAVS()
+    AVS->>AVSRegistrar: Tx1: Deploy AVSRegistrar
+    AVS->>AllocationManager: Tx2: updateMetadataURI()
+    AVS->>AllocationManager: Tx3: setAVSRegistrar(AVSRegistrar)
+    AllocationManager-->>: check supportsAVS()
+    AVS->>KeyRegistrar: Tx4: configureOperatorSet(operatorSet, keyMaterial)
 ```
 
 The `AVSAdmin` is the entity that conducts on-chain operations on behalf of the AVS. It can be a multisig, eoa, or governance contract. In Tx1, when the `metadataURI` is set, the identifier for the AVS in the core protocol is the address of the `AVSAdmin`. For ergonomic purposes, it is possible to have the identifier be the [`AVSRegistrar`](#avsregistrarasidentifier). See the [Core `PermissionController`](https://github.com/Layr-Labs/eigenlayer-contracts/blob/main/docs/permissions/PermissionController.md) for more information on how the admin can be changed. 
 
-#### Registration
+#### Registration 
+
+All registration/deregistration will flow from the `AllocationManager`. The `middlewareV2` architecture no longer requires an AVS to deploy a `KeyRegistrar`. Instead, the `AVSRegistrar` checks key membership in the core `KeyRegistrar` contract.
+
 ```mermaid
 sequenceDiagram
-    participant Operator
-    participant AllocationManager
-    participant AVSRegistrar
+    participant OP as Operator
+    participant KR as KeyRegistrar
+    participant AM as AllocationManager
+    participant AVR as AVSRegistrar
 
-    Operator->>AllocationManager: Tx1: Register for opSet
-    AllocationManager->>AVSRegistrar: Tx1: Send opSets, Data
+    OP->>KR: Tx1: registerKey
+    OP->>AM: Tx2: registerForOperatorSets
+    AM-->>AVR: registerForOperatorSets
+    AVR-->>KR: isRegistered
 ```
 
 #### Deregistration
+
+
 ```mermaid
 sequenceDiagram
     participant Operator
@@ -69,7 +82,25 @@ sequenceDiagram
     participant AVSRegistrar
 
     Operator->>AllocationManager: Tx1: Deregister
-    AllocationManager->>AVSRegistrar: Tx1: Send Deregistration
+    AllocationManager-->>AVSRegistrar: Tx1: Send Deregistration
+```
+
+#### Operator Key Rotation
+
+Rotation takes a dependency on the `AllocationManager`. In particular, operators are only allowed to deregister their key from an operatorSet if they are not slashable by said operatorSet. 
+
+To rotate a key, an operator must deregister from the operatorSet, wait until it is not slashable, deregister its key, and then register a new key. If the operator was not slashable, it can rotate its key without a delay. 
+
+```mermaid
+sequenceDiagram
+    participant OP as Operator
+    participant AM as AllocationManager
+    participant KR as KeyRegistrar
+
+    OP->>AM: Tx1: deregisterFromOperatorSets
+    Note over OP: Wait 14 days<br>(if previously allocated)
+    OP->>KR: Tx2: deregisterKey
+    OP->>AM: Tx3: register new key to operatorSet
 ```
 
 ---
@@ -143,7 +174,7 @@ function deregisterOperator(
 ) external virtual onlyAllocationManager;
 ```
 
-Deregisters an operator from one or more operator sets. This function can be called by an operator OR by the AVSs ejector if it has configured permissions in the [Core `Permission Controller`](https://github.com/Layr-Labs/eigenlayer-contracts/blob/main/docs/permissions/PermissionController.md).
+Deregisters an operator from one or more operator sets. This function can be called by on the `AllocationManager` by either the operator OR  the AVSs ejector if the AVS has configured permissions in the [Core `Permission Controller`](https://github.com/Layr-Labs/eigenlayer-contracts/blob/main/docs/permissions/PermissionController.md).
 
 *Effects:*
 - Emits `OperatorDeregistered` event
@@ -235,7 +266,6 @@ function _afterDeregisterOperator(
 - Updating internal state
 - Triggering external notifications
 - Recording additional information
-
 
 ---
 
@@ -419,3 +449,5 @@ function initialize(address admin, string memory metadataURI) public initializer
 1. Updates AVS metadata URI in the AllocationManager
 2. Sets itself as the AVS registrar
 3. Initiates admin transfer via PermissionController
+
+---

--- a/docs/middlewareV2/OperatorTableCalculator.md
+++ b/docs/middlewareV2/OperatorTableCalculator.md
@@ -33,7 +33,7 @@ In addition, an AVS can build custom calculation methodologies that include:
 - Capping the stake of an operator
 - Using oracles to price stake
 
-The [`ECDSATableCalculator`](../../src/middlewareV2/tableCalculator/ECDSATableCalculator.sol) and [`BN254TableCalculator`](../../src/middlewareV2/tableCalculator/BN254TableCalculator.sol) value slashable stake equally across all strategies. For example, if an operator allocates 100 stETH, 100 wETH, and 100 USDC the calculator would return 300 for the stake weight of the operator. 
+The [`ECDSATableCalculator`](../../src/middlewareV2/tableCalculator/ECDSATableCalculator.sol) and [`BN254TableCalculator`](../../src/middlewareV2/tableCalculator/BN254TableCalculator.sol) value slashable stake equally across all strategies. For example, if an operator allocates 100 stETH, 100 wETH, and 100 DAI the calculator would return 300 for the stake weight of the operator. 
 
 
 ---

--- a/src/middlewareV2/registrar/AVSRegistrar.sol
+++ b/src/middlewareV2/registrar/AVSRegistrar.sol
@@ -95,7 +95,7 @@ contract AVSRegistrar is Initializable, AVSRegistrarStorage {
     ) internal view {
         for (uint32 i = 0; i < operatorSetIds.length; i++) {
             OperatorSet memory operatorSet = OperatorSet({avs: avs, id: operatorSetIds[i]});
-            require(keyRegistrar.checkKey(operatorSet, operator), KeyNotRegistered());
+            require(keyRegistrar.isRegistered(operatorSet, operator), KeyNotRegistered());
         }
     }
 

--- a/test/mocks/KeyRegistrarMock.sol
+++ b/test/mocks/KeyRegistrarMock.sol
@@ -26,13 +26,6 @@ contract KeyRegistrarMock is IKeyRegistrar {
         _operatorRegistered[operatorSetKey][operator] = _isRegistered;
     }
 
-    function checkKey(
-        OperatorSet calldata operatorSet,
-        address operator
-    ) external view returns (bool) {
-        return _operatorRegistered[operatorSet.key()][operator];
-    }
-
     function initialize(
         address initialOwner
     ) external {}
@@ -51,7 +44,9 @@ contract KeyRegistrarMock is IKeyRegistrar {
     function isRegistered(
         OperatorSet memory operatorSet,
         address operator
-    ) external pure returns (bool) {}
+    ) external view returns (bool) {
+        return _operatorRegistered[operatorSet.key()][operator];
+    }
 
     function getOperatorSetCurveType(
         OperatorSet memory operatorSet


### PR DESCRIPTION
**Motivation:**

We've updated the `KeyRegistrar` interface to now only have an `isRegistered` call: https://github.com/Layr-Labs/eigenlayer-contracts/pull/1551

**Modifications:**

- Update call to `KeyRegistrar` from `AVSRegistrar`
- Rev submodule
- Also document table calculators in ReadME

**Result:**

Working integration