### PR TITLE
fix(m-01): add salt to merkle leaf hashing

### DIFF
--- a/src/middlewareV2/tableCalculator/BN254TableCalculatorBase.sol
+++ b/src/middlewareV2/tableCalculator/BN254TableCalculatorBase.sol
@@ -7,6 +7,8 @@ import {IOperatorTableCalculator} from
 import {IKeyRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
 import {Merkle} from "eigenlayer-contracts/src/contracts/libraries/Merkle.sol";
 import {BN254} from "eigenlayer-contracts/src/contracts/libraries/BN254.sol";
+import {LeafCalculatorMixin} from
+    "eigenlayer-contracts/src/contracts/mixins/LeafCalculatorMixin.sol";
 import {IBN254TableCalculator} from "../../interfaces/IBN254TableCalculator.sol";
 
 /**
@@ -15,7 +17,7 @@ import {IBN254TableCalculator} from "../../interfaces/IBN254TableCalculator.sol"
  * @dev This contract contains all the core logic for operator table calculations,
  *      with weight calculation left to be implemented by derived contracts
  */
-abstract contract BN254TableCalculatorBase is IBN254TableCalculator {
+abstract contract BN254TableCalculatorBase is IBN254TableCalculator, LeafCalculatorMixin {
     using Merkle for bytes32[];
     using BN254 for BN254.G1Point;
 
@@ -160,8 +162,10 @@ abstract contract BN254TableCalculatorBase is IBN254TableCalculator {
                 totalWeights[j] += weights[i][j];
             }
             (BN254.G1Point memory g1Point,) = keyRegistrar.getBN254Key(operatorSet, operators[i]);
+
+            // Use `LeafCalculatorMixin` to calculate the leaf hash for the operator info
             operatorInfoLeaves[operatorCount] =
-                keccak256(abi.encode(BN254OperatorInfo({pubkey: g1Point, weights: weights[i]})));
+                calculateOperatorInfoLeaf(BN254OperatorInfo({pubkey: g1Point, weights: weights[i]}));
 
             // Add the operator's G1 point to the aggregate pubkey
             aggregatePubkey = aggregatePubkey.plus(g1Point);

--- a/test/unit/middlewareV2/BN254TableCalculatorBaseUnit.t.sol
+++ b/test/unit/middlewareV2/BN254TableCalculatorBaseUnit.t.sol
@@ -22,6 +22,7 @@ import {BN254TableCalculatorBase} from
 import {MockEigenLayerDeployer} from "./MockDeployer.sol";
 import {Random} from "test/utils/Random.sol";
 import {Merkle} from "eigenlayer-contracts/src/contracts/libraries/Merkle.sol";
+import {LeafCalculatorMixin} from "eigenlayer-contracts/src/contracts/mixins/LeafCalculatorMixin.sol";
 
 // Mock implementation for testing abstract contract
 contract BN254TableCalculatorBaseHarness is BN254TableCalculatorBase {
@@ -61,7 +62,8 @@ contract BN254TableCalculatorBaseHarness is BN254TableCalculatorBase {
 contract BN254TableCalculatorBaseUnitTests is
     MockEigenLayerDeployer,
     IOperatorTableCalculatorTypes,
-    IKeyRegistrarTypes
+    IKeyRegistrarTypes,
+    LeafCalculatorMixin
 {
     using BN254 for BN254.G1Point;
     using OperatorSetLib for OperatorSet;
@@ -216,10 +218,8 @@ contract BN254TableCalculatorBaseUnitTests is
         BN254.G1Point memory pubkey,
         uint256[] memory weights
     ) internal pure returns (bytes32) {
-        return keccak256(
-            abi.encode(
-                IOperatorTableCalculatorTypes.BN254OperatorInfo({pubkey: pubkey, weights: weights})
-            )
+        return calculateOperatorInfoLeaf(
+            IOperatorTableCalculatorTypes.BN254OperatorInfo({pubkey: pubkey, weights: weights})
         );
     }
 }

--- a/test/unit/middlewareV2/BN254TableCalculatorBaseUnit.t.sol
+++ b/test/unit/middlewareV2/BN254TableCalculatorBaseUnit.t.sol
@@ -22,7 +22,8 @@ import {BN254TableCalculatorBase} from
 import {MockEigenLayerDeployer} from "./MockDeployer.sol";
 import {Random} from "test/utils/Random.sol";
 import {Merkle} from "eigenlayer-contracts/src/contracts/libraries/Merkle.sol";
-import {LeafCalculatorMixin} from "eigenlayer-contracts/src/contracts/mixins/LeafCalculatorMixin.sol";
+import {LeafCalculatorMixin} from
+    "eigenlayer-contracts/src/contracts/mixins/LeafCalculatorMixin.sol";
 
 // Mock implementation for testing abstract contract
 contract BN254TableCalculatorBaseHarness is BN254TableCalculatorBase {


### PR DESCRIPTION
**Motivation:**

As part of an audit finding, to protect against [second preimage attacks](https://flawed.net.nz/2018/02/21/attacking-merkle-trees-with-a-second-preimage-attack/), we add a salt to the leaf similar to the RewardsCoordinator to significantly reduce the likelihood of an internal node being used to produce an unintentional proof. https://github.com/Layr-Labs/eigenlayer-contracts/pull/1580 in core already did this on the cert verifier side. We now need to do this for table calc

**Modifications:**

- Inherit `LeafCalculatorMixin` in `BN254TableCalculatorBase`
- Use `calculateOperatorInfoLeaf`

**Result:**

Secure code
