### PR TITLE
fix(I-04): make avs var stateful & remove confusing natspec 

### DIFF
--- a/src/interfaces/IAVSRegistrarInternal.sol
+++ b/src/interfaces/IAVSRegistrarInternal.sol
@@ -17,7 +17,4 @@ interface IAVSRegistrarEvents {
 }
 
 /// @notice Since we have already defined a public interface, we add the events and errors here
-interface IAVSRegistrarInternal is IAVSRegistrarErrors, IAVSRegistrarEvents {
-    /// @notice Returns the address of the AVS in EigenLayer core
-    function getAVS() external view returns (address);
-}
+interface IAVSRegistrarInternal is IAVSRegistrarErrors, IAVSRegistrarEvents {}

--- a/src/middlewareV2/registrar/AVSRegistrar.sol
+++ b/src/middlewareV2/registrar/AVSRegistrar.sol
@@ -31,7 +31,7 @@ abstract contract AVSRegistrar is Initializable, AVSRegistrarStorage {
         _disableInitializers();
     }
 
-    // @dev This MUST be added to an `initialize` function in child contracts.
+    /// @dev This initialization function MUST be added to a child's `initialize` function to avoid uninitialized storage.
     function __AVSRegistrar_init(
         address _avs
     ) internal virtual {

--- a/src/middlewareV2/registrar/AVSRegistrar.sol
+++ b/src/middlewareV2/registrar/AVSRegistrar.sol
@@ -25,11 +25,17 @@ contract AVSRegistrar is Initializable, AVSRegistrarStorage {
     }
 
     constructor(
-        address _avs,
         IAllocationManager _allocationManager,
         IKeyRegistrar _keyRegistrar
-    ) AVSRegistrarStorage(_avs, _allocationManager, _keyRegistrar) {
+    ) AVSRegistrarStorage(_allocationManager, _keyRegistrar) {
         _disableInitializers();
+    }
+
+    // @dev This MUST be added to an `initialize` function in child contracts.
+    function __AVSRegistrar_init(
+        address _avs
+    ) internal virtual {
+        avs = _avs;
     }
 
     /// @inheritdoc IAVSRegistrar
@@ -67,11 +73,6 @@ contract AVSRegistrar is Initializable, AVSRegistrarStorage {
         address _avs
     ) public view virtual returns (bool) {
         return _avs == avs;
-    }
-
-    /// @inheritdoc IAVSRegistrarInternal
-    function getAVS() external view virtual returns (address) {
-        return avs;
     }
 
     /*

--- a/src/middlewareV2/registrar/AVSRegistrar.sol
+++ b/src/middlewareV2/registrar/AVSRegistrar.sol
@@ -16,7 +16,7 @@ import {AVSRegistrarStorage} from "./AVSRegistrarStorage.sol";
 import {Initializable} from "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";
 
 /// @notice A minimal AVSRegistrar contract that is used to register/deregister operators for an AVS
-contract AVSRegistrar is Initializable, AVSRegistrarStorage {
+abstract contract AVSRegistrar is Initializable, AVSRegistrarStorage {
     using OperatorSetLib for OperatorSet;
 
     modifier onlyAllocationManager() {

--- a/src/middlewareV2/registrar/AVSRegistrarStorage.sol
+++ b/src/middlewareV2/registrar/AVSRegistrarStorage.sol
@@ -15,18 +15,17 @@ abstract contract AVSRegistrarStorage is IAVSRegistrar, IAVSRegistrarInternal {
      *
      */
 
-    /// @notice The AVS that this registrar is for
-    /// @dev In practice, the AVS address in EigenLayer core is address that initialized the Metadata URI.
-    address internal immutable avs;
-
     /// @notice The allocation manager in EigenLayer core
     IAllocationManager public immutable allocationManager;
 
     /// @notice Pointer to the EigenLayer core Key Registrar
     IKeyRegistrar public immutable keyRegistrar;
 
-    constructor(address _avs, IAllocationManager _allocationManager, IKeyRegistrar _keyRegistrar) {
-        avs = _avs;
+    /// @notice The AVS that this registrar is for
+    /// @dev In practice, the AVS address in EigenLayer core is address that initialized the Metadata URI.
+    address public avs;
+
+    constructor(IAllocationManager _allocationManager, IKeyRegistrar _keyRegistrar) {
         allocationManager = _allocationManager;
         keyRegistrar = _keyRegistrar;
     }
@@ -36,5 +35,5 @@ abstract contract AVSRegistrarStorage is IAVSRegistrar, IAVSRegistrarInternal {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[50] private __GAP;
+    uint256[49] private __GAP;
 }

--- a/src/middlewareV2/registrar/modules/Allowlist.sol
+++ b/src/middlewareV2/registrar/modules/Allowlist.sol
@@ -18,13 +18,7 @@ abstract contract Allowlist is OwnableUpgradeable, AllowlistStorage {
     using OperatorSetLib for OperatorSet;
     using EnumerableSetUpgradeable for EnumerableSetUpgradeable.AddressSet;
 
-    function initialize(
-        address _owner
-    ) public virtual initializer {
-        _initializeAllowlist(_owner);
-    }
-
-    function _initializeAllowlist(
+    function __Allowlist_init(
         address _owner
     ) internal onlyInitializing {
         __Ownable_init();

--- a/src/middlewareV2/registrar/presets/AVSRegistrarAsIdentifier.sol
+++ b/src/middlewareV2/registrar/presets/AVSRegistrarAsIdentifier.sol
@@ -44,11 +44,4 @@ contract AVSRegistrarAsIdentifier is AVSRegistrar {
         // Set the admin for the AVS
         permissionController.addPendingAdmin(address(this), admin);
     }
-
-    /// @inheritdoc IAVSRegistrar
-    function supportsAVS(
-        address _avs
-    ) public view override returns (bool) {
-        return _avs == address(this);
-    }
 }

--- a/src/middlewareV2/registrar/presets/AVSRegistrarAsIdentifier.sol
+++ b/src/middlewareV2/registrar/presets/AVSRegistrarAsIdentifier.sol
@@ -1,14 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
+import {Initializable} from "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";
+
 import {IAVSRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IAVSRegistrar.sol";
-import {IAVSRegistrarInternal} from "../../../interfaces/IAVSRegistrarInternal.sol";
 import {IAllocationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 import {IPermissionController} from
     "eigenlayer-contracts/src/contracts/interfaces/IPermissionController.sol";
 import {IKeyRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
 
+import {IAVSRegistrarInternal} from "../../../interfaces/IAVSRegistrarInternal.sol";
 import {AVSRegistrar} from "../AVSRegistrar.sol";
 
 /// @notice An AVSRegistrar that is the identifier for the AVS in EigenLayer core.
@@ -18,11 +20,10 @@ contract AVSRegistrarAsIdentifier is AVSRegistrar {
     IPermissionController public immutable permissionController;
 
     constructor(
-        address _avs,
         IAllocationManager _allocationManager,
         IPermissionController _permissionController,
         IKeyRegistrar _keyRegistrar
-    ) AVSRegistrar(_avs, _allocationManager, _keyRegistrar) {
+    ) AVSRegistrar(_allocationManager, _keyRegistrar) {
         // Set the permission controller for future interactions
         permissionController = _permissionController;
     }
@@ -34,6 +35,8 @@ contract AVSRegistrarAsIdentifier is AVSRegistrar {
      * @dev This function enables the address of the AVS in the core protocol to be the proxy AVSRegistrarAsIdentifier contract
      */
     function initialize(address admin, string memory metadataURI) public initializer {
+        __AVSRegistrar_init(address(this));
+
         // Set the metadataURI and the registrar for the AVS to this registrar contract
         allocationManager.updateAVSMetadataURI(address(this), metadataURI);
         allocationManager.setAVSRegistrar(address(this), this);
@@ -47,10 +50,5 @@ contract AVSRegistrarAsIdentifier is AVSRegistrar {
         address _avs
     ) public view override returns (bool) {
         return _avs == address(this);
-    }
-
-    /// @inheritdoc IAVSRegistrarInternal
-    function getAVS() external view override returns (address) {
-        return address(this);
     }
 }

--- a/src/middlewareV2/registrar/presets/AVSRegistrarAsIdentifier.sol
+++ b/src/middlewareV2/registrar/presets/AVSRegistrarAsIdentifier.sol
@@ -17,8 +17,6 @@ contract AVSRegistrarAsIdentifier is AVSRegistrar {
     /// @notice The permission controller for the AVS
     IPermissionController public immutable permissionController;
 
-    /// @dev The immutable avs address `AVSRegistrar` is NOT the address of the AVS in EigenLayer core.
-    /// @dev The address of the AVS in EigenLayer core is the proxy contract, and it is set via the `initialize` function below.
     constructor(
         address _avs,
         IAllocationManager _allocationManager,

--- a/src/middlewareV2/registrar/presets/AVSRegistrarWithAllowlist.sol
+++ b/src/middlewareV2/registrar/presets/AVSRegistrarWithAllowlist.sol
@@ -12,15 +12,16 @@ import {OperatorSet} from "eigenlayer-contracts/src/contracts/libraries/Operator
 
 contract AVSRegistrarWithAllowlist is AVSRegistrar, Allowlist, IAVSRegistrarWithAllowlist {
     constructor(
-        address _avs,
         IAllocationManager _allocationManager,
         IKeyRegistrar _keyRegistrar
-    ) AVSRegistrar(_avs, _allocationManager, _keyRegistrar) {}
+    ) AVSRegistrar(_allocationManager, _keyRegistrar) {}
 
-    function initialize(
-        address admin
-    ) public override initializer {
-        _initializeAllowlist(admin);
+    function initialize(address avs, address admin) external initializer {
+        // Initialize the AVSRegistrar
+        __AVSRegistrar_init(avs);
+
+        // Initialize the allowlist
+        __Allowlist_init(admin);
     }
 
     /// @notice Before registering operator, check if the operator is in the allowlist

--- a/src/middlewareV2/registrar/presets/AVSRegistrarWithSocket.sol
+++ b/src/middlewareV2/registrar/presets/AVSRegistrarWithSocket.sol
@@ -11,10 +11,15 @@ import {SocketRegistry} from "../modules/SocketRegistry.sol";
 
 contract AVSRegistrarWithSocket is AVSRegistrar, SocketRegistry, IAVSRegistrarWithSocket {
     constructor(
-        address _avs,
         IAllocationManager _allocationManager,
         IKeyRegistrar _keyRegistrar
-    ) AVSRegistrar(_avs, _allocationManager, _keyRegistrar) {}
+    ) AVSRegistrar(_allocationManager, _keyRegistrar) {}
+
+    function initialize(
+        address avs
+    ) external initializer {
+        __AVSRegistrar_init(avs);
+    }
 
     /// @notice Set the socket for the operator
     /// @dev This function sets the socket even if the operator is already registered

--- a/test/unit/middlewareV2/AVSRegistrarAllowlistUnit.t.sol
+++ b/test/unit/middlewareV2/AVSRegistrarAllowlistUnit.t.sol
@@ -29,7 +29,7 @@ contract AVSRegistrarWithAllowlistUnitTests is
                     address(avsRegistrarImplementation),
                     address(proxyAdmin),
                     abi.encodeWithSelector(
-                        AVSRegistrarWithAllowlist.initialize.selector, address(this)
+                        AVSRegistrarWithAllowlist.initialize.selector, AVS, address(this)
                     )
                 )
             )

--- a/test/unit/middlewareV2/AVSRegistrarAllowlistUnit.t.sol
+++ b/test/unit/middlewareV2/AVSRegistrarAllowlistUnit.t.sol
@@ -19,7 +19,6 @@ contract AVSRegistrarWithAllowlistUnitTests is
         super.setUp();
 
         avsRegistrarImplementation = new AVSRegistrarWithAllowlist(
-            AVS,
             IAllocationManager(address(allocationManagerMock)),
             IKeyRegistrar(address(keyRegistrarMock))
         );
@@ -57,7 +56,7 @@ contract AVSRegistrarWithAllowlistUnitTests_initialize is AVSRegistrarWithAllowl
 
     function test_revert_alreadyInitialized() public {
         cheats.expectRevert("Initializable: contract is already initialized");
-        avsRegistrarWithAllowlist.initialize(allowlistAdmin);
+        avsRegistrarWithAllowlist.initialize(AVS, allowlistAdmin);
     }
 }
 
@@ -345,12 +344,5 @@ contract AVSRegistrarWithAllowlistUnitTests_ViewFunctions is AVSRegistrarWithAll
                 "supportsAVS: should return false for non-AVS address"
             );
         }
-    }
-
-    function test_getAVS() public {
-        // Should return the configured AVS address
-        assertEq(
-            avsRegistrarWithAllowlist.getAVS(), AVS, "getAVS: should return configured AVS address"
-        );
     }
 }

--- a/test/unit/middlewareV2/AVSRegistrarAsIdentifierUnit.t.sol
+++ b/test/unit/middlewareV2/AVSRegistrarAsIdentifierUnit.t.sol
@@ -24,7 +24,6 @@ contract AVSRegistrarAsIdentifierUnitTests is AVSRegistrarBase {
 
         // Deploy the implementation
         avsRegistrarImplementation = new AVSRegistrarAsIdentifier(
-            AVS,
             IAllocationManager(address(allocationManagerMock)),
             permissionController,
             IKeyRegistrar(address(keyRegistrarMock))
@@ -45,7 +44,6 @@ contract AVSRegistrarAsIdentifierUnitTests_constructor is AVSRegistrarAsIdentifi
     function test_constructor() public {
         // Deploy a new implementation to test constructor
         AVSRegistrarAsIdentifier impl = new AVSRegistrarAsIdentifier(
-            AVS,
             IAllocationManager(address(allocationManagerMock)),
             permissionController,
             IKeyRegistrar(address(keyRegistrarMock))
@@ -202,17 +200,6 @@ contract AVSRegistrarAsIdentifierUnitTests_supportsAVS is AVSRegistrarAsIdentifi
                 "supportsAVS: should return false for non-self"
             );
         }
-    }
-}
-
-contract AVSRegistrarAsIdentifierUnitTests_getAVS is AVSRegistrarAsIdentifierUnitTests {
-    function test_getAVS() public {
-        // Should return the proxy address (self) since AVSRegistrarAsIdentifier overrides getAVS
-        assertEq(
-            avsRegistrarAsIdentifier.getAVS(),
-            address(avsRegistrarAsIdentifier),
-            "getAVS: should return self (proxy) address"
-        );
     }
 }
 

--- a/test/unit/middlewareV2/AVSRegistrarAsIdentifierUnit.t.sol
+++ b/test/unit/middlewareV2/AVSRegistrarAsIdentifierUnit.t.sol
@@ -33,7 +33,11 @@ contract AVSRegistrarAsIdentifierUnitTests is AVSRegistrarBase {
         avsRegistrarAsIdentifier = AVSRegistrarAsIdentifier(
             address(
                 new TransparentUpgradeableProxy(
-                    address(avsRegistrarImplementation), address(proxyAdmin), ""
+                    address(avsRegistrarImplementation),
+                    address(proxyAdmin),
+                    abi.encodeWithSelector(
+                        AVSRegistrarAsIdentifier.initialize.selector, address(this), METADATA_URI
+                    )
                 )
             )
         );
@@ -127,8 +131,8 @@ contract AVSRegistrarAsIdentifierUnitTests_initialize is AVSRegistrarAsIdentifie
             )
         );
 
-        // Initialize
-        avsRegistrarAsIdentifier.initialize(admin, METADATA_URI);
+        // // Initialize
+        // avsRegistrarAsIdentifier.initialize(admin, METADATA_URI);
     }
 
     function test_revert_alreadyInitialized() public {
@@ -149,7 +153,7 @@ contract AVSRegistrarAsIdentifierUnitTests_initialize is AVSRegistrarAsIdentifie
             ""
         );
 
-        avsRegistrarAsIdentifier.initialize(admin, METADATA_URI);
+        // avsRegistrarAsIdentifier.initialize(admin, METADATA_URI);
 
         // Try to initialize again
         vm.expectRevert("Initializable: contract is already initialized");
@@ -226,7 +230,7 @@ contract AVSRegistrarAsIdentifierUnitTests_registerOperator is AVSRegistrarAsIde
             ""
         );
 
-        avsRegistrarAsIdentifier.initialize(admin, METADATA_URI);
+        // avsRegistrarAsIdentifier.initialize(admin, METADATA_URI);
     }
 
     function testFuzz_revert_notAllocationManager(
@@ -305,7 +309,7 @@ contract AVSRegistrarAsIdentifierUnitTests_deregisterOperator is
             ""
         );
 
-        avsRegistrarAsIdentifier.initialize(admin, METADATA_URI);
+        // avsRegistrarAsIdentifier.initialize(admin, METADATA_URI);
     }
 
     function testFuzz_revert_notAllocationManager(

--- a/test/unit/middlewareV2/AVSRegistrarAsIdentifierUnit.t.sol
+++ b/test/unit/middlewareV2/AVSRegistrarAsIdentifierUnit.t.sol
@@ -36,7 +36,7 @@ contract AVSRegistrarAsIdentifierUnitTests is AVSRegistrarBase {
                     address(avsRegistrarImplementation),
                     address(proxyAdmin),
                     abi.encodeWithSelector(
-                        AVSRegistrarAsIdentifier.initialize.selector, address(this), METADATA_URI
+                        AVSRegistrarAsIdentifier.initialize.selector, AVS, METADATA_URI
                     )
                 )
             )
@@ -74,6 +74,14 @@ contract AVSRegistrarAsIdentifierUnitTests_constructor is AVSRegistrarAsIdentifi
 
 contract AVSRegistrarAsIdentifierUnitTests_initialize is AVSRegistrarAsIdentifierUnitTests {
     function test_initialize() public {
+        avsRegistrarAsIdentifier = AVSRegistrarAsIdentifier(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(avsRegistrarImplementation), address(proxyAdmin), ""
+                )
+            )
+        );
+
         // Mock the allocationManager calls
         vm.mockCall(
             address(allocationManagerMock),
@@ -131,8 +139,8 @@ contract AVSRegistrarAsIdentifierUnitTests_initialize is AVSRegistrarAsIdentifie
             )
         );
 
-        // // Initialize
-        // avsRegistrarAsIdentifier.initialize(admin, METADATA_URI);
+        // Initialize
+        avsRegistrarAsIdentifier.initialize(admin, METADATA_URI);
     }
 
     function test_revert_alreadyInitialized() public {
@@ -210,29 +218,6 @@ contract AVSRegistrarAsIdentifierUnitTests_supportsAVS is AVSRegistrarAsIdentifi
 contract AVSRegistrarAsIdentifierUnitTests_registerOperator is AVSRegistrarAsIdentifierUnitTests {
     using ArrayLib for *;
 
-    function setUp() public virtual override {
-        super.setUp();
-
-        // Initialize the contract
-        vm.mockCall(
-            address(allocationManagerMock),
-            abi.encodeWithSelector(IAllocationManager.updateAVSMetadataURI.selector),
-            ""
-        );
-        vm.mockCall(
-            address(allocationManagerMock),
-            abi.encodeWithSelector(IAllocationManager.setAVSRegistrar.selector),
-            ""
-        );
-        vm.mockCall(
-            address(permissionController),
-            abi.encodeWithSelector(IPermissionController.addPendingAdmin.selector),
-            ""
-        );
-
-        // avsRegistrarAsIdentifier.initialize(admin, METADATA_URI);
-    }
-
     function testFuzz_revert_notAllocationManager(
         address notAllocationManager
     ) public filterFuzzedAddressInputs(notAllocationManager) {
@@ -270,14 +255,16 @@ contract AVSRegistrarAsIdentifierUnitTests_registerOperator is AVSRegistrarAsIde
         // Register keys for the operator - Note: using AVS as the avs address in the OperatorSet
         for (uint32 i; i < operatorSetIds.length; ++i) {
             keyRegistrarMock.setIsRegistered(
-                defaultOperator, OperatorSet({avs: AVS, id: operatorSetIds[i]}), true
+                defaultOperator,
+                OperatorSet({avs: address(avsRegistrarAsIdentifier), id: operatorSetIds[i]}),
+                true
             );
         }
 
         // Register operator
+        vm.prank(address(allocationManagerMock));
         vm.expectEmit(true, true, true, true);
         emit OperatorRegistered(defaultOperator, operatorSetIds);
-        vm.prank(address(allocationManagerMock));
         avsRegistrarAsIdentifier.registerOperator(
             defaultOperator, address(avsRegistrarAsIdentifier), operatorSetIds, "0x"
         );
@@ -288,29 +275,6 @@ contract AVSRegistrarAsIdentifierUnitTests_deregisterOperator is
     AVSRegistrarAsIdentifierUnitTests
 {
     using ArrayLib for *;
-
-    function setUp() public virtual override {
-        super.setUp();
-
-        // Initialize the contract
-        vm.mockCall(
-            address(allocationManagerMock),
-            abi.encodeWithSelector(IAllocationManager.updateAVSMetadataURI.selector),
-            ""
-        );
-        vm.mockCall(
-            address(allocationManagerMock),
-            abi.encodeWithSelector(IAllocationManager.setAVSRegistrar.selector),
-            ""
-        );
-        vm.mockCall(
-            address(permissionController),
-            abi.encodeWithSelector(IPermissionController.addPendingAdmin.selector),
-            ""
-        );
-
-        // avsRegistrarAsIdentifier.initialize(admin, METADATA_URI);
-    }
 
     function testFuzz_revert_notAllocationManager(
         address notAllocationManager

--- a/test/unit/middlewareV2/AVSRegistrarBase.t.sol
+++ b/test/unit/middlewareV2/AVSRegistrarBase.t.sol
@@ -16,6 +16,21 @@ import {
 import {ArrayLib} from "eigenlayer-contracts/src/test/utils/ArrayLib.sol";
 import "test/utils/Random.sol";
 
+contract AVSRegistrarImplementation is AVSRegistrar {
+    constructor(
+        IAllocationManager _allocationManager,
+        IKeyRegistrar _keyRegistrar
+    ) AVSRegistrar(_allocationManager, _keyRegistrar) {
+        _disableInitializers();
+    }
+
+    function initialize(
+        address _owner
+    ) external initializer {
+        __AVSRegistrar_init(_owner);
+    }
+}
+
 abstract contract AVSRegistrarBase is
     MockEigenLayerDeployer,
     IAVSRegistrarErrors,

--- a/test/unit/middlewareV2/AVSRegistrarSocketUnit.t.sol
+++ b/test/unit/middlewareV2/AVSRegistrarSocketUnit.t.sol
@@ -20,7 +20,6 @@ contract AVSRegistrarSocketUnitTests is
         super.setUp();
 
         avsRegistrarImplementation = new AVSRegistrarWithSocket(
-            AVS,
             IAllocationManager(address(allocationManagerMock)),
             IKeyRegistrar(address(keyRegistrarMock))
         );
@@ -202,12 +201,5 @@ contract AVSRegistrarSocketUnitTests_ViewFunctions is AVSRegistrarSocketUnitTest
                 "supportsAVS: should return false for non-AVS address"
             );
         }
-    }
-
-    function test_getAVS() public {
-        // Should return the configured AVS address
-        assertEq(
-            avsRegistrarWithSocket.getAVS(), AVS, "getAVS: should return configured AVS address"
-        );
     }
 }

--- a/test/unit/middlewareV2/AVSRegistrarSocketUnit.t.sol
+++ b/test/unit/middlewareV2/AVSRegistrarSocketUnit.t.sol
@@ -27,7 +27,9 @@ contract AVSRegistrarSocketUnitTests is
         avsRegistrarWithSocket = AVSRegistrarWithSocket(
             address(
                 new TransparentUpgradeableProxy(
-                    address(avsRegistrarImplementation), address(proxyAdmin), ""
+                    address(avsRegistrarImplementation),
+                    address(proxyAdmin),
+                    abi.encodeWithSelector(AVSRegistrarWithSocket.initialize.selector, AVS)
                 )
             )
         );

--- a/test/unit/middlewareV2/AVSRegistrarUnit.t.sol
+++ b/test/unit/middlewareV2/AVSRegistrarUnit.t.sol
@@ -8,15 +8,19 @@ contract AVSRegistrarUnitTests is AVSRegistrarBase {
     function setUp() public override {
         super.setUp();
 
-        avsRegistrarImplementation = new AVSRegistrar(
-            IAllocationManager(address(allocationManagerMock)),
-            IKeyRegistrar(address(keyRegistrarMock))
+        avsRegistrarImplementation = AVSRegistrar(
+            new AVSRegistrarImplementation(
+                IAllocationManager(address(allocationManagerMock)),
+                IKeyRegistrar(address(keyRegistrarMock))
+            )
         );
 
         avsRegistrar = AVSRegistrar(
             address(
                 new TransparentUpgradeableProxy(
-                    address(avsRegistrarImplementation), address(proxyAdmin), ""
+                    address(avsRegistrarImplementation),
+                    address(proxyAdmin),
+                    abi.encodeWithSelector(AVSRegistrarImplementation.initialize.selector, AVS)
                 )
             )
         );

--- a/test/unit/middlewareV2/AVSRegistrarUnit.t.sol
+++ b/test/unit/middlewareV2/AVSRegistrarUnit.t.sol
@@ -9,7 +9,6 @@ contract AVSRegistrarUnitTests is AVSRegistrarBase {
         super.setUp();
 
         avsRegistrarImplementation = new AVSRegistrar(
-            AVS,
             IAllocationManager(address(allocationManagerMock)),
             IKeyRegistrar(address(keyRegistrarMock))
         );
@@ -129,10 +128,5 @@ contract AVSRegistrarUnitTests_ViewFunctions is AVSRegistrarUnitTests {
                 "supportsAVS: should return false for non-AVS address"
             );
         }
-    }
-
-    function test_getAVS() public {
-        // Should return the configured AVS address
-        assertEq(avsRegistrar.getAVS(), AVS, "getAVS: should return configured AVS address");
     }
 }

--- a/test/unit/middlewareV2/AllowlistUnit.t.sol
+++ b/test/unit/middlewareV2/AllowlistUnit.t.sol
@@ -1,479 +1,487 @@
-// // SPDX-License-Identifier: BUSL-1.1
-// pragma solidity ^0.8.27;
-
-// import "forge-std/Test.sol";
-// import {TransparentUpgradeableProxy} from
-//     "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-// import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
-
-// import {Allowlist} from "src/middlewareV2/registrar/modules/Allowlist.sol";
-// import {IAllowlist, IAllowlistErrors, IAllowlistEvents} from "src/interfaces/IAllowlist.sol";
-// import {
-//     OperatorSet,
-//     OperatorSetLib
-// } from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
-// import {Random, Randomness} from "test/utils/Random.sol";
-
-// // Concrete implementation for testing
-// contract AllowlistImplementation is Allowlist {
-//     function version() external pure returns (string memory) {
-//         return "1.0.0";
-//     }
-// }
-
-// contract AllowlistUnitTests is Test, IAllowlistErrors, IAllowlistEvents {
-//     using OperatorSetLib for OperatorSet;
-
-//     Vm cheats = Vm(VM_ADDRESS);
-
-//     // Contracts
-//     AllowlistImplementation public allowlistImplementation;
-//     AllowlistImplementation public allowlist;
-//     ProxyAdmin public proxyAdmin;
-
-//     // Test addresses
-//     address public allowlistOwner = address(this);
-//     address public avs1 = address(0x1);
-//     address public avs2 = address(0x2);
-//     address public operator1 = address(0x3);
-//     address public operator2 = address(0x4);
-//     address public operator3 = address(0x5);
-//     address public defaultOperator = operator1;
-
-//     // Test operator sets
-//     OperatorSet defaultOperatorSet;
-//     OperatorSet alternativeOperatorSet;
-//     uint32 public defaultOperatorSetId = 0;
-
-//     /// @dev set the random seed for the current test
-//     modifier rand(
-//         Randomness r
-//     ) {
-//         r.set();
-//         _;
-//     }
-
-//     function random() internal returns (Randomness) {
-//         return Randomness.wrap(Random.SEED).shuffle();
-//     }
-
-//     function setUp() public virtual {
-//         // Deploy proxy admin
-//         proxyAdmin = new ProxyAdmin();
-
-//         // Deploy implementation
-//         allowlistImplementation = new AllowlistImplementation();
-
-//         // Deploy proxy
-//         allowlist = AllowlistImplementation(
-//             address(
-//                 new TransparentUpgradeableProxy(
-//                     address(allowlistImplementation),
-//                     address(proxyAdmin),
-//                     abi.encodeWithSelector(Allowlist.initialize.selector, allowlistOwner)
-//                 )
-//             )
-//         );
-
-//         // Set up operator sets
-//         defaultOperatorSet = OperatorSet({avs: avs1, id: defaultOperatorSetId});
-//         alternativeOperatorSet = OperatorSet({avs: avs2, id: 1});
-//     }
-
-//     function _addOperatorToAllowlist(address operator, OperatorSet memory operatorSet) internal {
-//         cheats.prank(allowlistOwner);
-//         allowlist.addOperatorToAllowlist(operatorSet, operator);
-//     }
-
-//     function _addOperatorsToAllowlist(
-//         address[] memory operators,
-//         OperatorSet memory operatorSet
-//     ) internal {
-//         for (uint256 i = 0; i < operators.length; i++) {
-//             _addOperatorToAllowlist(operators[i], operatorSet);
-//         }
-//     }
-// }
-
-// contract AllowlistUnitTests_initialize is AllowlistUnitTests {
-//     function test_initialization() public view {
-//         // Check the owner is set correctly
-//         assertEq(allowlist.owner(), allowlistOwner, "Initialization: owner incorrect");
-//     }
-
-//     function test_revert_alreadyInitialized() public {
-//         cheats.expectRevert("Initializable: contract is already initialized");
-//         allowlist.initialize(allowlistOwner);
-//     }
-
-//     function testFuzz_initialization(
-//         address randomOwner
-//     ) public {
-//         // Deploy new instance with random owner
-//         AllowlistImplementation newAllowlist = AllowlistImplementation(
-//             address(
-//                 new TransparentUpgradeableProxy(
-//                     address(allowlistImplementation),
-//                     address(proxyAdmin),
-//                     abi.encodeWithSelector(Allowlist.initialize.selector, randomOwner)
-//                 )
-//             )
-//         );
-
-//         assertEq(newAllowlist.owner(), randomOwner, "Owner should be set to randomOwner");
-//     }
-// }
-
-// contract AllowlistUnitTests_addOperatorToAllowlist is AllowlistUnitTests {
-//     function testFuzz_revert_notOwner(
-//         address notOwner
-//     ) public {
-//         cheats.assume(notOwner != allowlistOwner);
-
-//         cheats.expectRevert("Ownable: caller is not the owner");
-//         cheats.prank(notOwner);
-//         allowlist.addOperatorToAllowlist(defaultOperatorSet, defaultOperator);
-//     }
-
-//     function test_revert_operatorAlreadyInAllowlist() public {
-//         // Add operator first time
-//         _addOperatorToAllowlist(defaultOperator, defaultOperatorSet);
-
-//         // Try to add again
-//         cheats.expectRevert(OperatorAlreadyInAllowlist.selector);
-//         cheats.prank(allowlistOwner);
-//         allowlist.addOperatorToAllowlist(defaultOperatorSet, defaultOperator);
-//     }
-
-//     function test_correctness_singleOperator() public {
-//         // Add operator
-//         cheats.expectEmit(true, true, true, true);
-//         emit OperatorAddedToAllowlist(defaultOperatorSet, defaultOperator);
-//         cheats.prank(allowlistOwner);
-//         allowlist.addOperatorToAllowlist(defaultOperatorSet, defaultOperator);
-
-//         // Check operator is in allowlist
-//         assertTrue(
-//             allowlist.isOperatorAllowed(defaultOperatorSet, defaultOperator),
-//             "Operator should be in allowlist"
-//         );
-//     }
-
-//     function testFuzz_correctness_multipleOperatorSets(
-//         Randomness r
-//     ) public rand(r) {
-//         // Generate random operator set ids
-//         uint32 numOperatorSets = r.Uint32(1, 50);
-//         uint32[] memory operatorSetIds = r.Uint32Array(numOperatorSets, 0, type(uint32).max);
-
-//         // Add operator to multiple operator sets
-//         for (uint32 i = 0; i < operatorSetIds.length; i++) {
-//             OperatorSet memory operatorSet = OperatorSet({avs: avs1, id: operatorSetIds[i]});
-
-//             cheats.expectEmit(true, true, true, true);
-//             emit OperatorAddedToAllowlist(operatorSet, defaultOperator);
-//             cheats.prank(allowlistOwner);
-//             allowlist.addOperatorToAllowlist(operatorSet, defaultOperator);
-//         }
-
-//         // Verify operator is in all operator sets
-//         for (uint32 i = 0; i < operatorSetIds.length; i++) {
-//             OperatorSet memory operatorSet = OperatorSet({avs: avs1, id: operatorSetIds[i]});
-//             assertTrue(
-//                 allowlist.isOperatorAllowed(operatorSet, defaultOperator),
-//                 "Operator should be in all operator sets"
-//             );
-//         }
-//     }
-
-//     function testFuzz_correctness_multipleOperators(
-//         Randomness r
-//     ) public rand(r) {
-//         // Generate random operators
-//         uint32 numOperators = r.Uint32(1, 50);
-//         address[] memory operators = new address[](numOperators);
-//         for (uint32 i = 0; i < numOperators; i++) {
-//             operators[i] = r.Address();
-//         }
-
-//         // Add all operators to the default operator set
-//         for (uint32 i = 0; i < operators.length; i++) {
-//             cheats.expectEmit(true, true, true, true);
-//             emit OperatorAddedToAllowlist(defaultOperatorSet, operators[i]);
-//             cheats.prank(allowlistOwner);
-//             allowlist.addOperatorToAllowlist(defaultOperatorSet, operators[i]);
-//         }
-
-//         // Verify all operators are in the allowlist
-//         for (uint32 i = 0; i < operators.length; i++) {
-//             assertTrue(
-//                 allowlist.isOperatorAllowed(defaultOperatorSet, operators[i]),
-//                 "All operators should be in allowlist"
-//             );
-//         }
-//     }
-// }
-
-// contract AllowlistUnitTests_removeOperatorFromAllowlist is AllowlistUnitTests {
-//     function testFuzz_revert_notOwner(
-//         address notOwner
-//     ) public {
-//         cheats.assume(notOwner != allowlistOwner);
-
-//         cheats.expectRevert("Ownable: caller is not the owner");
-//         cheats.prank(notOwner);
-//         allowlist.removeOperatorFromAllowlist(defaultOperatorSet, defaultOperator);
-//     }
-
-//     function test_revert_operatorNotInAllowlist() public {
-//         cheats.expectRevert(OperatorNotInAllowlist.selector);
-//         cheats.prank(allowlistOwner);
-//         allowlist.removeOperatorFromAllowlist(defaultOperatorSet, defaultOperator);
-//     }
-
-//     function test_correctness_removeAfterAdd() public {
-//         // Add operator first
-//         _addOperatorToAllowlist(defaultOperator, defaultOperatorSet);
-
-//         // Remove operator
-//         cheats.expectEmit(true, true, true, true);
-//         emit OperatorRemovedFromAllowlist(defaultOperatorSet, defaultOperator);
-//         cheats.prank(allowlistOwner);
-//         allowlist.removeOperatorFromAllowlist(defaultOperatorSet, defaultOperator);
-
-//         // Check operator is not in allowlist
-//         assertFalse(
-//             allowlist.isOperatorAllowed(defaultOperatorSet, defaultOperator),
-//             "Operator should not be in allowlist after removal"
-//         );
-//     }
-
-//     function testFuzz_correctness_multipleOperatorSets(
-//         Randomness r
-//     ) public rand(r) {
-//         // Generate random operator set ids
-//         uint32 numOperatorSets = r.Uint32(1, 50);
-//         uint32[] memory operatorSetIds = r.Uint32Array(numOperatorSets, 0, type(uint32).max);
-
-//         // Add operator to all operator sets
-//         for (uint32 i = 0; i < operatorSetIds.length; i++) {
-//             OperatorSet memory operatorSet = OperatorSet({avs: avs1, id: operatorSetIds[i]});
-//             _addOperatorToAllowlist(defaultOperator, operatorSet);
-//         }
-
-//         // Remove operator from all operator sets
-//         for (uint32 i = 0; i < operatorSetIds.length; i++) {
-//             OperatorSet memory operatorSet = OperatorSet({avs: avs1, id: operatorSetIds[i]});
-
-//             cheats.expectEmit(true, true, true, true);
-//             emit OperatorRemovedFromAllowlist(operatorSet, defaultOperator);
-//             cheats.prank(allowlistOwner);
-//             allowlist.removeOperatorFromAllowlist(operatorSet, defaultOperator);
-//         }
-
-//         // Verify operator is not in any operator set
-//         for (uint32 i = 0; i < operatorSetIds.length; i++) {
-//             OperatorSet memory operatorSet = OperatorSet({avs: avs1, id: operatorSetIds[i]});
-//             assertFalse(
-//                 allowlist.isOperatorAllowed(operatorSet, defaultOperator),
-//                 "Operator should not be in any operator set"
-//             );
-//         }
-//     }
-
-//     function test_correctness_partialRemoval() public {
-//         // Add operator to multiple operator sets
-//         _addOperatorToAllowlist(defaultOperator, defaultOperatorSet);
-//         _addOperatorToAllowlist(defaultOperator, alternativeOperatorSet);
-
-//         // Remove from only one operator set
-//         cheats.prank(allowlistOwner);
-//         allowlist.removeOperatorFromAllowlist(defaultOperatorSet, defaultOperator);
-
-//         // Check operator is removed from one but not the other
-//         assertFalse(
-//             allowlist.isOperatorAllowed(defaultOperatorSet, defaultOperator),
-//             "Operator should be removed from default operator set"
-//         );
-//         assertTrue(
-//             allowlist.isOperatorAllowed(alternativeOperatorSet, defaultOperator),
-//             "Operator should still be in alternative operator set"
-//         );
-//     }
-// }
-
-// contract AllowlistUnitTests_isOperatorAllowed is AllowlistUnitTests {
-//     function test_returnsFalse_whenNotAdded() public view {
-//         assertFalse(
-//             allowlist.isOperatorAllowed(defaultOperatorSet, defaultOperator),
-//             "Should return false for operator not in allowlist"
-//         );
-//     }
-
-//     function test_returnsTrue_whenAdded() public {
-//         _addOperatorToAllowlist(defaultOperator, defaultOperatorSet);
-
-//         assertTrue(
-//             allowlist.isOperatorAllowed(defaultOperatorSet, defaultOperator),
-//             "Should return true for operator in allowlist"
-//         );
-//     }
-
-//     function testFuzz_correctness(
-//         Randomness r
-//     ) public rand(r) {
-//         // Generate random operators and operator sets
-//         uint32 numOperators = r.Uint32(5, 20);
-//         uint32 numOperatorSets = r.Uint32(5, 20);
-
-//         address[] memory operators = new address[](numOperators);
-//         for (uint32 i = 0; i < numOperators; i++) {
-//             operators[i] = r.Address();
-//         }
-
-//         OperatorSet[] memory operatorSets = new OperatorSet[](numOperatorSets);
-//         for (uint32 i = 0; i < numOperatorSets; i++) {
-//             operatorSets[i] = OperatorSet({avs: r.Address(), id: r.Uint32(0, type(uint32).max)});
-//         }
-
-//         // Randomly add some operators to some operator sets
-//         for (uint32 i = 0; i < operators.length; i++) {
-//             for (uint32 j = 0; j < operatorSets.length; j++) {
-//                 if (r.Boolean()) {
-//                     // 50% chance
-//                     _addOperatorToAllowlist(operators[i], operatorSets[j]);
-//                 }
-//             }
-//         }
-
-//         // Verify the state is correct by re-checking
-//         for (uint32 i = 0; i < operators.length; i++) {
-//             for (uint32 j = 0; j < operatorSets.length; j++) {
-//                 // The state should be consistent with what we set
-//                 bool shouldBeAllowed = allowlist.isOperatorAllowed(operatorSets[j], operators[i]);
-
-//                 // If allowed, removing should work
-//                 if (shouldBeAllowed) {
-//                     cheats.prank(allowlistOwner);
-//                     allowlist.removeOperatorFromAllowlist(operatorSets[j], operators[i]);
-//                     assertFalse(
-//                         allowlist.isOperatorAllowed(operatorSets[j], operators[i]),
-//                         "After removal, operator should not be allowed"
-//                     );
-//                 }
-//             }
-//         }
-//     }
-// }
-
-// contract AllowlistUnitTests_getAllowedOperators is AllowlistUnitTests {
-//     function test_returnsEmptyArray_whenNoOperators() public view {
-//         address[] memory allowedOperators = allowlist.getAllowedOperators(defaultOperatorSet);
-//         assertEq(allowedOperators.length, 0, "Should return empty array when no operators");
-//     }
-
-//     function test_returnsSingleOperator() public {
-//         _addOperatorToAllowlist(defaultOperator, defaultOperatorSet);
-
-//         address[] memory allowedOperators = allowlist.getAllowedOperators(defaultOperatorSet);
-//         assertEq(allowedOperators.length, 1, "Should return array with one operator");
-//         assertEq(allowedOperators[0], defaultOperator, "Should return the correct operator");
-//     }
-
-//     function test_returnsMultipleOperators() public {
-//         address[] memory operators = new address[](3);
-//         operators[0] = operator1;
-//         operators[1] = operator2;
-//         operators[2] = operator3;
-
-//         // Add all operators
-//         _addOperatorsToAllowlist(operators, defaultOperatorSet);
-
-//         address[] memory allowedOperators = allowlist.getAllowedOperators(defaultOperatorSet);
-//         assertEq(allowedOperators.length, 3, "Should return all operators");
-
-//         // Note: Order may not be preserved, so we check membership
-//         bool found1 = false;
-//         bool found2 = false;
-//         bool found3 = false;
-
-//         for (uint256 i = 0; i < allowedOperators.length; i++) {
-//             if (allowedOperators[i] == operator1) found1 = true;
-//             if (allowedOperators[i] == operator2) found2 = true;
-//             if (allowedOperators[i] == operator3) found3 = true;
-//         }
-
-//         assertTrue(found1 && found2 && found3, "All operators should be in the returned array");
-//     }
-
-//     function testFuzz_correctness(
-//         Randomness r
-//     ) public rand(r) {
-//         // Generate random operators
-//         uint32 numOperators = r.Uint32(1, 50);
-//         address[] memory operators = new address[](numOperators);
-//         for (uint32 i = 0; i < numOperators; i++) {
-//             operators[i] = r.Address();
-//         }
-
-//         // Add all operators to default operator set
-//         _addOperatorsToAllowlist(operators, defaultOperatorSet);
-
-//         // Get allowed operators
-//         address[] memory allowedOperators = allowlist.getAllowedOperators(defaultOperatorSet);
-
-//         assertEq(allowedOperators.length, operators.length, "Should return all added operators");
-
-//         // Check all operators are in the returned array
-//         for (uint32 i = 0; i < operators.length; i++) {
-//             bool found = false;
-//             for (uint32 j = 0; j < allowedOperators.length; j++) {
-//                 if (allowedOperators[j] == operators[i]) {
-//                     found = true;
-//                     break;
-//                 }
-//             }
-//             assertTrue(found, "All added operators should be in the returned array");
-//         }
-//     }
-
-//     function test_independentOperatorSets() public {
-//         // Add different operators to different operator sets
-//         _addOperatorToAllowlist(operator1, defaultOperatorSet);
-//         _addOperatorToAllowlist(operator2, defaultOperatorSet);
-//         _addOperatorToAllowlist(operator3, alternativeOperatorSet);
-
-//         // Check default operator set
-//         address[] memory defaultAllowed = allowlist.getAllowedOperators(defaultOperatorSet);
-//         assertEq(defaultAllowed.length, 2, "Default operator set should have 2 operators");
-
-//         // Check alternative operator set
-//         address[] memory alternativeAllowed = allowlist.getAllowedOperators(alternativeOperatorSet);
-//         assertEq(alternativeAllowed.length, 1, "Alternative operator set should have 1 operator");
-//         assertEq(
-//             alternativeAllowed[0], operator3, "Alternative operator set should contain operator3"
-//         );
-//     }
-
-//     function test_afterRemoval() public {
-//         // Add multiple operators
-//         _addOperatorToAllowlist(operator1, defaultOperatorSet);
-//         _addOperatorToAllowlist(operator2, defaultOperatorSet);
-//         _addOperatorToAllowlist(operator3, defaultOperatorSet);
-
-//         // Remove one operator
-//         cheats.prank(allowlistOwner);
-//         allowlist.removeOperatorFromAllowlist(defaultOperatorSet, operator2);
-
-//         // Check the result
-//         address[] memory allowedOperators = allowlist.getAllowedOperators(defaultOperatorSet);
-//         assertEq(allowedOperators.length, 2, "Should have 2 operators after removal");
-
-//         // Verify operator2 is not in the array
-//         for (uint256 i = 0; i < allowedOperators.length; i++) {
-//             assertTrue(
-//                 allowedOperators[i] != operator2, "Removed operator should not be in the array"
-//             );
-//         }
-//     }
-// }
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import "forge-std/Test.sol";
+import {TransparentUpgradeableProxy} from
+    "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+
+import {Allowlist} from "src/middlewareV2/registrar/modules/Allowlist.sol";
+import {IAllowlist, IAllowlistErrors, IAllowlistEvents} from "src/interfaces/IAllowlist.sol";
+import {
+    OperatorSet,
+    OperatorSetLib
+} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+import {Random, Randomness} from "test/utils/Random.sol";
+
+// Concrete implementation for testing
+contract AllowlistImplementation is Allowlist {
+    function initialize(
+        address _owner
+    ) external initializer {
+        __Allowlist_init(_owner);
+    }
+
+    function version() external pure returns (string memory) {
+        return "1.0.0";
+    }
+}
+
+contract AllowlistUnitTests is Test, IAllowlistErrors, IAllowlistEvents {
+    using OperatorSetLib for OperatorSet;
+
+    Vm cheats = Vm(VM_ADDRESS);
+
+    // Contracts
+    AllowlistImplementation public allowlistImplementation;
+    AllowlistImplementation public allowlist;
+    ProxyAdmin public proxyAdmin;
+
+    // Test addresses
+    address public allowlistOwner = address(this);
+    address public avs1 = address(0x1);
+    address public avs2 = address(0x2);
+    address public operator1 = address(0x3);
+    address public operator2 = address(0x4);
+    address public operator3 = address(0x5);
+    address public defaultOperator = operator1;
+
+    // Test operator sets
+    OperatorSet defaultOperatorSet;
+    OperatorSet alternativeOperatorSet;
+    uint32 public defaultOperatorSetId = 0;
+
+    /// @dev set the random seed for the current test
+    modifier rand(
+        Randomness r
+    ) {
+        r.set();
+        _;
+    }
+
+    function random() internal returns (Randomness) {
+        return Randomness.wrap(Random.SEED).shuffle();
+    }
+
+    function setUp() public virtual {
+        // Deploy proxy admin
+        proxyAdmin = new ProxyAdmin();
+
+        // Deploy implementation
+        allowlistImplementation = new AllowlistImplementation();
+
+        // Deploy proxy
+        allowlist = AllowlistImplementation(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(allowlistImplementation),
+                    address(proxyAdmin),
+                    abi.encodeWithSelector(
+                        AllowlistImplementation.initialize.selector, allowlistOwner
+                    )
+                )
+            )
+        );
+
+        // Set up operator sets
+        defaultOperatorSet = OperatorSet({avs: avs1, id: defaultOperatorSetId});
+        alternativeOperatorSet = OperatorSet({avs: avs2, id: 1});
+    }
+
+    function _addOperatorToAllowlist(address operator, OperatorSet memory operatorSet) internal {
+        cheats.prank(allowlistOwner);
+        allowlist.addOperatorToAllowlist(operatorSet, operator);
+    }
+
+    function _addOperatorsToAllowlist(
+        address[] memory operators,
+        OperatorSet memory operatorSet
+    ) internal {
+        for (uint256 i = 0; i < operators.length; i++) {
+            _addOperatorToAllowlist(operators[i], operatorSet);
+        }
+    }
+}
+
+contract AllowlistUnitTests_initialize is AllowlistUnitTests {
+    function test_initialization() public view {
+        // Check the owner is set correctly
+        assertEq(allowlist.owner(), allowlistOwner, "Initialization: owner incorrect");
+    }
+
+    function test_revert_alreadyInitialized() public {
+        cheats.expectRevert("Initializable: contract is already initialized");
+        allowlist.initialize(allowlistOwner);
+    }
+
+    function testFuzz_initialization(
+        address randomOwner
+    ) public {
+        // Deploy new instance with random owner
+        AllowlistImplementation newAllowlist = AllowlistImplementation(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(allowlistImplementation),
+                    address(proxyAdmin),
+                    abi.encodeWithSelector(AllowlistImplementation.initialize.selector, randomOwner)
+                )
+            )
+        );
+
+        assertEq(newAllowlist.owner(), randomOwner, "Owner should be set to randomOwner");
+    }
+}
+
+contract AllowlistUnitTests_addOperatorToAllowlist is AllowlistUnitTests {
+    function testFuzz_revert_notOwner(
+        address notOwner
+    ) public {
+        cheats.assume(notOwner != allowlistOwner);
+
+        cheats.expectRevert("Ownable: caller is not the owner");
+        cheats.prank(notOwner);
+        allowlist.addOperatorToAllowlist(defaultOperatorSet, defaultOperator);
+    }
+
+    function test_revert_operatorAlreadyInAllowlist() public {
+        // Add operator first time
+        _addOperatorToAllowlist(defaultOperator, defaultOperatorSet);
+
+        // Try to add again
+        cheats.expectRevert(OperatorAlreadyInAllowlist.selector);
+        cheats.prank(allowlistOwner);
+        allowlist.addOperatorToAllowlist(defaultOperatorSet, defaultOperator);
+    }
+
+    function test_correctness_singleOperator() public {
+        // Add operator
+        cheats.expectEmit(true, true, true, true);
+        emit OperatorAddedToAllowlist(defaultOperatorSet, defaultOperator);
+        cheats.prank(allowlistOwner);
+        allowlist.addOperatorToAllowlist(defaultOperatorSet, defaultOperator);
+
+        // Check operator is in allowlist
+        assertTrue(
+            allowlist.isOperatorAllowed(defaultOperatorSet, defaultOperator),
+            "Operator should be in allowlist"
+        );
+    }
+
+    function testFuzz_correctness_multipleOperatorSets(
+        Randomness r
+    ) public rand(r) {
+        // Generate random operator set ids
+        uint32 numOperatorSets = r.Uint32(1, 50);
+        uint32[] memory operatorSetIds = r.Uint32Array(numOperatorSets, 0, type(uint32).max);
+
+        // Add operator to multiple operator sets
+        for (uint32 i = 0; i < operatorSetIds.length; i++) {
+            OperatorSet memory operatorSet = OperatorSet({avs: avs1, id: operatorSetIds[i]});
+
+            cheats.expectEmit(true, true, true, true);
+            emit OperatorAddedToAllowlist(operatorSet, defaultOperator);
+            cheats.prank(allowlistOwner);
+            allowlist.addOperatorToAllowlist(operatorSet, defaultOperator);
+        }
+
+        // Verify operator is in all operator sets
+        for (uint32 i = 0; i < operatorSetIds.length; i++) {
+            OperatorSet memory operatorSet = OperatorSet({avs: avs1, id: operatorSetIds[i]});
+            assertTrue(
+                allowlist.isOperatorAllowed(operatorSet, defaultOperator),
+                "Operator should be in all operator sets"
+            );
+        }
+    }
+
+    function testFuzz_correctness_multipleOperators(
+        Randomness r
+    ) public rand(r) {
+        // Generate random operators
+        uint32 numOperators = r.Uint32(1, 50);
+        address[] memory operators = new address[](numOperators);
+        for (uint32 i = 0; i < numOperators; i++) {
+            operators[i] = r.Address();
+        }
+
+        // Add all operators to the default operator set
+        for (uint32 i = 0; i < operators.length; i++) {
+            cheats.expectEmit(true, true, true, true);
+            emit OperatorAddedToAllowlist(defaultOperatorSet, operators[i]);
+            cheats.prank(allowlistOwner);
+            allowlist.addOperatorToAllowlist(defaultOperatorSet, operators[i]);
+        }
+
+        // Verify all operators are in the allowlist
+        for (uint32 i = 0; i < operators.length; i++) {
+            assertTrue(
+                allowlist.isOperatorAllowed(defaultOperatorSet, operators[i]),
+                "All operators should be in allowlist"
+            );
+        }
+    }
+}
+
+contract AllowlistUnitTests_removeOperatorFromAllowlist is AllowlistUnitTests {
+    function testFuzz_revert_notOwner(
+        address notOwner
+    ) public {
+        cheats.assume(notOwner != allowlistOwner);
+
+        cheats.expectRevert("Ownable: caller is not the owner");
+        cheats.prank(notOwner);
+        allowlist.removeOperatorFromAllowlist(defaultOperatorSet, defaultOperator);
+    }
+
+    function test_revert_operatorNotInAllowlist() public {
+        cheats.expectRevert(OperatorNotInAllowlist.selector);
+        cheats.prank(allowlistOwner);
+        allowlist.removeOperatorFromAllowlist(defaultOperatorSet, defaultOperator);
+    }
+
+    function test_correctness_removeAfterAdd() public {
+        // Add operator first
+        _addOperatorToAllowlist(defaultOperator, defaultOperatorSet);
+
+        // Remove operator
+        cheats.expectEmit(true, true, true, true);
+        emit OperatorRemovedFromAllowlist(defaultOperatorSet, defaultOperator);
+        cheats.prank(allowlistOwner);
+        allowlist.removeOperatorFromAllowlist(defaultOperatorSet, defaultOperator);
+
+        // Check operator is not in allowlist
+        assertFalse(
+            allowlist.isOperatorAllowed(defaultOperatorSet, defaultOperator),
+            "Operator should not be in allowlist after removal"
+        );
+    }
+
+    function testFuzz_correctness_multipleOperatorSets(
+        Randomness r
+    ) public rand(r) {
+        // Generate random operator set ids
+        uint32 numOperatorSets = r.Uint32(1, 50);
+        uint32[] memory operatorSetIds = r.Uint32Array(numOperatorSets, 0, type(uint32).max);
+
+        // Add operator to all operator sets
+        for (uint32 i = 0; i < operatorSetIds.length; i++) {
+            OperatorSet memory operatorSet = OperatorSet({avs: avs1, id: operatorSetIds[i]});
+            _addOperatorToAllowlist(defaultOperator, operatorSet);
+        }
+
+        // Remove operator from all operator sets
+        for (uint32 i = 0; i < operatorSetIds.length; i++) {
+            OperatorSet memory operatorSet = OperatorSet({avs: avs1, id: operatorSetIds[i]});
+
+            cheats.expectEmit(true, true, true, true);
+            emit OperatorRemovedFromAllowlist(operatorSet, defaultOperator);
+            cheats.prank(allowlistOwner);
+            allowlist.removeOperatorFromAllowlist(operatorSet, defaultOperator);
+        }
+
+        // Verify operator is not in any operator set
+        for (uint32 i = 0; i < operatorSetIds.length; i++) {
+            OperatorSet memory operatorSet = OperatorSet({avs: avs1, id: operatorSetIds[i]});
+            assertFalse(
+                allowlist.isOperatorAllowed(operatorSet, defaultOperator),
+                "Operator should not be in any operator set"
+            );
+        }
+    }
+
+    function test_correctness_partialRemoval() public {
+        // Add operator to multiple operator sets
+        _addOperatorToAllowlist(defaultOperator, defaultOperatorSet);
+        _addOperatorToAllowlist(defaultOperator, alternativeOperatorSet);
+
+        // Remove from only one operator set
+        cheats.prank(allowlistOwner);
+        allowlist.removeOperatorFromAllowlist(defaultOperatorSet, defaultOperator);
+
+        // Check operator is removed from one but not the other
+        assertFalse(
+            allowlist.isOperatorAllowed(defaultOperatorSet, defaultOperator),
+            "Operator should be removed from default operator set"
+        );
+        assertTrue(
+            allowlist.isOperatorAllowed(alternativeOperatorSet, defaultOperator),
+            "Operator should still be in alternative operator set"
+        );
+    }
+}
+
+contract AllowlistUnitTests_isOperatorAllowed is AllowlistUnitTests {
+    function test_returnsFalse_whenNotAdded() public view {
+        assertFalse(
+            allowlist.isOperatorAllowed(defaultOperatorSet, defaultOperator),
+            "Should return false for operator not in allowlist"
+        );
+    }
+
+    function test_returnsTrue_whenAdded() public {
+        _addOperatorToAllowlist(defaultOperator, defaultOperatorSet);
+
+        assertTrue(
+            allowlist.isOperatorAllowed(defaultOperatorSet, defaultOperator),
+            "Should return true for operator in allowlist"
+        );
+    }
+
+    function testFuzz_correctness(
+        Randomness r
+    ) public rand(r) {
+        // Generate random operators and operator sets
+        uint32 numOperators = r.Uint32(5, 20);
+        uint32 numOperatorSets = r.Uint32(5, 20);
+
+        address[] memory operators = new address[](numOperators);
+        for (uint32 i = 0; i < numOperators; i++) {
+            operators[i] = r.Address();
+        }
+
+        OperatorSet[] memory operatorSets = new OperatorSet[](numOperatorSets);
+        for (uint32 i = 0; i < numOperatorSets; i++) {
+            operatorSets[i] = OperatorSet({avs: r.Address(), id: r.Uint32(0, type(uint32).max)});
+        }
+
+        // Randomly add some operators to some operator sets
+        for (uint32 i = 0; i < operators.length; i++) {
+            for (uint32 j = 0; j < operatorSets.length; j++) {
+                if (r.Boolean()) {
+                    // 50% chance
+                    _addOperatorToAllowlist(operators[i], operatorSets[j]);
+                }
+            }
+        }
+
+        // Verify the state is correct by re-checking
+        for (uint32 i = 0; i < operators.length; i++) {
+            for (uint32 j = 0; j < operatorSets.length; j++) {
+                // The state should be consistent with what we set
+                bool shouldBeAllowed = allowlist.isOperatorAllowed(operatorSets[j], operators[i]);
+
+                // If allowed, removing should work
+                if (shouldBeAllowed) {
+                    cheats.prank(allowlistOwner);
+                    allowlist.removeOperatorFromAllowlist(operatorSets[j], operators[i]);
+                    assertFalse(
+                        allowlist.isOperatorAllowed(operatorSets[j], operators[i]),
+                        "After removal, operator should not be allowed"
+                    );
+                }
+            }
+        }
+    }
+}
+
+contract AllowlistUnitTests_getAllowedOperators is AllowlistUnitTests {
+    function test_returnsEmptyArray_whenNoOperators() public view {
+        address[] memory allowedOperators = allowlist.getAllowedOperators(defaultOperatorSet);
+        assertEq(allowedOperators.length, 0, "Should return empty array when no operators");
+    }
+
+    function test_returnsSingleOperator() public {
+        _addOperatorToAllowlist(defaultOperator, defaultOperatorSet);
+
+        address[] memory allowedOperators = allowlist.getAllowedOperators(defaultOperatorSet);
+        assertEq(allowedOperators.length, 1, "Should return array with one operator");
+        assertEq(allowedOperators[0], defaultOperator, "Should return the correct operator");
+    }
+
+    function test_returnsMultipleOperators() public {
+        address[] memory operators = new address[](3);
+        operators[0] = operator1;
+        operators[1] = operator2;
+        operators[2] = operator3;
+
+        // Add all operators
+        _addOperatorsToAllowlist(operators, defaultOperatorSet);
+
+        address[] memory allowedOperators = allowlist.getAllowedOperators(defaultOperatorSet);
+        assertEq(allowedOperators.length, 3, "Should return all operators");
+
+        // Note: Order may not be preserved, so we check membership
+        bool found1 = false;
+        bool found2 = false;
+        bool found3 = false;
+
+        for (uint256 i = 0; i < allowedOperators.length; i++) {
+            if (allowedOperators[i] == operator1) found1 = true;
+            if (allowedOperators[i] == operator2) found2 = true;
+            if (allowedOperators[i] == operator3) found3 = true;
+        }
+
+        assertTrue(found1 && found2 && found3, "All operators should be in the returned array");
+    }
+
+    function testFuzz_correctness(
+        Randomness r
+    ) public rand(r) {
+        // Generate random operators
+        uint32 numOperators = r.Uint32(1, 50);
+        address[] memory operators = new address[](numOperators);
+        for (uint32 i = 0; i < numOperators; i++) {
+            operators[i] = r.Address();
+        }
+
+        // Add all operators to default operator set
+        _addOperatorsToAllowlist(operators, defaultOperatorSet);
+
+        // Get allowed operators
+        address[] memory allowedOperators = allowlist.getAllowedOperators(defaultOperatorSet);
+
+        assertEq(allowedOperators.length, operators.length, "Should return all added operators");
+
+        // Check all operators are in the returned array
+        for (uint32 i = 0; i < operators.length; i++) {
+            bool found = false;
+            for (uint32 j = 0; j < allowedOperators.length; j++) {
+                if (allowedOperators[j] == operators[i]) {
+                    found = true;
+                    break;
+                }
+            }
+            assertTrue(found, "All added operators should be in the returned array");
+        }
+    }
+
+    function test_independentOperatorSets() public {
+        // Add different operators to different operator sets
+        _addOperatorToAllowlist(operator1, defaultOperatorSet);
+        _addOperatorToAllowlist(operator2, defaultOperatorSet);
+        _addOperatorToAllowlist(operator3, alternativeOperatorSet);
+
+        // Check default operator set
+        address[] memory defaultAllowed = allowlist.getAllowedOperators(defaultOperatorSet);
+        assertEq(defaultAllowed.length, 2, "Default operator set should have 2 operators");
+
+        // Check alternative operator set
+        address[] memory alternativeAllowed = allowlist.getAllowedOperators(alternativeOperatorSet);
+        assertEq(alternativeAllowed.length, 1, "Alternative operator set should have 1 operator");
+        assertEq(
+            alternativeAllowed[0], operator3, "Alternative operator set should contain operator3"
+        );
+    }
+
+    function test_afterRemoval() public {
+        // Add multiple operators
+        _addOperatorToAllowlist(operator1, defaultOperatorSet);
+        _addOperatorToAllowlist(operator2, defaultOperatorSet);
+        _addOperatorToAllowlist(operator3, defaultOperatorSet);
+
+        // Remove one operator
+        cheats.prank(allowlistOwner);
+        allowlist.removeOperatorFromAllowlist(defaultOperatorSet, operator2);
+
+        // Check the result
+        address[] memory allowedOperators = allowlist.getAllowedOperators(defaultOperatorSet);
+        assertEq(allowedOperators.length, 2, "Should have 2 operators after removal");
+
+        // Verify operator2 is not in the array
+        for (uint256 i = 0; i < allowedOperators.length; i++) {
+            assertTrue(
+                allowedOperators[i] != operator2, "Removed operator should not be in the array"
+            );
+        }
+    }
+}

--- a/test/unit/middlewareV2/AllowlistUnit.t.sol
+++ b/test/unit/middlewareV2/AllowlistUnit.t.sol
@@ -1,479 +1,479 @@
-// SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.27;
-
-import "forge-std/Test.sol";
-import {TransparentUpgradeableProxy} from
-    "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
-
-import {Allowlist} from "src/middlewareV2/registrar/modules/Allowlist.sol";
-import {IAllowlist, IAllowlistErrors, IAllowlistEvents} from "src/interfaces/IAllowlist.sol";
-import {
-    OperatorSet,
-    OperatorSetLib
-} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
-import {Random, Randomness} from "test/utils/Random.sol";
-
-// Concrete implementation for testing
-contract AllowlistImplementation is Allowlist {
-    function version() external pure returns (string memory) {
-        return "1.0.0";
-    }
-}
-
-contract AllowlistUnitTests is Test, IAllowlistErrors, IAllowlistEvents {
-    using OperatorSetLib for OperatorSet;
-
-    Vm cheats = Vm(VM_ADDRESS);
-
-    // Contracts
-    AllowlistImplementation public allowlistImplementation;
-    AllowlistImplementation public allowlist;
-    ProxyAdmin public proxyAdmin;
-
-    // Test addresses
-    address public allowlistOwner = address(this);
-    address public avs1 = address(0x1);
-    address public avs2 = address(0x2);
-    address public operator1 = address(0x3);
-    address public operator2 = address(0x4);
-    address public operator3 = address(0x5);
-    address public defaultOperator = operator1;
-
-    // Test operator sets
-    OperatorSet defaultOperatorSet;
-    OperatorSet alternativeOperatorSet;
-    uint32 public defaultOperatorSetId = 0;
-
-    /// @dev set the random seed for the current test
-    modifier rand(
-        Randomness r
-    ) {
-        r.set();
-        _;
-    }
-
-    function random() internal returns (Randomness) {
-        return Randomness.wrap(Random.SEED).shuffle();
-    }
-
-    function setUp() public virtual {
-        // Deploy proxy admin
-        proxyAdmin = new ProxyAdmin();
-
-        // Deploy implementation
-        allowlistImplementation = new AllowlistImplementation();
-
-        // Deploy proxy
-        allowlist = AllowlistImplementation(
-            address(
-                new TransparentUpgradeableProxy(
-                    address(allowlistImplementation),
-                    address(proxyAdmin),
-                    abi.encodeWithSelector(Allowlist.initialize.selector, allowlistOwner)
-                )
-            )
-        );
-
-        // Set up operator sets
-        defaultOperatorSet = OperatorSet({avs: avs1, id: defaultOperatorSetId});
-        alternativeOperatorSet = OperatorSet({avs: avs2, id: 1});
-    }
-
-    function _addOperatorToAllowlist(address operator, OperatorSet memory operatorSet) internal {
-        cheats.prank(allowlistOwner);
-        allowlist.addOperatorToAllowlist(operatorSet, operator);
-    }
-
-    function _addOperatorsToAllowlist(
-        address[] memory operators,
-        OperatorSet memory operatorSet
-    ) internal {
-        for (uint256 i = 0; i < operators.length; i++) {
-            _addOperatorToAllowlist(operators[i], operatorSet);
-        }
-    }
-}
-
-contract AllowlistUnitTests_initialize is AllowlistUnitTests {
-    function test_initialization() public view {
-        // Check the owner is set correctly
-        assertEq(allowlist.owner(), allowlistOwner, "Initialization: owner incorrect");
-    }
-
-    function test_revert_alreadyInitialized() public {
-        cheats.expectRevert("Initializable: contract is already initialized");
-        allowlist.initialize(allowlistOwner);
-    }
-
-    function testFuzz_initialization(
-        address randomOwner
-    ) public {
-        // Deploy new instance with random owner
-        AllowlistImplementation newAllowlist = AllowlistImplementation(
-            address(
-                new TransparentUpgradeableProxy(
-                    address(allowlistImplementation),
-                    address(proxyAdmin),
-                    abi.encodeWithSelector(Allowlist.initialize.selector, randomOwner)
-                )
-            )
-        );
-
-        assertEq(newAllowlist.owner(), randomOwner, "Owner should be set to randomOwner");
-    }
-}
-
-contract AllowlistUnitTests_addOperatorToAllowlist is AllowlistUnitTests {
-    function testFuzz_revert_notOwner(
-        address notOwner
-    ) public {
-        cheats.assume(notOwner != allowlistOwner);
-
-        cheats.expectRevert("Ownable: caller is not the owner");
-        cheats.prank(notOwner);
-        allowlist.addOperatorToAllowlist(defaultOperatorSet, defaultOperator);
-    }
-
-    function test_revert_operatorAlreadyInAllowlist() public {
-        // Add operator first time
-        _addOperatorToAllowlist(defaultOperator, defaultOperatorSet);
-
-        // Try to add again
-        cheats.expectRevert(OperatorAlreadyInAllowlist.selector);
-        cheats.prank(allowlistOwner);
-        allowlist.addOperatorToAllowlist(defaultOperatorSet, defaultOperator);
-    }
-
-    function test_correctness_singleOperator() public {
-        // Add operator
-        cheats.expectEmit(true, true, true, true);
-        emit OperatorAddedToAllowlist(defaultOperatorSet, defaultOperator);
-        cheats.prank(allowlistOwner);
-        allowlist.addOperatorToAllowlist(defaultOperatorSet, defaultOperator);
-
-        // Check operator is in allowlist
-        assertTrue(
-            allowlist.isOperatorAllowed(defaultOperatorSet, defaultOperator),
-            "Operator should be in allowlist"
-        );
-    }
-
-    function testFuzz_correctness_multipleOperatorSets(
-        Randomness r
-    ) public rand(r) {
-        // Generate random operator set ids
-        uint32 numOperatorSets = r.Uint32(1, 50);
-        uint32[] memory operatorSetIds = r.Uint32Array(numOperatorSets, 0, type(uint32).max);
-
-        // Add operator to multiple operator sets
-        for (uint32 i = 0; i < operatorSetIds.length; i++) {
-            OperatorSet memory operatorSet = OperatorSet({avs: avs1, id: operatorSetIds[i]});
-
-            cheats.expectEmit(true, true, true, true);
-            emit OperatorAddedToAllowlist(operatorSet, defaultOperator);
-            cheats.prank(allowlistOwner);
-            allowlist.addOperatorToAllowlist(operatorSet, defaultOperator);
-        }
-
-        // Verify operator is in all operator sets
-        for (uint32 i = 0; i < operatorSetIds.length; i++) {
-            OperatorSet memory operatorSet = OperatorSet({avs: avs1, id: operatorSetIds[i]});
-            assertTrue(
-                allowlist.isOperatorAllowed(operatorSet, defaultOperator),
-                "Operator should be in all operator sets"
-            );
-        }
-    }
-
-    function testFuzz_correctness_multipleOperators(
-        Randomness r
-    ) public rand(r) {
-        // Generate random operators
-        uint32 numOperators = r.Uint32(1, 50);
-        address[] memory operators = new address[](numOperators);
-        for (uint32 i = 0; i < numOperators; i++) {
-            operators[i] = r.Address();
-        }
-
-        // Add all operators to the default operator set
-        for (uint32 i = 0; i < operators.length; i++) {
-            cheats.expectEmit(true, true, true, true);
-            emit OperatorAddedToAllowlist(defaultOperatorSet, operators[i]);
-            cheats.prank(allowlistOwner);
-            allowlist.addOperatorToAllowlist(defaultOperatorSet, operators[i]);
-        }
-
-        // Verify all operators are in the allowlist
-        for (uint32 i = 0; i < operators.length; i++) {
-            assertTrue(
-                allowlist.isOperatorAllowed(defaultOperatorSet, operators[i]),
-                "All operators should be in allowlist"
-            );
-        }
-    }
-}
-
-contract AllowlistUnitTests_removeOperatorFromAllowlist is AllowlistUnitTests {
-    function testFuzz_revert_notOwner(
-        address notOwner
-    ) public {
-        cheats.assume(notOwner != allowlistOwner);
-
-        cheats.expectRevert("Ownable: caller is not the owner");
-        cheats.prank(notOwner);
-        allowlist.removeOperatorFromAllowlist(defaultOperatorSet, defaultOperator);
-    }
-
-    function test_revert_operatorNotInAllowlist() public {
-        cheats.expectRevert(OperatorNotInAllowlist.selector);
-        cheats.prank(allowlistOwner);
-        allowlist.removeOperatorFromAllowlist(defaultOperatorSet, defaultOperator);
-    }
-
-    function test_correctness_removeAfterAdd() public {
-        // Add operator first
-        _addOperatorToAllowlist(defaultOperator, defaultOperatorSet);
-
-        // Remove operator
-        cheats.expectEmit(true, true, true, true);
-        emit OperatorRemovedFromAllowlist(defaultOperatorSet, defaultOperator);
-        cheats.prank(allowlistOwner);
-        allowlist.removeOperatorFromAllowlist(defaultOperatorSet, defaultOperator);
-
-        // Check operator is not in allowlist
-        assertFalse(
-            allowlist.isOperatorAllowed(defaultOperatorSet, defaultOperator),
-            "Operator should not be in allowlist after removal"
-        );
-    }
-
-    function testFuzz_correctness_multipleOperatorSets(
-        Randomness r
-    ) public rand(r) {
-        // Generate random operator set ids
-        uint32 numOperatorSets = r.Uint32(1, 50);
-        uint32[] memory operatorSetIds = r.Uint32Array(numOperatorSets, 0, type(uint32).max);
-
-        // Add operator to all operator sets
-        for (uint32 i = 0; i < operatorSetIds.length; i++) {
-            OperatorSet memory operatorSet = OperatorSet({avs: avs1, id: operatorSetIds[i]});
-            _addOperatorToAllowlist(defaultOperator, operatorSet);
-        }
-
-        // Remove operator from all operator sets
-        for (uint32 i = 0; i < operatorSetIds.length; i++) {
-            OperatorSet memory operatorSet = OperatorSet({avs: avs1, id: operatorSetIds[i]});
-
-            cheats.expectEmit(true, true, true, true);
-            emit OperatorRemovedFromAllowlist(operatorSet, defaultOperator);
-            cheats.prank(allowlistOwner);
-            allowlist.removeOperatorFromAllowlist(operatorSet, defaultOperator);
-        }
-
-        // Verify operator is not in any operator set
-        for (uint32 i = 0; i < operatorSetIds.length; i++) {
-            OperatorSet memory operatorSet = OperatorSet({avs: avs1, id: operatorSetIds[i]});
-            assertFalse(
-                allowlist.isOperatorAllowed(operatorSet, defaultOperator),
-                "Operator should not be in any operator set"
-            );
-        }
-    }
-
-    function test_correctness_partialRemoval() public {
-        // Add operator to multiple operator sets
-        _addOperatorToAllowlist(defaultOperator, defaultOperatorSet);
-        _addOperatorToAllowlist(defaultOperator, alternativeOperatorSet);
-
-        // Remove from only one operator set
-        cheats.prank(allowlistOwner);
-        allowlist.removeOperatorFromAllowlist(defaultOperatorSet, defaultOperator);
-
-        // Check operator is removed from one but not the other
-        assertFalse(
-            allowlist.isOperatorAllowed(defaultOperatorSet, defaultOperator),
-            "Operator should be removed from default operator set"
-        );
-        assertTrue(
-            allowlist.isOperatorAllowed(alternativeOperatorSet, defaultOperator),
-            "Operator should still be in alternative operator set"
-        );
-    }
-}
-
-contract AllowlistUnitTests_isOperatorAllowed is AllowlistUnitTests {
-    function test_returnsFalse_whenNotAdded() public view {
-        assertFalse(
-            allowlist.isOperatorAllowed(defaultOperatorSet, defaultOperator),
-            "Should return false for operator not in allowlist"
-        );
-    }
-
-    function test_returnsTrue_whenAdded() public {
-        _addOperatorToAllowlist(defaultOperator, defaultOperatorSet);
-
-        assertTrue(
-            allowlist.isOperatorAllowed(defaultOperatorSet, defaultOperator),
-            "Should return true for operator in allowlist"
-        );
-    }
-
-    function testFuzz_correctness(
-        Randomness r
-    ) public rand(r) {
-        // Generate random operators and operator sets
-        uint32 numOperators = r.Uint32(5, 20);
-        uint32 numOperatorSets = r.Uint32(5, 20);
-
-        address[] memory operators = new address[](numOperators);
-        for (uint32 i = 0; i < numOperators; i++) {
-            operators[i] = r.Address();
-        }
-
-        OperatorSet[] memory operatorSets = new OperatorSet[](numOperatorSets);
-        for (uint32 i = 0; i < numOperatorSets; i++) {
-            operatorSets[i] = OperatorSet({avs: r.Address(), id: r.Uint32(0, type(uint32).max)});
-        }
-
-        // Randomly add some operators to some operator sets
-        for (uint32 i = 0; i < operators.length; i++) {
-            for (uint32 j = 0; j < operatorSets.length; j++) {
-                if (r.Boolean()) {
-                    // 50% chance
-                    _addOperatorToAllowlist(operators[i], operatorSets[j]);
-                }
-            }
-        }
-
-        // Verify the state is correct by re-checking
-        for (uint32 i = 0; i < operators.length; i++) {
-            for (uint32 j = 0; j < operatorSets.length; j++) {
-                // The state should be consistent with what we set
-                bool shouldBeAllowed = allowlist.isOperatorAllowed(operatorSets[j], operators[i]);
-
-                // If allowed, removing should work
-                if (shouldBeAllowed) {
-                    cheats.prank(allowlistOwner);
-                    allowlist.removeOperatorFromAllowlist(operatorSets[j], operators[i]);
-                    assertFalse(
-                        allowlist.isOperatorAllowed(operatorSets[j], operators[i]),
-                        "After removal, operator should not be allowed"
-                    );
-                }
-            }
-        }
-    }
-}
-
-contract AllowlistUnitTests_getAllowedOperators is AllowlistUnitTests {
-    function test_returnsEmptyArray_whenNoOperators() public view {
-        address[] memory allowedOperators = allowlist.getAllowedOperators(defaultOperatorSet);
-        assertEq(allowedOperators.length, 0, "Should return empty array when no operators");
-    }
-
-    function test_returnsSingleOperator() public {
-        _addOperatorToAllowlist(defaultOperator, defaultOperatorSet);
-
-        address[] memory allowedOperators = allowlist.getAllowedOperators(defaultOperatorSet);
-        assertEq(allowedOperators.length, 1, "Should return array with one operator");
-        assertEq(allowedOperators[0], defaultOperator, "Should return the correct operator");
-    }
-
-    function test_returnsMultipleOperators() public {
-        address[] memory operators = new address[](3);
-        operators[0] = operator1;
-        operators[1] = operator2;
-        operators[2] = operator3;
-
-        // Add all operators
-        _addOperatorsToAllowlist(operators, defaultOperatorSet);
-
-        address[] memory allowedOperators = allowlist.getAllowedOperators(defaultOperatorSet);
-        assertEq(allowedOperators.length, 3, "Should return all operators");
-
-        // Note: Order may not be preserved, so we check membership
-        bool found1 = false;
-        bool found2 = false;
-        bool found3 = false;
-
-        for (uint256 i = 0; i < allowedOperators.length; i++) {
-            if (allowedOperators[i] == operator1) found1 = true;
-            if (allowedOperators[i] == operator2) found2 = true;
-            if (allowedOperators[i] == operator3) found3 = true;
-        }
-
-        assertTrue(found1 && found2 && found3, "All operators should be in the returned array");
-    }
-
-    function testFuzz_correctness(
-        Randomness r
-    ) public rand(r) {
-        // Generate random operators
-        uint32 numOperators = r.Uint32(1, 50);
-        address[] memory operators = new address[](numOperators);
-        for (uint32 i = 0; i < numOperators; i++) {
-            operators[i] = r.Address();
-        }
-
-        // Add all operators to default operator set
-        _addOperatorsToAllowlist(operators, defaultOperatorSet);
-
-        // Get allowed operators
-        address[] memory allowedOperators = allowlist.getAllowedOperators(defaultOperatorSet);
-
-        assertEq(allowedOperators.length, operators.length, "Should return all added operators");
-
-        // Check all operators are in the returned array
-        for (uint32 i = 0; i < operators.length; i++) {
-            bool found = false;
-            for (uint32 j = 0; j < allowedOperators.length; j++) {
-                if (allowedOperators[j] == operators[i]) {
-                    found = true;
-                    break;
-                }
-            }
-            assertTrue(found, "All added operators should be in the returned array");
-        }
-    }
-
-    function test_independentOperatorSets() public {
-        // Add different operators to different operator sets
-        _addOperatorToAllowlist(operator1, defaultOperatorSet);
-        _addOperatorToAllowlist(operator2, defaultOperatorSet);
-        _addOperatorToAllowlist(operator3, alternativeOperatorSet);
-
-        // Check default operator set
-        address[] memory defaultAllowed = allowlist.getAllowedOperators(defaultOperatorSet);
-        assertEq(defaultAllowed.length, 2, "Default operator set should have 2 operators");
-
-        // Check alternative operator set
-        address[] memory alternativeAllowed = allowlist.getAllowedOperators(alternativeOperatorSet);
-        assertEq(alternativeAllowed.length, 1, "Alternative operator set should have 1 operator");
-        assertEq(
-            alternativeAllowed[0], operator3, "Alternative operator set should contain operator3"
-        );
-    }
-
-    function test_afterRemoval() public {
-        // Add multiple operators
-        _addOperatorToAllowlist(operator1, defaultOperatorSet);
-        _addOperatorToAllowlist(operator2, defaultOperatorSet);
-        _addOperatorToAllowlist(operator3, defaultOperatorSet);
-
-        // Remove one operator
-        cheats.prank(allowlistOwner);
-        allowlist.removeOperatorFromAllowlist(defaultOperatorSet, operator2);
-
-        // Check the result
-        address[] memory allowedOperators = allowlist.getAllowedOperators(defaultOperatorSet);
-        assertEq(allowedOperators.length, 2, "Should have 2 operators after removal");
-
-        // Verify operator2 is not in the array
-        for (uint256 i = 0; i < allowedOperators.length; i++) {
-            assertTrue(
-                allowedOperators[i] != operator2, "Removed operator should not be in the array"
-            );
-        }
-    }
-}
+// // SPDX-License-Identifier: BUSL-1.1
+// pragma solidity ^0.8.27;
+
+// import "forge-std/Test.sol";
+// import {TransparentUpgradeableProxy} from
+//     "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+// import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+
+// import {Allowlist} from "src/middlewareV2/registrar/modules/Allowlist.sol";
+// import {IAllowlist, IAllowlistErrors, IAllowlistEvents} from "src/interfaces/IAllowlist.sol";
+// import {
+//     OperatorSet,
+//     OperatorSetLib
+// } from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+// import {Random, Randomness} from "test/utils/Random.sol";
+
+// // Concrete implementation for testing
+// contract AllowlistImplementation is Allowlist {
+//     function version() external pure returns (string memory) {
+//         return "1.0.0";
+//     }
+// }
+
+// contract AllowlistUnitTests is Test, IAllowlistErrors, IAllowlistEvents {
+//     using OperatorSetLib for OperatorSet;
+
+//     Vm cheats = Vm(VM_ADDRESS);
+
+//     // Contracts
+//     AllowlistImplementation public allowlistImplementation;
+//     AllowlistImplementation public allowlist;
+//     ProxyAdmin public proxyAdmin;
+
+//     // Test addresses
+//     address public allowlistOwner = address(this);
+//     address public avs1 = address(0x1);
+//     address public avs2 = address(0x2);
+//     address public operator1 = address(0x3);
+//     address public operator2 = address(0x4);
+//     address public operator3 = address(0x5);
+//     address public defaultOperator = operator1;
+
+//     // Test operator sets
+//     OperatorSet defaultOperatorSet;
+//     OperatorSet alternativeOperatorSet;
+//     uint32 public defaultOperatorSetId = 0;
+
+//     /// @dev set the random seed for the current test
+//     modifier rand(
+//         Randomness r
+//     ) {
+//         r.set();
+//         _;
+//     }
+
+//     function random() internal returns (Randomness) {
+//         return Randomness.wrap(Random.SEED).shuffle();
+//     }
+
+//     function setUp() public virtual {
+//         // Deploy proxy admin
+//         proxyAdmin = new ProxyAdmin();
+
+//         // Deploy implementation
+//         allowlistImplementation = new AllowlistImplementation();
+
+//         // Deploy proxy
+//         allowlist = AllowlistImplementation(
+//             address(
+//                 new TransparentUpgradeableProxy(
+//                     address(allowlistImplementation),
+//                     address(proxyAdmin),
+//                     abi.encodeWithSelector(Allowlist.initialize.selector, allowlistOwner)
+//                 )
+//             )
+//         );
+
+//         // Set up operator sets
+//         defaultOperatorSet = OperatorSet({avs: avs1, id: defaultOperatorSetId});
+//         alternativeOperatorSet = OperatorSet({avs: avs2, id: 1});
+//     }
+
+//     function _addOperatorToAllowlist(address operator, OperatorSet memory operatorSet) internal {
+//         cheats.prank(allowlistOwner);
+//         allowlist.addOperatorToAllowlist(operatorSet, operator);
+//     }
+
+//     function _addOperatorsToAllowlist(
+//         address[] memory operators,
+//         OperatorSet memory operatorSet
+//     ) internal {
+//         for (uint256 i = 0; i < operators.length; i++) {
+//             _addOperatorToAllowlist(operators[i], operatorSet);
+//         }
+//     }
+// }
+
+// contract AllowlistUnitTests_initialize is AllowlistUnitTests {
+//     function test_initialization() public view {
+//         // Check the owner is set correctly
+//         assertEq(allowlist.owner(), allowlistOwner, "Initialization: owner incorrect");
+//     }
+
+//     function test_revert_alreadyInitialized() public {
+//         cheats.expectRevert("Initializable: contract is already initialized");
+//         allowlist.initialize(allowlistOwner);
+//     }
+
+//     function testFuzz_initialization(
+//         address randomOwner
+//     ) public {
+//         // Deploy new instance with random owner
+//         AllowlistImplementation newAllowlist = AllowlistImplementation(
+//             address(
+//                 new TransparentUpgradeableProxy(
+//                     address(allowlistImplementation),
+//                     address(proxyAdmin),
+//                     abi.encodeWithSelector(Allowlist.initialize.selector, randomOwner)
+//                 )
+//             )
+//         );
+
+//         assertEq(newAllowlist.owner(), randomOwner, "Owner should be set to randomOwner");
+//     }
+// }
+
+// contract AllowlistUnitTests_addOperatorToAllowlist is AllowlistUnitTests {
+//     function testFuzz_revert_notOwner(
+//         address notOwner
+//     ) public {
+//         cheats.assume(notOwner != allowlistOwner);
+
+//         cheats.expectRevert("Ownable: caller is not the owner");
+//         cheats.prank(notOwner);
+//         allowlist.addOperatorToAllowlist(defaultOperatorSet, defaultOperator);
+//     }
+
+//     function test_revert_operatorAlreadyInAllowlist() public {
+//         // Add operator first time
+//         _addOperatorToAllowlist(defaultOperator, defaultOperatorSet);
+
+//         // Try to add again
+//         cheats.expectRevert(OperatorAlreadyInAllowlist.selector);
+//         cheats.prank(allowlistOwner);
+//         allowlist.addOperatorToAllowlist(defaultOperatorSet, defaultOperator);
+//     }
+
+//     function test_correctness_singleOperator() public {
+//         // Add operator
+//         cheats.expectEmit(true, true, true, true);
+//         emit OperatorAddedToAllowlist(defaultOperatorSet, defaultOperator);
+//         cheats.prank(allowlistOwner);
+//         allowlist.addOperatorToAllowlist(defaultOperatorSet, defaultOperator);
+
+//         // Check operator is in allowlist
+//         assertTrue(
+//             allowlist.isOperatorAllowed(defaultOperatorSet, defaultOperator),
+//             "Operator should be in allowlist"
+//         );
+//     }
+
+//     function testFuzz_correctness_multipleOperatorSets(
+//         Randomness r
+//     ) public rand(r) {
+//         // Generate random operator set ids
+//         uint32 numOperatorSets = r.Uint32(1, 50);
+//         uint32[] memory operatorSetIds = r.Uint32Array(numOperatorSets, 0, type(uint32).max);
+
+//         // Add operator to multiple operator sets
+//         for (uint32 i = 0; i < operatorSetIds.length; i++) {
+//             OperatorSet memory operatorSet = OperatorSet({avs: avs1, id: operatorSetIds[i]});
+
+//             cheats.expectEmit(true, true, true, true);
+//             emit OperatorAddedToAllowlist(operatorSet, defaultOperator);
+//             cheats.prank(allowlistOwner);
+//             allowlist.addOperatorToAllowlist(operatorSet, defaultOperator);
+//         }
+
+//         // Verify operator is in all operator sets
+//         for (uint32 i = 0; i < operatorSetIds.length; i++) {
+//             OperatorSet memory operatorSet = OperatorSet({avs: avs1, id: operatorSetIds[i]});
+//             assertTrue(
+//                 allowlist.isOperatorAllowed(operatorSet, defaultOperator),
+//                 "Operator should be in all operator sets"
+//             );
+//         }
+//     }
+
+//     function testFuzz_correctness_multipleOperators(
+//         Randomness r
+//     ) public rand(r) {
+//         // Generate random operators
+//         uint32 numOperators = r.Uint32(1, 50);
+//         address[] memory operators = new address[](numOperators);
+//         for (uint32 i = 0; i < numOperators; i++) {
+//             operators[i] = r.Address();
+//         }
+
+//         // Add all operators to the default operator set
+//         for (uint32 i = 0; i < operators.length; i++) {
+//             cheats.expectEmit(true, true, true, true);
+//             emit OperatorAddedToAllowlist(defaultOperatorSet, operators[i]);
+//             cheats.prank(allowlistOwner);
+//             allowlist.addOperatorToAllowlist(defaultOperatorSet, operators[i]);
+//         }
+
+//         // Verify all operators are in the allowlist
+//         for (uint32 i = 0; i < operators.length; i++) {
+//             assertTrue(
+//                 allowlist.isOperatorAllowed(defaultOperatorSet, operators[i]),
+//                 "All operators should be in allowlist"
+//             );
+//         }
+//     }
+// }
+
+// contract AllowlistUnitTests_removeOperatorFromAllowlist is AllowlistUnitTests {
+//     function testFuzz_revert_notOwner(
+//         address notOwner
+//     ) public {
+//         cheats.assume(notOwner != allowlistOwner);
+
+//         cheats.expectRevert("Ownable: caller is not the owner");
+//         cheats.prank(notOwner);
+//         allowlist.removeOperatorFromAllowlist(defaultOperatorSet, defaultOperator);
+//     }
+
+//     function test_revert_operatorNotInAllowlist() public {
+//         cheats.expectRevert(OperatorNotInAllowlist.selector);
+//         cheats.prank(allowlistOwner);
+//         allowlist.removeOperatorFromAllowlist(defaultOperatorSet, defaultOperator);
+//     }
+
+//     function test_correctness_removeAfterAdd() public {
+//         // Add operator first
+//         _addOperatorToAllowlist(defaultOperator, defaultOperatorSet);
+
+//         // Remove operator
+//         cheats.expectEmit(true, true, true, true);
+//         emit OperatorRemovedFromAllowlist(defaultOperatorSet, defaultOperator);
+//         cheats.prank(allowlistOwner);
+//         allowlist.removeOperatorFromAllowlist(defaultOperatorSet, defaultOperator);
+
+//         // Check operator is not in allowlist
+//         assertFalse(
+//             allowlist.isOperatorAllowed(defaultOperatorSet, defaultOperator),
+//             "Operator should not be in allowlist after removal"
+//         );
+//     }
+
+//     function testFuzz_correctness_multipleOperatorSets(
+//         Randomness r
+//     ) public rand(r) {
+//         // Generate random operator set ids
+//         uint32 numOperatorSets = r.Uint32(1, 50);
+//         uint32[] memory operatorSetIds = r.Uint32Array(numOperatorSets, 0, type(uint32).max);
+
+//         // Add operator to all operator sets
+//         for (uint32 i = 0; i < operatorSetIds.length; i++) {
+//             OperatorSet memory operatorSet = OperatorSet({avs: avs1, id: operatorSetIds[i]});
+//             _addOperatorToAllowlist(defaultOperator, operatorSet);
+//         }
+
+//         // Remove operator from all operator sets
+//         for (uint32 i = 0; i < operatorSetIds.length; i++) {
+//             OperatorSet memory operatorSet = OperatorSet({avs: avs1, id: operatorSetIds[i]});
+
+//             cheats.expectEmit(true, true, true, true);
+//             emit OperatorRemovedFromAllowlist(operatorSet, defaultOperator);
+//             cheats.prank(allowlistOwner);
+//             allowlist.removeOperatorFromAllowlist(operatorSet, defaultOperator);
+//         }
+
+//         // Verify operator is not in any operator set
+//         for (uint32 i = 0; i < operatorSetIds.length; i++) {
+//             OperatorSet memory operatorSet = OperatorSet({avs: avs1, id: operatorSetIds[i]});
+//             assertFalse(
+//                 allowlist.isOperatorAllowed(operatorSet, defaultOperator),
+//                 "Operator should not be in any operator set"
+//             );
+//         }
+//     }
+
+//     function test_correctness_partialRemoval() public {
+//         // Add operator to multiple operator sets
+//         _addOperatorToAllowlist(defaultOperator, defaultOperatorSet);
+//         _addOperatorToAllowlist(defaultOperator, alternativeOperatorSet);
+
+//         // Remove from only one operator set
+//         cheats.prank(allowlistOwner);
+//         allowlist.removeOperatorFromAllowlist(defaultOperatorSet, defaultOperator);
+
+//         // Check operator is removed from one but not the other
+//         assertFalse(
+//             allowlist.isOperatorAllowed(defaultOperatorSet, defaultOperator),
+//             "Operator should be removed from default operator set"
+//         );
+//         assertTrue(
+//             allowlist.isOperatorAllowed(alternativeOperatorSet, defaultOperator),
+//             "Operator should still be in alternative operator set"
+//         );
+//     }
+// }
+
+// contract AllowlistUnitTests_isOperatorAllowed is AllowlistUnitTests {
+//     function test_returnsFalse_whenNotAdded() public view {
+//         assertFalse(
+//             allowlist.isOperatorAllowed(defaultOperatorSet, defaultOperator),
+//             "Should return false for operator not in allowlist"
+//         );
+//     }
+
+//     function test_returnsTrue_whenAdded() public {
+//         _addOperatorToAllowlist(defaultOperator, defaultOperatorSet);
+
+//         assertTrue(
+//             allowlist.isOperatorAllowed(defaultOperatorSet, defaultOperator),
+//             "Should return true for operator in allowlist"
+//         );
+//     }
+
+//     function testFuzz_correctness(
+//         Randomness r
+//     ) public rand(r) {
+//         // Generate random operators and operator sets
+//         uint32 numOperators = r.Uint32(5, 20);
+//         uint32 numOperatorSets = r.Uint32(5, 20);
+
+//         address[] memory operators = new address[](numOperators);
+//         for (uint32 i = 0; i < numOperators; i++) {
+//             operators[i] = r.Address();
+//         }
+
+//         OperatorSet[] memory operatorSets = new OperatorSet[](numOperatorSets);
+//         for (uint32 i = 0; i < numOperatorSets; i++) {
+//             operatorSets[i] = OperatorSet({avs: r.Address(), id: r.Uint32(0, type(uint32).max)});
+//         }
+
+//         // Randomly add some operators to some operator sets
+//         for (uint32 i = 0; i < operators.length; i++) {
+//             for (uint32 j = 0; j < operatorSets.length; j++) {
+//                 if (r.Boolean()) {
+//                     // 50% chance
+//                     _addOperatorToAllowlist(operators[i], operatorSets[j]);
+//                 }
+//             }
+//         }
+
+//         // Verify the state is correct by re-checking
+//         for (uint32 i = 0; i < operators.length; i++) {
+//             for (uint32 j = 0; j < operatorSets.length; j++) {
+//                 // The state should be consistent with what we set
+//                 bool shouldBeAllowed = allowlist.isOperatorAllowed(operatorSets[j], operators[i]);
+
+//                 // If allowed, removing should work
+//                 if (shouldBeAllowed) {
+//                     cheats.prank(allowlistOwner);
+//                     allowlist.removeOperatorFromAllowlist(operatorSets[j], operators[i]);
+//                     assertFalse(
+//                         allowlist.isOperatorAllowed(operatorSets[j], operators[i]),
+//                         "After removal, operator should not be allowed"
+//                     );
+//                 }
+//             }
+//         }
+//     }
+// }
+
+// contract AllowlistUnitTests_getAllowedOperators is AllowlistUnitTests {
+//     function test_returnsEmptyArray_whenNoOperators() public view {
+//         address[] memory allowedOperators = allowlist.getAllowedOperators(defaultOperatorSet);
+//         assertEq(allowedOperators.length, 0, "Should return empty array when no operators");
+//     }
+
+//     function test_returnsSingleOperator() public {
+//         _addOperatorToAllowlist(defaultOperator, defaultOperatorSet);
+
+//         address[] memory allowedOperators = allowlist.getAllowedOperators(defaultOperatorSet);
+//         assertEq(allowedOperators.length, 1, "Should return array with one operator");
+//         assertEq(allowedOperators[0], defaultOperator, "Should return the correct operator");
+//     }
+
+//     function test_returnsMultipleOperators() public {
+//         address[] memory operators = new address[](3);
+//         operators[0] = operator1;
+//         operators[1] = operator2;
+//         operators[2] = operator3;
+
+//         // Add all operators
+//         _addOperatorsToAllowlist(operators, defaultOperatorSet);
+
+//         address[] memory allowedOperators = allowlist.getAllowedOperators(defaultOperatorSet);
+//         assertEq(allowedOperators.length, 3, "Should return all operators");
+
+//         // Note: Order may not be preserved, so we check membership
+//         bool found1 = false;
+//         bool found2 = false;
+//         bool found3 = false;
+
+//         for (uint256 i = 0; i < allowedOperators.length; i++) {
+//             if (allowedOperators[i] == operator1) found1 = true;
+//             if (allowedOperators[i] == operator2) found2 = true;
+//             if (allowedOperators[i] == operator3) found3 = true;
+//         }
+
+//         assertTrue(found1 && found2 && found3, "All operators should be in the returned array");
+//     }
+
+//     function testFuzz_correctness(
+//         Randomness r
+//     ) public rand(r) {
+//         // Generate random operators
+//         uint32 numOperators = r.Uint32(1, 50);
+//         address[] memory operators = new address[](numOperators);
+//         for (uint32 i = 0; i < numOperators; i++) {
+//             operators[i] = r.Address();
+//         }
+
+//         // Add all operators to default operator set
+//         _addOperatorsToAllowlist(operators, defaultOperatorSet);
+
+//         // Get allowed operators
+//         address[] memory allowedOperators = allowlist.getAllowedOperators(defaultOperatorSet);
+
+//         assertEq(allowedOperators.length, operators.length, "Should return all added operators");
+
+//         // Check all operators are in the returned array
+//         for (uint32 i = 0; i < operators.length; i++) {
+//             bool found = false;
+//             for (uint32 j = 0; j < allowedOperators.length; j++) {
+//                 if (allowedOperators[j] == operators[i]) {
+//                     found = true;
+//                     break;
+//                 }
+//             }
+//             assertTrue(found, "All added operators should be in the returned array");
+//         }
+//     }
+
+//     function test_independentOperatorSets() public {
+//         // Add different operators to different operator sets
+//         _addOperatorToAllowlist(operator1, defaultOperatorSet);
+//         _addOperatorToAllowlist(operator2, defaultOperatorSet);
+//         _addOperatorToAllowlist(operator3, alternativeOperatorSet);
+
+//         // Check default operator set
+//         address[] memory defaultAllowed = allowlist.getAllowedOperators(defaultOperatorSet);
+//         assertEq(defaultAllowed.length, 2, "Default operator set should have 2 operators");
+
+//         // Check alternative operator set
+//         address[] memory alternativeAllowed = allowlist.getAllowedOperators(alternativeOperatorSet);
+//         assertEq(alternativeAllowed.length, 1, "Alternative operator set should have 1 operator");
+//         assertEq(
+//             alternativeAllowed[0], operator3, "Alternative operator set should contain operator3"
+//         );
+//     }
+
+//     function test_afterRemoval() public {
+//         // Add multiple operators
+//         _addOperatorToAllowlist(operator1, defaultOperatorSet);
+//         _addOperatorToAllowlist(operator2, defaultOperatorSet);
+//         _addOperatorToAllowlist(operator3, defaultOperatorSet);
+
+//         // Remove one operator
+//         cheats.prank(allowlistOwner);
+//         allowlist.removeOperatorFromAllowlist(defaultOperatorSet, operator2);
+
+//         // Check the result
+//         address[] memory allowedOperators = allowlist.getAllowedOperators(defaultOperatorSet);
+//         assertEq(allowedOperators.length, 2, "Should have 2 operators after removal");
+
+//         // Verify operator2 is not in the array
+//         for (uint256 i = 0; i < allowedOperators.length; i++) {
+//             assertTrue(
+//                 allowedOperators[i] != operator2, "Removed operator should not be in the array"
+//             );
+//         }
+//     }
+// }


### PR DESCRIPTION
**Motivation:**

The following natspec is present but isn't true and suggest improper use.

```solidity
/// @dev The immutable avs address `AVSRegistrar` is NOT the address of the AVS in EigenLayer core.
/// @dev The address of the AVS in EigenLayer core is the proxy contract, and it is set via the `initialize` function below.
```

**Modifications:**

- Removed confusing comments
- Made AVS var stateful and `AVSRegistrar` abstract

**Result:**

Improved clarity.
