### PR TITLE
fix: add allowlist to TaskAVSRegistarBase

### DIFF
--- a/src/avs/task/TaskAVSRegistrarBase.sol
+++ b/src/avs/task/TaskAVSRegistrarBase.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {OwnableUpgradeable} from "@openzeppelin-upgrades/contracts/access/OwnableUpgradeable.sol";
 import {Initializable} from "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";
 import {IAllocationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
@@ -22,7 +21,6 @@ import {OperatorSet} from "eigenlayer-contracts/src/contracts/libraries/Operator
  */
 abstract contract TaskAVSRegistrarBase is
     Initializable,
-    OwnableUpgradeable,
     AVSRegistrarWithSocket,
     Allowlist,
     TaskAVSRegistrarBaseStorage
@@ -53,8 +51,6 @@ abstract contract TaskAVSRegistrarBase is
         AvsConfig memory _initialConfig
     ) internal onlyInitializing {
         __AVSRegistrar_init(_avs);
-        __Ownable_init();
-        _transferOwnership(_owner);
         _setAvsConfig(_initialConfig);
         __Allowlist_init(_owner);
     }

--- a/src/avs/task/TaskAVSRegistrarBase.sol
+++ b/src/avs/task/TaskAVSRegistrarBase.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {Initializable} from "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";
 import {IAllocationManager} from
     "eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 import {IPermissionController} from
     "eigenlayer-contracts/src/contracts/interfaces/IPermissionController.sol";
 import {IKeyRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
-import {AVSRegistrarWithSocket} from
-    "../../middlewareV2/registrar/presets/AVSRegistrarWithSocket.sol";
+import {OperatorSet} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+
+import {AVSRegistrar} from "../../middlewareV2/registrar/AVSRegistrar.sol";
+import {SocketRegistry} from "../../middlewareV2/registrar/modules/SocketRegistry.sol";
+import {Allowlist} from "../../middlewareV2/registrar/modules/Allowlist.sol";
 import {ITaskAVSRegistrarBase} from "../../interfaces/ITaskAVSRegistrarBase.sol";
 import {TaskAVSRegistrarBaseStorage} from "./TaskAVSRegistrarBaseStorage.sol";
-import {Allowlist} from "../../middlewareV2/registrar/modules/Allowlist.sol";
-import {OperatorSet} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
 
 /**
  * @title TaskAVSRegistrarBase
@@ -20,8 +20,8 @@ import {OperatorSet} from "eigenlayer-contracts/src/contracts/libraries/Operator
  * @notice Abstract AVS Registrar for task-based AVSs
  */
 abstract contract TaskAVSRegistrarBase is
-    Initializable,
-    AVSRegistrarWithSocket,
+    AVSRegistrar,
+    SocketRegistry,
     Allowlist,
     TaskAVSRegistrarBaseStorage
 {
@@ -35,7 +35,7 @@ abstract contract TaskAVSRegistrarBase is
         IAllocationManager _allocationManager,
         IKeyRegistrar _keyRegistrar,
         IPermissionController _permissionController
-    ) AVSRegistrarWithSocket(_allocationManager, _keyRegistrar, _permissionController) {
+    ) AVSRegistrar(_allocationManager, _keyRegistrar) SocketRegistry(_permissionController) {
         _disableInitializers();
     }
 
@@ -50,9 +50,10 @@ abstract contract TaskAVSRegistrarBase is
         address _owner,
         AvsConfig memory _initialConfig
     ) internal onlyInitializing {
+        __Allowlist_init(_owner); // initializes Ownable
         __AVSRegistrar_init(_avs);
+
         _setAvsConfig(_initialConfig);
-        __Allowlist_init(_owner);
     }
 
     /// @inheritdoc ITaskAVSRegistrarBase
@@ -116,5 +117,25 @@ abstract contract TaskAVSRegistrarBase is
                 );
             }
         }
+    }
+
+    /**
+     * @notice Set the socket for the operator
+     * @dev This function sets the socket even if the operator is already registered
+     * @dev Operators should make sure to always provide the socket when registering
+     * @param operator The address of the operator
+     * @param operatorSetIds The IDs of the operator sets
+     * @param data The data passed to the operator
+     */
+    function _afterRegisterOperator(
+        address operator,
+        uint32[] calldata operatorSetIds,
+        bytes calldata data
+    ) internal override {
+        super._afterRegisterOperator(operator, operatorSetIds, data);
+
+        // Set operator socket
+        string memory socket = abi.decode(data, (string));
+        _setOperatorSocket(operator, socket);
     }
 }

--- a/src/avs/task/TaskAVSRegistrarBase.sol
+++ b/src/avs/task/TaskAVSRegistrarBase.sol
@@ -12,6 +12,8 @@ import {AVSRegistrarWithSocket} from
     "../../middlewareV2/registrar/presets/AVSRegistrarWithSocket.sol";
 import {ITaskAVSRegistrarBase} from "../../interfaces/ITaskAVSRegistrarBase.sol";
 import {TaskAVSRegistrarBaseStorage} from "./TaskAVSRegistrarBaseStorage.sol";
+import {Allowlist} from "../../middlewareV2/registrar/modules/Allowlist.sol";
+import {OperatorSet} from "eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
 
 /**
  * @title TaskAVSRegistrarBase
@@ -22,6 +24,7 @@ abstract contract TaskAVSRegistrarBase is
     Initializable,
     OwnableUpgradeable,
     AVSRegistrarWithSocket,
+    Allowlist,
     TaskAVSRegistrarBaseStorage
 {
     /**
@@ -53,6 +56,7 @@ abstract contract TaskAVSRegistrarBase is
         __Ownable_init();
         _transferOwnership(_owner);
         _setAvsConfig(_initialConfig);
+        __Allowlist_init(_owner);
     }
 
     /// @inheritdoc ITaskAVSRegistrarBase
@@ -92,5 +96,23 @@ abstract contract TaskAVSRegistrarBase is
 
         avsConfig = config;
         emit AvsConfigSet(config.aggregatorOperatorSetId, config.executorOperatorSetIds);
+    }
+
+    /// @notice Before registering operator, check if the operator is in the allowlist
+    /// @dev Reverts for:
+    ///      - OperatorNotInAllowlist: The operator is not in the allowlist
+    function _beforeRegisterOperator(
+        address operator,
+        uint32[] calldata operatorSetIds,
+        bytes calldata data
+    ) internal override {
+        super._beforeRegisterOperator(operator, operatorSetIds, data);
+
+        for (uint32 i; i < operatorSetIds.length; ++i) {
+            require(
+                isOperatorAllowed(OperatorSet({avs: avs, id: operatorSetIds[i]}), operator),
+                OperatorNotInAllowlist()
+            );
+        }
     }
 }

--- a/src/avs/task/TaskAVSRegistrarBase.sol
+++ b/src/avs/task/TaskAVSRegistrarBase.sol
@@ -24,8 +24,8 @@ abstract contract TaskAVSRegistrarBase is
     Initializable,
     OwnableUpgradeable,
     AVSRegistrarWithSocket,
-    Allowlist,
-    TaskAVSRegistrarBaseStorage
+    TaskAVSRegistrarBaseStorage,
+    Allowlist
 {
     /**
      * @dev Constructor that passes parameters to parent
@@ -98,9 +98,13 @@ abstract contract TaskAVSRegistrarBase is
         emit AvsConfigSet(config.aggregatorOperatorSetId, config.executorOperatorSetIds);
     }
 
-    /// @notice Before registering operator, check if the operator is in the allowlist
-    /// @dev Reverts for:
-    ///      - OperatorNotInAllowlist: The operator is not in the allowlist
+    /**
+     * @notice Before registering operator, check if the operator is in the allowlist for the aggregator operator set
+     * @dev Only the aggregator operator set requires allowlist validation. Executor operator sets do not require allowlist checks.
+     * @param operator The address of the operator
+     * @param operatorSetIds The IDs of the operator sets
+     * @param data The data passed to the operator
+     */
     function _beforeRegisterOperator(
         address operator,
         uint32[] calldata operatorSetIds,
@@ -108,11 +112,13 @@ abstract contract TaskAVSRegistrarBase is
     ) internal override {
         super._beforeRegisterOperator(operator, operatorSetIds, data);
 
-        for (uint32 i; i < operatorSetIds.length; ++i) {
-            require(
-                isOperatorAllowed(OperatorSet({avs: avs, id: operatorSetIds[i]}), operator),
-                OperatorNotInAllowlist()
-            );
+        for (uint32 i = 0; i < operatorSetIds.length; i++) {
+            if (operatorSetIds[i] == avsConfig.aggregatorOperatorSetId) {
+                require(
+                    isOperatorAllowed(OperatorSet({avs: avs, id: operatorSetIds[i]}), operator),
+                    OperatorNotInAllowlist()
+                );
+            }
         }
     }
 }

--- a/src/avs/task/TaskAVSRegistrarBase.sol
+++ b/src/avs/task/TaskAVSRegistrarBase.sol
@@ -24,8 +24,8 @@ abstract contract TaskAVSRegistrarBase is
     Initializable,
     OwnableUpgradeable,
     AVSRegistrarWithSocket,
-    TaskAVSRegistrarBaseStorage,
-    Allowlist
+    Allowlist,
+    TaskAVSRegistrarBaseStorage
 {
     /**
      * @dev Constructor that passes parameters to parent

--- a/src/interfaces/ITaskAVSRegistrarBase.sol
+++ b/src/interfaces/ITaskAVSRegistrarBase.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.27;
 import {IAVSRegistrar} from "eigenlayer-contracts/src/contracts/interfaces/IAVSRegistrar.sol";
 import {IAVSRegistrarInternal} from "./IAVSRegistrarInternal.sol";
 import {ISocketRegistryV2} from "./ISocketRegistryV2.sol";
+import {IAllowlist} from "./IAllowlist.sol";
 
 /**
  * @title ITaskAVSRegistrarBaseTypes
@@ -59,7 +60,8 @@ interface ITaskAVSRegistrarBase is
     ITaskAVSRegistrarBaseEvents,
     IAVSRegistrar,
     IAVSRegistrarInternal,
-    ISocketRegistryV2
+    ISocketRegistryV2,
+    IAllowlist
 {
     /**
      * @notice Sets the configuration for this AVS

--- a/test/mocks/AllocationManagerMock.sol
+++ b/test/mocks/AllocationManagerMock.sol
@@ -332,4 +332,18 @@ contract AllocationManagerMock is AllocationManagerIntermediate {
 
         return minimumSlashableStake;
     }
+
+    /**
+     * @notice Register an operator to an AVS through the AVS registrar
+     * @dev This function delegates to the appropriate AVS registrar
+     */
+    function registerOperator(
+        address avs,
+        address operator,
+        uint32[] calldata operatorSetIds,
+        bytes calldata data
+    ) external {
+        IAVSRegistrar avsRegistrar = IAVSRegistrar(_avsRegistrar[avs]);
+        avsRegistrar.registerOperator(operator, avs, operatorSetIds, data);
+    }
 }

--- a/test/unit/TaskAVSRegistrarBaseUnit.t.sol
+++ b/test/unit/TaskAVSRegistrarBaseUnit.t.sol
@@ -17,13 +17,22 @@ import {ITaskAVSRegistrarBaseErrors} from "../../src/interfaces/ITaskAVSRegistra
 import {ITaskAVSRegistrarBaseEvents} from "../../src/interfaces/ITaskAVSRegistrarBase.sol";
 import {MockTaskAVSRegistrar} from "../mocks/MockTaskAVSRegistrar.sol";
 import {MockEigenLayerDeployer} from "./middlewareV2/MockDeployer.sol";
+import {IAllowlist} from "../../src/interfaces/IAllowlist.sol";
+import {OperatorSet} from "../../lib/eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+import {IAllowlistErrors} from "../../src/interfaces/IAllowlist.sol";
+import {IAllowlistEvents} from "../../src/interfaces/IAllowlist.sol";
+import {IAVSRegistrar} from "../../lib/eigenlayer-contracts/src/contracts/interfaces/IAVSRegistrar.sol";
+import {IAVSRegistrarInternal} from "../../src/interfaces/IAVSRegistrarInternal.sol";
 
 // Base test contract with common setup
 contract TaskAVSRegistrarBaseUnitTests is
     MockEigenLayerDeployer,
     ITaskAVSRegistrarBaseTypes,
     ITaskAVSRegistrarBaseErrors,
-    ITaskAVSRegistrarBaseEvents
+    ITaskAVSRegistrarBaseEvents,
+    IAllowlistErrors,
+    IAllowlistEvents,
+    IAVSRegistrarInternal
 {
     // Test addresses
     address public avs = address(0x1);
@@ -60,6 +69,9 @@ contract TaskAVSRegistrarBaseUnitTests is
             )
         );
         registrar = MockTaskAVSRegistrar(address(proxy));
+
+        // Configure the AllocationManagerMock to know about this registrar
+        allocationManagerMock.setAVSRegistrar(avs, IAVSRegistrar(address(registrar)));
     }
 
     // Helper function to create a valid AVS config
@@ -686,5 +698,470 @@ contract TaskAVSRegistrarBaseUnitTests_AccessControl is TaskAVSRegistrarBaseUnit
         vm.prank(owner);
         vm.expectRevert("Ownable: caller is not the owner");
         registrar.setAvsConfig(config);
+    }
+}
+
+// Test contract for allowlist functionality
+contract TaskAVSRegistrarBaseUnitTests_Allowlist is TaskAVSRegistrarBaseUnitTests {
+    // Test addresses for allowlist testing
+    address public constant ALLOWLISTED_OPERATOR_1 = address(0x100);
+    address public constant ALLOWLISTED_OPERATOR_2 = address(0x101);
+    address public constant NON_ALLOWLISTED_OPERATOR = address(0x102);
+    address public constant ANOTHER_OPERATOR = address(0x103);
+
+    // Test operator sets
+    OperatorSet public aggregatorOperatorSet;
+    OperatorSet public executorOperatorSet1;
+    OperatorSet public executorOperatorSet2;
+
+    function setUp() public override {
+        super.setUp();
+
+        // Create operator sets for testing
+        aggregatorOperatorSet = OperatorSet({avs: avs, id: AGGREGATOR_OPERATOR_SET_ID});
+        executorOperatorSet1 = OperatorSet({avs: avs, id: EXECUTOR_OPERATOR_SET_ID_1});
+        executorOperatorSet2 = OperatorSet({avs: avs, id: EXECUTOR_OPERATOR_SET_ID_2});
+    }
+
+    // Helper function to add operators to allowlist
+    function _addOperatorToAllowlist(OperatorSet memory operatorSet, address operator) internal {
+        vm.prank(owner);
+        registrar.addOperatorToAllowlist(operatorSet, operator);
+    }
+
+    // Helper function to remove operators from allowlist
+    function _removeOperatorFromAllowlist(OperatorSet memory operatorSet, address operator) internal {
+        vm.prank(owner);
+        registrar.removeOperatorFromAllowlist(operatorSet, operator);
+    }
+
+    function test_AllowlistInitialization() public {
+        // Verify allowlist is properly initialized
+        assertEq(registrar.owner(), owner);
+
+        // Check that no operators are allowlisted initially
+        assertFalse(registrar.isOperatorAllowed(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1));
+        assertFalse(registrar.isOperatorAllowed(executorOperatorSet1, ALLOWLISTED_OPERATOR_1));
+    }
+
+    function test_AddOperatorToAllowlist() public {
+        // Add operator to allowlist
+        _addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+
+        // Verify operator is now allowlisted
+        assertTrue(registrar.isOperatorAllowed(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1));
+        assertFalse(registrar.isOperatorAllowed(aggregatorOperatorSet, NON_ALLOWLISTED_OPERATOR));
+    }
+
+    function test_AddOperatorToAllowlist_EmitsEvent() public {
+        // Expect event emission
+        vm.expectEmit(true, true, true, true, address(registrar));
+        emit OperatorAddedToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+
+        // Add operator to allowlist
+        _addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+    }
+
+    function test_AddOperatorToAllowlist_AlreadyInAllowlist() public {
+        // Add operator first time
+        _addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+
+        // Try to add again, should revert
+        vm.prank(owner);
+        vm.expectRevert(OperatorAlreadyInAllowlist.selector);
+        registrar.addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+    }
+
+    function test_AddOperatorToAllowlist_NotOwner() public {
+        // Non-owner tries to add operator
+        vm.prank(nonOwner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        registrar.addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+    }
+
+    function test_RemoveOperatorFromAllowlist() public {
+        // Add operator first
+        _addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+        assertTrue(registrar.isOperatorAllowed(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1));
+
+        // Remove operator
+        _removeOperatorFromAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+
+        // Verify operator is no longer allowlisted
+        assertFalse(registrar.isOperatorAllowed(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1));
+    }
+
+    function test_RemoveOperatorFromAllowlist_EmitsEvent() public {
+        // Add operator first
+        _addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+
+        // Expect event emission
+        vm.expectEmit(true, true, true, true, address(registrar));
+        emit OperatorRemovedFromAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+
+        // Remove operator
+        _removeOperatorFromAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+    }
+
+    function test_RemoveOperatorFromAllowlist_NotInAllowlist() public {
+        // Try to remove operator that's not in allowlist
+        vm.prank(owner);
+        vm.expectRevert(OperatorNotInAllowlist.selector);
+        registrar.removeOperatorFromAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+    }
+
+    function test_RemoveOperatorFromAllowlist_NotOwner() public {
+        // Add operator first
+        _addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+
+        // Non-owner tries to remove operator
+        vm.prank(nonOwner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        registrar.removeOperatorFromAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+    }
+
+    function test_IsOperatorAllowed() public {
+        // Initially not allowlisted
+        assertFalse(registrar.isOperatorAllowed(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1));
+
+        // Add to allowlist
+        _addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+        assertTrue(registrar.isOperatorAllowed(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1));
+
+        // Remove from allowlist
+        _removeOperatorFromAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+        assertFalse(registrar.isOperatorAllowed(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1));
+    }
+
+    function test_IsOperatorAllowed_DifferentOperatorSets() public {
+        // Add operator to one operator set
+        _addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+
+        // Operator should only be allowlisted for that specific operator set
+        assertTrue(registrar.isOperatorAllowed(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1));
+        assertFalse(registrar.isOperatorAllowed(executorOperatorSet1, ALLOWLISTED_OPERATOR_1));
+        assertFalse(registrar.isOperatorAllowed(executorOperatorSet2, ALLOWLISTED_OPERATOR_1));
+    }
+
+    function test_GetAllowedOperators() public {
+        // Initially empty
+        address[] memory allowedOperators = registrar.getAllowedOperators(aggregatorOperatorSet);
+        assertEq(allowedOperators.length, 0);
+
+        // Add operators
+        _addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+        _addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_2);
+
+        // Get allowed operators
+        allowedOperators = registrar.getAllowedOperators(aggregatorOperatorSet);
+        assertEq(allowedOperators.length, 2);
+
+        // Verify both operators are in the list (order may vary)
+        bool found1 = false;
+        bool found2 = false;
+        for (uint256 i = 0; i < allowedOperators.length; i++) {
+            if (allowedOperators[i] == ALLOWLISTED_OPERATOR_1) found1 = true;
+            if (allowedOperators[i] == ALLOWLISTED_OPERATOR_2) found2 = true;
+        }
+        assertTrue(found1);
+        assertTrue(found2);
+    }
+
+    function test_GetAllowedOperators_AfterRemoval() public {
+        // Add operators
+        _addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+        _addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_2);
+
+        // Remove one operator
+        _removeOperatorFromAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+
+        // Get allowed operators
+        address[] memory allowedOperators = registrar.getAllowedOperators(aggregatorOperatorSet);
+        assertEq(allowedOperators.length, 1);
+        assertEq(allowedOperators[0], ALLOWLISTED_OPERATOR_2);
+    }
+
+    function test_GetAllowedOperators_DifferentOperatorSets() public {
+        // Add operators to different operator sets
+        _addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+        _addOperatorToAllowlist(executorOperatorSet1, ALLOWLISTED_OPERATOR_2);
+
+        // Check aggregator operator set
+        address[] memory allowedOperators = registrar.getAllowedOperators(aggregatorOperatorSet);
+        assertEq(allowedOperators.length, 1);
+        assertEq(allowedOperators[0], ALLOWLISTED_OPERATOR_1);
+
+        // Check executor operator set
+        allowedOperators = registrar.getAllowedOperators(executorOperatorSet1);
+        assertEq(allowedOperators.length, 1);
+        assertEq(allowedOperators[0], ALLOWLISTED_OPERATOR_2);
+    }
+
+    function test_AllowlistIsolation() public {
+        // Add operators to different operator sets
+        _addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+        _addOperatorToAllowlist(executorOperatorSet1, ALLOWLISTED_OPERATOR_2);
+
+        // Verify isolation - operators are only allowlisted for their specific sets
+        assertTrue(registrar.isOperatorAllowed(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1));
+        assertFalse(registrar.isOperatorAllowed(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_2));
+        assertFalse(registrar.isOperatorAllowed(executorOperatorSet1, ALLOWLISTED_OPERATOR_1));
+        assertTrue(registrar.isOperatorAllowed(executorOperatorSet1, ALLOWLISTED_OPERATOR_2));
+    }
+
+    function test_AllowlistMultipleOperators() public {
+        // Add multiple operators to same operator set
+        _addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+        _addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_2);
+        _addOperatorToAllowlist(aggregatorOperatorSet, ANOTHER_OPERATOR);
+
+        // Verify all are allowlisted
+        assertTrue(registrar.isOperatorAllowed(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1));
+        assertTrue(registrar.isOperatorAllowed(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_2));
+        assertTrue(registrar.isOperatorAllowed(aggregatorOperatorSet, ANOTHER_OPERATOR));
+
+        // Verify non-allowlisted operator is not allowlisted
+        assertFalse(registrar.isOperatorAllowed(aggregatorOperatorSet, NON_ALLOWLISTED_OPERATOR));
+    }
+
+    function test_AllowlistEdgeCases() public {
+        // Test with zero address
+        _addOperatorToAllowlist(aggregatorOperatorSet, address(0));
+        assertTrue(registrar.isOperatorAllowed(aggregatorOperatorSet, address(0)));
+
+        // Test with contract address
+        address contractAddress = address(registrar);
+        _addOperatorToAllowlist(aggregatorOperatorSet, contractAddress);
+        assertTrue(registrar.isOperatorAllowed(aggregatorOperatorSet, contractAddress));
+
+        // Test with very large address
+        address largeAddress = address(0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF);
+        _addOperatorToAllowlist(aggregatorOperatorSet, largeAddress);
+        assertTrue(registrar.isOperatorAllowed(aggregatorOperatorSet, largeAddress));
+    }
+
+    function test_AllowlistOwnershipTransfer() public {
+        // Add operator as current owner
+        _addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+        assertTrue(registrar.isOperatorAllowed(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1));
+
+        // Transfer ownership
+        address newOwner = address(0x999);
+        vm.prank(owner);
+        registrar.transferOwnership(newOwner);
+
+        // Old owner can no longer manage allowlist
+        vm.prank(owner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        registrar.addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_2);
+
+        // New owner can manage allowlist
+        vm.prank(newOwner);
+        registrar.addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_2);
+        assertTrue(registrar.isOperatorAllowed(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_2));
+
+        // Old allowlist entries still exist
+        assertTrue(registrar.isOperatorAllowed(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1));
+    }
+
+    function test_AllowlistOwnershipRenounce() public {
+        // Add operator
+        _addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1);
+
+        // Renounce ownership
+        vm.prank(owner);
+        registrar.renounceOwnership();
+
+        // No one can manage allowlist anymore
+        vm.prank(owner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        registrar.addOperatorToAllowlist(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_2);
+
+        // Existing allowlist entries still exist
+        assertTrue(registrar.isOperatorAllowed(aggregatorOperatorSet, ALLOWLISTED_OPERATOR_1));
+    }
+}
+
+// Test contract for operator registration with allowlist validation
+contract TaskAVSRegistrarBaseUnitTests_OperatorRegistration is TaskAVSRegistrarBaseUnitTests {
+    address public constant OPERATOR_1 = address(0x200);
+    address public constant OPERATOR_2 = address(0x201);
+    address public constant OPERATOR_3 = address(0x202);
+
+    OperatorSet public aggregatorOperatorSet;
+    OperatorSet public executorOperatorSet1;
+    OperatorSet public executorOperatorSet2;
+
+    function setUp() public override {
+        super.setUp();
+
+        aggregatorOperatorSet = OperatorSet({avs: avs, id: AGGREGATOR_OPERATOR_SET_ID});
+        executorOperatorSet1 = OperatorSet({avs: avs, id: EXECUTOR_OPERATOR_SET_ID_1});
+        executorOperatorSet2 = OperatorSet({avs: avs, id: EXECUTOR_OPERATOR_SET_ID_2});
+
+        // Add operators to allowlist
+        vm.prank(owner);
+        registrar.addOperatorToAllowlist(aggregatorOperatorSet, OPERATOR_1);
+        vm.prank(owner);
+        registrar.addOperatorToAllowlist(executorOperatorSet1, OPERATOR_2);
+        vm.prank(owner);
+        registrar.addOperatorToAllowlist(executorOperatorSet2, OPERATOR_3);
+    }
+
+    function test_RegisterOperator_Allowlisted() public {
+        // Mock that operator is registered in key registrar
+        keyRegistrarMock.setIsRegistered(OPERATOR_1, aggregatorOperatorSet, true);
+
+        // Should not revert when operator is allowlisted
+        uint32[] memory operatorSetIds = new uint32[](1);
+        operatorSetIds[0] = AGGREGATOR_OPERATOR_SET_ID;
+        bytes memory socketData = abi.encode("http://localhost:8080");
+        allocationManagerMock.registerOperator(avs, OPERATOR_1, operatorSetIds, socketData);
+    }
+
+    function test_RegisterOperator_NotAllowlisted() public {
+        address nonAllowlistedOperator = address(0x300);
+
+        // Mock that operator is registered in key registrar
+        keyRegistrarMock.setIsRegistered(nonAllowlistedOperator, aggregatorOperatorSet, true);
+
+        // Should revert when operator is not allowlisted
+        vm.expectRevert(OperatorNotInAllowlist.selector);
+        uint32[] memory operatorSetIds = new uint32[](1);
+        operatorSetIds[0] = AGGREGATOR_OPERATOR_SET_ID;
+        bytes memory socketData = abi.encode("http://localhost:8080");
+        allocationManagerMock.registerOperator(avs, nonAllowlistedOperator, operatorSetIds, socketData);
+    }
+
+    function test_RegisterOperator_MultipleOperatorSets() public {
+        // Mock that operator is registered in both operator sets
+        keyRegistrarMock.setIsRegistered(OPERATOR_1, aggregatorOperatorSet, true);
+        keyRegistrarMock.setIsRegistered(OPERATOR_1, executorOperatorSet1, true);
+
+        // Add operator to both allowlists
+        vm.prank(owner);
+        registrar.addOperatorToAllowlist(executorOperatorSet1, OPERATOR_1);
+
+        // Should not revert when operator is allowlisted for all operator sets
+        uint32[] memory operatorSetIds = new uint32[](2);
+        operatorSetIds[0] = AGGREGATOR_OPERATOR_SET_ID;
+        operatorSetIds[1] = EXECUTOR_OPERATOR_SET_ID_1;
+
+        bytes memory socketData = abi.encode("http://localhost:8080");
+        allocationManagerMock.registerOperator(avs, OPERATOR_1, operatorSetIds, socketData);
+    }
+
+    function test_RegisterOperator_MultipleOperatorSets_PartiallyAllowlisted() public {
+        // Mock that operator is registered in both operator sets
+        keyRegistrarMock.setIsRegistered(OPERATOR_1, aggregatorOperatorSet, true);
+        keyRegistrarMock.setIsRegistered(OPERATOR_1, executorOperatorSet1, true);
+
+        // OPERATOR_1 is already in aggregatorOperatorSet allowlist from setup
+        // Note: Not added to executorOperatorSet1 allowlist
+
+        // Should revert when operator is not allowlisted for all operator sets
+        uint32[] memory operatorSetIds = new uint32[](2);
+        operatorSetIds[0] = AGGREGATOR_OPERATOR_SET_ID;
+        operatorSetIds[1] = EXECUTOR_OPERATOR_SET_ID_1;
+
+        vm.expectRevert(OperatorNotInAllowlist.selector);
+        bytes memory socketData = abi.encode("http://localhost:8080");
+        allocationManagerMock.registerOperator(avs, OPERATOR_1, operatorSetIds, socketData);
+    }
+
+    function test_RegisterOperator_AllowlistRemovedAfterRegistration() public {
+        // Mock that operator is registered in key registrar
+        keyRegistrarMock.setIsRegistered(OPERATOR_1, aggregatorOperatorSet, true);
+
+        // Register operator (should succeed)
+        uint32[] memory operatorSetIds = new uint32[](1);
+        operatorSetIds[0] = AGGREGATOR_OPERATOR_SET_ID;
+        bytes memory socketData = abi.encode("http://localhost:8080");
+        allocationManagerMock.registerOperator(avs, OPERATOR_1, operatorSetIds, socketData);
+
+        // Remove operator from allowlist
+        vm.prank(owner);
+        registrar.removeOperatorFromAllowlist(aggregatorOperatorSet, OPERATOR_1);
+
+        // Try to register again (should fail)
+        vm.expectRevert(OperatorNotInAllowlist.selector);
+        uint32[] memory operatorSetIds2 = new uint32[](1);
+        operatorSetIds2[0] = AGGREGATOR_OPERATOR_SET_ID;
+        bytes memory socketData2 = abi.encode("http://localhost:8080");
+        allocationManagerMock.registerOperator(avs, OPERATOR_1, operatorSetIds2, socketData2);
+    }
+
+    function test_RegisterOperator_AllowlistAddedAfterFailedRegistration() public {
+        address operator = address(0x400);
+
+        // Mock that operator is registered in key registrar
+        keyRegistrarMock.setIsRegistered(operator, aggregatorOperatorSet, true);
+
+        // Try to register without being allowlisted (should fail)
+        vm.expectRevert(OperatorNotInAllowlist.selector);
+        uint32[] memory operatorSetIds = new uint32[](1);
+        operatorSetIds[0] = AGGREGATOR_OPERATOR_SET_ID;
+        bytes memory socketData = abi.encode("http://localhost:8080");
+        allocationManagerMock.registerOperator(avs, operator, operatorSetIds, socketData);
+
+        // Add operator to allowlist
+        vm.prank(owner);
+        registrar.addOperatorToAllowlist(aggregatorOperatorSet, operator);
+
+        // Now registration should succeed
+        uint32[] memory operatorSetIds3 = new uint32[](1);
+        operatorSetIds3[0] = AGGREGATOR_OPERATOR_SET_ID;
+        bytes memory socketData3 = abi.encode("http://localhost:8080");
+        allocationManagerMock.registerOperator(avs, operator, operatorSetIds3, socketData3);
+    }
+
+    function test_RegisterOperator_ZeroAddress() public {
+        // Mock that zero address is registered in key registrar
+        keyRegistrarMock.setIsRegistered(address(0), aggregatorOperatorSet, true);
+
+        // Add zero address to allowlist
+        vm.prank(owner);
+        registrar.addOperatorToAllowlist(aggregatorOperatorSet, address(0));
+
+        // Should not revert when zero address is allowlisted
+        uint32[] memory operatorSetIds = new uint32[](1);
+        operatorSetIds[0] = AGGREGATOR_OPERATOR_SET_ID;
+        bytes memory socketData = abi.encode("http://localhost:8080");
+        allocationManagerMock.registerOperator(avs, address(0), operatorSetIds, socketData);
+    }
+
+    function test_RegisterOperator_ContractAddress() public {
+        address contractAddress = address(registrar);
+
+        // Mock that contract address is registered in key registrar
+        keyRegistrarMock.setIsRegistered(contractAddress, aggregatorOperatorSet, true);
+
+        // Add contract address to allowlist
+        vm.prank(owner);
+        registrar.addOperatorToAllowlist(aggregatorOperatorSet, contractAddress);
+
+        // Should not revert when contract address is allowlisted
+        uint32[] memory operatorSetIds = new uint32[](1);
+        operatorSetIds[0] = AGGREGATOR_OPERATOR_SET_ID;
+        bytes memory socketData = abi.encode("http://localhost:8080");
+        allocationManagerMock.registerOperator(avs, contractAddress, operatorSetIds, socketData);
+    }
+
+    function test_RegisterOperator_AllowlistValidationOrder() public {
+        // Test that allowlist validation happens before other validations
+        address operator = address(0x500);
+
+        // Mock that operator is registered in key registrar
+        keyRegistrarMock.setIsRegistered(operator, aggregatorOperatorSet, true);
+
+        // Add operator to allowlist
+        vm.prank(owner);
+        registrar.addOperatorToAllowlist(aggregatorOperatorSet, operator);
+
+        // Should succeed now that both allowlist and key registrar checks pass
+        uint32[] memory operatorSetIds = new uint32[](1);
+        operatorSetIds[0] = AGGREGATOR_OPERATOR_SET_ID;
+        bytes memory socketData = abi.encode("http://localhost:8080");
+        allocationManagerMock.registerOperator(avs, operator, operatorSetIds, socketData);
     }
 }

--- a/test/unit/TaskAVSRegistrarBaseUnit.t.sol
+++ b/test/unit/TaskAVSRegistrarBaseUnit.t.sol
@@ -1025,7 +1025,7 @@ contract TaskAVSRegistrarBaseUnitTests_OperatorRegistration is TaskAVSRegistrarB
         // Mock that operator is registered in key registrar
         keyRegistrarMock.setIsRegistered(nonAllowlistedOperator, aggregatorOperatorSet, true);
 
-        // Should revert when operator is not allowlisted
+        // Should revert when operator is not allowlisted for aggregator operator set
         vm.expectRevert(OperatorNotInAllowlist.selector);
         uint32[] memory operatorSetIds = new uint32[](1);
         operatorSetIds[0] = AGGREGATOR_OPERATOR_SET_ID;
@@ -1038,11 +1038,10 @@ contract TaskAVSRegistrarBaseUnitTests_OperatorRegistration is TaskAVSRegistrarB
         keyRegistrarMock.setIsRegistered(OPERATOR_1, aggregatorOperatorSet, true);
         keyRegistrarMock.setIsRegistered(OPERATOR_1, executorOperatorSet1, true);
 
-        // Add operator to both allowlists
-        vm.prank(owner);
-        registrar.addOperatorToAllowlist(executorOperatorSet1, OPERATOR_1);
+        // Only need to add operator to aggregator allowlist (executor sets don't require allowlist)
+        // OPERATOR_1 is already in aggregatorOperatorSet allowlist from setup
 
-        // Should not revert when operator is allowlisted for all operator sets
+        // Should not revert when operator is allowlisted for aggregator operator set
         uint32[] memory operatorSetIds = new uint32[](2);
         operatorSetIds[0] = AGGREGATOR_OPERATOR_SET_ID;
         operatorSetIds[1] = EXECUTOR_OPERATOR_SET_ID_1;
@@ -1057,14 +1056,13 @@ contract TaskAVSRegistrarBaseUnitTests_OperatorRegistration is TaskAVSRegistrarB
         keyRegistrarMock.setIsRegistered(OPERATOR_1, executorOperatorSet1, true);
 
         // OPERATOR_1 is already in aggregatorOperatorSet allowlist from setup
-        // Note: Not added to executorOperatorSet1 allowlist
+        // Note: Executor operator sets don't require allowlist checks
 
-        // Should revert when operator is not allowlisted for all operator sets
+        // Should succeed since aggregator operator set is allowlisted and executor sets don't need allowlist
         uint32[] memory operatorSetIds = new uint32[](2);
         operatorSetIds[0] = AGGREGATOR_OPERATOR_SET_ID;
         operatorSetIds[1] = EXECUTOR_OPERATOR_SET_ID_1;
 
-        vm.expectRevert(OperatorNotInAllowlist.selector);
         bytes memory socketData = abi.encode("http://localhost:8080");
         allocationManagerMock.registerOperator(avs, OPERATOR_1, operatorSetIds, socketData);
     }
@@ -1161,6 +1159,64 @@ contract TaskAVSRegistrarBaseUnitTests_OperatorRegistration is TaskAVSRegistrarB
         // Should succeed now that both allowlist and key registrar checks pass
         uint32[] memory operatorSetIds = new uint32[](1);
         operatorSetIds[0] = AGGREGATOR_OPERATOR_SET_ID;
+        bytes memory socketData = abi.encode("http://localhost:8080");
+        allocationManagerMock.registerOperator(avs, operator, operatorSetIds, socketData);
+    }
+
+    function test_RegisterOperator_ExecutorOperatorSet_NoAllowlistRequired() public {
+        // Test that executor operator sets don't require allowlist checks
+        address operator = address(0x600);
+
+        // Mock that operator is registered in key registrar for executor operator set
+        keyRegistrarMock.setIsRegistered(operator, executorOperatorSet1, true);
+
+        // Operator is NOT in allowlist for executor operator set (and shouldn't need to be)
+        // This should succeed since executor operator sets don't require allowlist
+
+        uint32[] memory operatorSetIds = new uint32[](1);
+        operatorSetIds[0] = EXECUTOR_OPERATOR_SET_ID_1;
+        bytes memory socketData = abi.encode("http://localhost:8080");
+        allocationManagerMock.registerOperator(avs, operator, operatorSetIds, socketData);
+    }
+
+    function test_RegisterOperator_MixedOperatorSets_OnlyAggregatorRequiresAllowlist() public {
+        // Test mixed operator sets where only aggregator requires allowlist
+        address operator = address(0x700);
+
+        // Mock that operator is registered in key registrar for both operator sets
+        keyRegistrarMock.setIsRegistered(operator, aggregatorOperatorSet, true);
+        keyRegistrarMock.setIsRegistered(operator, executorOperatorSet1, true);
+
+        // Add operator to aggregator allowlist (required for aggregator operator set)
+        vm.prank(owner);
+        registrar.addOperatorToAllowlist(aggregatorOperatorSet, operator);
+
+        // Operator is NOT in allowlist for executor operator set (not required)
+        // But IS in allowlist for aggregator operator set (required and satisfied)
+        // This should succeed since only aggregator requires allowlist
+
+        uint32[] memory operatorSetIds = new uint32[](2);
+        operatorSetIds[0] = EXECUTOR_OPERATOR_SET_ID_1;  // No allowlist required
+        operatorSetIds[1] = AGGREGATOR_OPERATOR_SET_ID;   // Allowlist required (and satisfied)
+
+        bytes memory socketData = abi.encode("http://localhost:8080");
+        allocationManagerMock.registerOperator(avs, operator, operatorSetIds, socketData);
+    }
+
+    function test_RegisterOperator_ExecutorOnly_NoAllowlistCheck() public {
+        // Test registration with only executor operator sets (no aggregator)
+        address operator = address(0x800);
+
+        // Mock that operator is registered in key registrar for executor operator sets
+        keyRegistrarMock.setIsRegistered(operator, executorOperatorSet1, true);
+        keyRegistrarMock.setIsRegistered(operator, executorOperatorSet2, true);
+
+        // Operator is NOT in any allowlist (and shouldn't need to be for executor sets)
+        // This should succeed since executor operator sets don't require allowlist
+
+        uint32[] memory operatorSetIds = new uint32[](2);
+        operatorSetIds[0] = EXECUTOR_OPERATOR_SET_ID_1;
+        operatorSetIds[1] = EXECUTOR_OPERATOR_SET_ID_2;
         bytes memory socketData = abi.encode("http://localhost:8080");
         allocationManagerMock.registerOperator(avs, operator, operatorSetIds, socketData);
     }

--- a/test/unit/TaskAVSRegistrarBaseUnit.t.sol
+++ b/test/unit/TaskAVSRegistrarBaseUnit.t.sol
@@ -18,10 +18,12 @@ import {ITaskAVSRegistrarBaseEvents} from "../../src/interfaces/ITaskAVSRegistra
 import {MockTaskAVSRegistrar} from "../mocks/MockTaskAVSRegistrar.sol";
 import {MockEigenLayerDeployer} from "./middlewareV2/MockDeployer.sol";
 import {IAllowlist} from "../../src/interfaces/IAllowlist.sol";
-import {OperatorSet} from "../../lib/eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+import {OperatorSet} from
+    "../../lib/eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
 import {IAllowlistErrors} from "../../src/interfaces/IAllowlist.sol";
 import {IAllowlistEvents} from "../../src/interfaces/IAllowlist.sol";
-import {IAVSRegistrar} from "../../lib/eigenlayer-contracts/src/contracts/interfaces/IAVSRegistrar.sol";
+import {IAVSRegistrar} from
+    "../../lib/eigenlayer-contracts/src/contracts/interfaces/IAVSRegistrar.sol";
 import {IAVSRegistrarInternal} from "../../src/interfaces/IAVSRegistrarInternal.sol";
 
 // Base test contract with common setup
@@ -730,7 +732,10 @@ contract TaskAVSRegistrarBaseUnitTests_Allowlist is TaskAVSRegistrarBaseUnitTest
     }
 
     // Helper function to remove operators from allowlist
-    function _removeOperatorFromAllowlist(OperatorSet memory operatorSet, address operator) internal {
+    function _removeOperatorFromAllowlist(
+        OperatorSet memory operatorSet,
+        address operator
+    ) internal {
         vm.prank(owner);
         registrar.removeOperatorFromAllowlist(operatorSet, operator);
     }
@@ -1030,7 +1035,9 @@ contract TaskAVSRegistrarBaseUnitTests_OperatorRegistration is TaskAVSRegistrarB
         uint32[] memory operatorSetIds = new uint32[](1);
         operatorSetIds[0] = AGGREGATOR_OPERATOR_SET_ID;
         bytes memory socketData = abi.encode("http://localhost:8080");
-        allocationManagerMock.registerOperator(avs, nonAllowlistedOperator, operatorSetIds, socketData);
+        allocationManagerMock.registerOperator(
+            avs, nonAllowlistedOperator, operatorSetIds, socketData
+        );
     }
 
     function test_RegisterOperator_MultipleOperatorSets() public {
@@ -1196,8 +1203,8 @@ contract TaskAVSRegistrarBaseUnitTests_OperatorRegistration is TaskAVSRegistrarB
         // This should succeed since only aggregator requires allowlist
 
         uint32[] memory operatorSetIds = new uint32[](2);
-        operatorSetIds[0] = EXECUTOR_OPERATOR_SET_ID_1;  // No allowlist required
-        operatorSetIds[1] = AGGREGATOR_OPERATOR_SET_ID;   // Allowlist required (and satisfied)
+        operatorSetIds[0] = EXECUTOR_OPERATOR_SET_ID_1; // No allowlist required
+        operatorSetIds[1] = AGGREGATOR_OPERATOR_SET_ID; // Allowlist required (and satisfied)
 
         bytes memory socketData = abi.encode("http://localhost:8080");
         allocationManagerMock.registerOperator(avs, operator, operatorSetIds, socketData);


### PR DESCRIPTION
**Motivation:**

To ensure that AVSs have control over the aggregators registering for Hourglass, an allowlist is added to prevent arbitrary aggregator registration.

**Modifications:**

Inherited `Allowlist` into the TaskAVSRegistarBase

**Result:**

Stronger permissions around registration
