### PR TITLE
fix(I-07): add onlyInitializing modifier to initializing function

### DIFF
--- a/src/middlewareV2/registrar/AVSRegistrar.sol
+++ b/src/middlewareV2/registrar/AVSRegistrar.sol
@@ -34,7 +34,7 @@ abstract contract AVSRegistrar is Initializable, AVSRegistrarStorage {
     /// @dev This initialization function MUST be added to a child's `initialize` function to avoid uninitialized storage.
     function __AVSRegistrar_init(
         address _avs
-    ) internal virtual {
+    ) internal virtual onlyInitializing {
         avs = _avs;
     }
 


### PR DESCRIPTION
**Motivation:**

The `__AVSRegistrar_init` function lacks an `onlyInitializing` modifier, which ensures that the function can only be called during contract setup.

**Modifications:**

* Add the `onlyInitializing` modifier to the `AVSRegistrar` contract

**Result:**

Guarantee that this initializing function cannot be called out of the initialization process
