### PR TITLE
feat: update registry coordinator for new createOperatorSets 

### DIFF
--- a/.github/workflows/storage-report.yml
+++ b/.github/workflows/storage-report.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: v1.3.5
+          version: nightly
 
       - name: "Generate and prepare the storage reports for current branch"
         run: |

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -125,6 +125,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
     uint32 GENESIS_REWARDS_TIMESTAMP = 1712188800;
     /// @notice Equivalent to 100%, but in basis points.
     uint16 internal constant ONE_HUNDRED_IN_BIPS = 10000;
+    
 
     uint32 defaultOperatorSplitBips = 1000;
     /// @notice Delay in timestamp before a posted root can be claimed against

--- a/test/integration/IntegrationDeployer.t.sol
+++ b/test/integration/IntegrationDeployer.t.sol
@@ -125,7 +125,6 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
     uint32 GENESIS_REWARDS_TIMESTAMP = 1712188800;
     /// @notice Equivalent to 100%, but in basis points.
     uint16 internal constant ONE_HUNDRED_IN_BIPS = 10000;
-    
 
     uint32 defaultOperatorSplitBips = 1000;
     /// @notice Delay in timestamp before a posted root can be claimed against


### PR DESCRIPTION
**Motivation:**

As part of https://github.com/Layr-Labs/eigenlayer-contracts/pull/1645, we are adding a new `createOperatorSets` function that passes in the slasher address upon creation of an operatorSet.  Although the *old* `createOperatorSets` function is not being deprecated, we are updating the `RegistryCoordinator` in order to be **only compatible the new function**. 

**Modifications:**

- Update `createSlashableStakeQuorum` to take in a `slasher` address
- Update all tests
- Update `solc` version in `foundry.toml` to `0.8.29`, matching Core

**Result:**

Compatible with updated `AllocationManager` interface