### PR TITLE
fix: make storage variable internal due to existing getter

### DIFF
--- a/src/avs/task/TaskAVSRegistrarBaseStorage.sol
+++ b/src/avs/task/TaskAVSRegistrarBaseStorage.sol
@@ -11,7 +11,7 @@ import {ITaskAVSRegistrarBase} from "../../interfaces/ITaskAVSRegistrarBase.sol"
  */
 abstract contract TaskAVSRegistrarBaseStorage is ITaskAVSRegistrarBase {
     /// @notice Configuration for this AVS
-    AvsConfig public avsConfig;
+    AvsConfig internal avsConfig;
 
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new


### PR DESCRIPTION
**Motivation:**

`avsConfig` is marked `public`, but the getter `getAVSConfig` also retrieves the storage variable. Making the storage variable public automatically produces a getter. As such, currently two getters exist for the same storage variable.

**Modifications:**

* Changed the storage variable from `public` to `internal`

**Result:**

* Cheaper deployments
* More legible getters
