### PR TITLE
docs: format table in `OperatorTableCalculator`

### DIFF
--- a/docs/middlewareV2/OperatorTableCalculator.md
+++ b/docs/middlewareV2/OperatorTableCalculator.md
@@ -1,7 +1,7 @@
 ## OperatorTableCalculator
 
 | File | Type | Notes |
-| -------- | -------- | 
+| -------- | -------- | -------- | 
 | [`ECDSATableCalculatorBase.sol`](../../src/middlewareV2/tableCalculator/ECDSATableCalculatorBase.sol) | Abstract | Base functionality for ECDSA operator tables |
 | [`BN254TableCalculatorBase.sol`](../../src/middlewareV2/tableCalculator/BN254TableCalculatorBase.sol) | Abstract | Base functionality for BN254 operator tables |
 


### PR DESCRIPTION
Table for `operatorTableCalculator` was not formatted properly