### PR TITLE
fix: foundry ci version

### DIFF
--- a/.github/workflows/forge-test-intense.yml
+++ b/.github/workflows/forge-test-intense.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: v1.3.5
 
       # Build the project and display contract sizes.
       - name: Forge Build

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: v1.3.5
 
       # Run Forge's formatting checker to ensure consistent code style.
       - name: Forge Fmt
@@ -73,7 +73,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: v1.3.5
 
       # Install LCOV for coverage report generation.
       - name: Install LCOV

--- a/.github/workflows/storage-report.yml
+++ b/.github/workflows/storage-report.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: v1.3.5
 
       - name: "Generate and prepare the storage reports for current branch"
         run: |

--- a/test/fork/EigenDA.t.sol
+++ b/test/fork/EigenDA.t.sol
@@ -220,6 +220,8 @@ contract EigenDATest is Test {
     IStrategyManager public strategyManager;
 
     function setUp() public virtual {
+        // Skip this test as holesky is deprecated
+        vm.skip(true);
         // Setup the Holesky fork and load EigenDA deployment data
         eigenDAData = _setupEigenDAFork("test/utils");
 

--- a/test/fork/End2End.t.sol
+++ b/test/fork/End2End.t.sol
@@ -105,6 +105,8 @@ contract End2EndForkTest is Test {
     }
 
     function testEndToEndSetup_M2Migration() public {
+        // Skip this test as holesky is deprecated
+        vm.skip(true);
         (
             OperatorLib.Operator[] memory operators,
             DeploymentData memory coreDeployment,


### PR DESCRIPTION
Pin foundry to 1.3.5 so CI will pass based on current formatting. 