### PR TITLE
fix(I-03): rename `ISocketRegistry` -> `ISocketRegistryV2`

### DIFF
--- a/src/interfaces/IAVSRegistrarWithSocket.sol
+++ b/src/interfaces/IAVSRegistrarWithSocket.sol
@@ -2,6 +2,6 @@
 pragma solidity ^0.8.27;
 
 import {IAVSRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IAVSRegistrar.sol";
-import {ISocketRegistry} from "./ISocketRegistryV2.sol";
+import {ISocketRegistryV2} from "./ISocketRegistryV2.sol";
 
-interface IAVSRegistrarWithSocket is IAVSRegistrar, ISocketRegistry {}
+interface IAVSRegistrarWithSocket is IAVSRegistrar, ISocketRegistryV2 {}

--- a/src/interfaces/ISocketRegistryV2.sol
+++ b/src/interfaces/ISocketRegistryV2.sol
@@ -14,7 +14,7 @@ interface ISocketRegistryEvents {
     event OperatorSocketSet(address indexed operator, string socket);
 }
 
-interface ISocketRegistry is ISocketRegistryErrors, ISocketRegistryEvents {
+interface ISocketRegistryV2 is ISocketRegistryErrors, ISocketRegistryEvents {
     /**
      * @notice Gets the socket for an operator.
      * @param operator The operator to get the socket for.

--- a/src/middlewareV2/registrar/modules/SocketRegistry.sol
+++ b/src/middlewareV2/registrar/modules/SocketRegistry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {ISocketRegistry} from "../../../interfaces/ISocketRegistryV2.sol";
+import {ISocketRegistryV2} from "../../../interfaces/ISocketRegistryV2.sol";
 import {SocketRegistryStorage} from "./SocketRegistryStorage.sol";
 import {
     OperatorSetLib,
@@ -13,14 +13,14 @@ import {
 abstract contract SocketRegistry is SocketRegistryStorage {
     using OperatorSetLib for OperatorSet;
 
-    /// @inheritdoc ISocketRegistry
+    /// @inheritdoc ISocketRegistryV2
     function getOperatorSocket(
         address operator
     ) external view returns (string memory) {
         return _operatorToSocket[operator];
     }
 
-    /// @inheritdoc ISocketRegistry
+    /// @inheritdoc ISocketRegistryV2
     function updateSocket(address operator, string memory socket) external {
         require(msg.sender == operator, CallerNotOperator());
         _setOperatorSocket(operator, socket);

--- a/src/middlewareV2/registrar/modules/SocketRegistryStorage.sol
+++ b/src/middlewareV2/registrar/modules/SocketRegistryStorage.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.12;
 
-import {ISocketRegistry} from "../../../interfaces/ISocketRegistryV2.sol";
+import {ISocketRegistryV2} from "../../../interfaces/ISocketRegistryV2.sol";
 
 /**
  * @title Storage variables for the `SocketRegistry` contract.
  * @author Layr Labs, Inc.
  */
-abstract contract SocketRegistryStorage is ISocketRegistry {
+abstract contract SocketRegistryStorage is ISocketRegistryV2 {
     /**
      *
      *                                    STATE


### PR DESCRIPTION
**Motivation:**

We now have two `ISocketRegistry` interfaces, and need to differentiate for clarity.

**Modifications:**

- Renamed **new** `ISocketRegistry` -> `ISocketRegistryV2`

**Result:**

Improved clarity.
